### PR TITLE
ci(release): port hardened PR-based release flow from skill-code-review

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,17 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+# Tighten workflow-default permissions to nothing; the publish job
+# grants itself only what it needs. Jobs added later don't inherit.
+permissions: {}
+
 jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write       # npm --provenance OIDC
 
     steps:
       - name: Refuse non-tag refs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,20 @@ jobs:
       id-token: write
 
     steps:
+      - name: Refuse non-tag refs
+        # `workflow_dispatch` is kept (so an operator can re-run a
+        # publish for an existing tag after a transient npm outage),
+        # but it can also be fired against a branch, in which case
+        # the tag/version check below is skipped (its `if` gates on
+        # refs/tags/v*) and `npm publish` would still run. That is
+        # an untagged-publish hole. Refuse any ref that isn't a
+        # `refs/tags/v*` tag up-front, regardless of event type.
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          echo "::error::publish.yml only runs for refs/tags/v*; got ${{ github.ref }}."
+          echo "::error::Re-dispatch against an existing v<version> tag, or push a new one via the release flow."
+          exit 1
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
@@ -24,11 +38,28 @@ jobs:
 
       - run: npm ci
 
+      - name: Preflight
+        run: npm run preflight
+
       - name: Validate
         run: npm run validate
 
-      - name: Test
+      - name: Lint
+        run: npm run lint
+
+      - name: Tests
         run: npm test
+
+      - name: Verify version matches tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)."
+            echo "::error::Investigate the merge commit; this should not happen under the PR-based flow."
+            exit 1
+          fi
 
       - name: Publish
         run: npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,10 @@ on:
           - minor
           - major
 
-permissions:
-  contents: write
-  pull-requests: write
+# Tighten default permissions at workflow scope to nothing; grant
+# only what each job needs explicitly below. Jobs added later don't
+# silently inherit write.
+permissions: {}
 
 # Serialize release dispatches so two operators can't race on the
 # same `release/v<version>` branch. A queued run picks up after
@@ -43,6 +44,9 @@ jobs:
   open-release-pr:
     name: Open release PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push release/v<version> branch
+      pull-requests: write   # open/edit the release PR
 
     steps:
       - name: Refuse dispatch from non-main refs
@@ -82,7 +86,17 @@ jobs:
 
       - name: Bump version on a release branch
         id: bump
+        env:
+          # Pass `inputs.bump` via env rather than direct `${{ }}`
+          # interpolation into the shell body. The `choice` input is
+          # fixed to patch/minor/major today, but a later refactor to
+          # `type: string` would silently open a script-injection
+          # sink. The env + explicit allowlist below closes the class.
+          BUMP: ${{ inputs.bump }}
         run: |
+          case "$BUMP" in patch|minor|major) ;; *)
+            echo "::error::unexpected bump value: $BUMP"; exit 1 ;;
+          esac
           # Read current to detect no-op bumps (shouldn't happen with
           # npm version <bump>, but bail loudly if it does).
           BEFORE=$(node -p "require('./package.json').version")
@@ -94,7 +108,7 @@ jobs:
           # Note: this repo also has a `prepare: husky` script; npm
           # version does not invoke `prepare`, but --ignore-scripts
           # makes the guarantee explicit.
-          npm version ${{ inputs.bump }} --no-git-tag-version --ignore-scripts
+          npm version "$BUMP" --no-git-tag-version --ignore-scripts
           AFTER=$(node -p "require('./package.json').version")
           if [ "$BEFORE" = "$AFTER" ]; then
             echo "::error::npm version produced no change ($BEFORE == $AFTER)"
@@ -131,9 +145,24 @@ jobs:
           # ref:sha form so the lease is actually enforced against
           # a known SHA. If the branch doesn't exist on the remote
           # yet, a plain push is sufficient and safe.
+          #
+          # Additional guard: if a reviewer has pushed fix commits
+          # to the existing release PR, force-pushing here would
+          # silently drop them. Detect the "more than one commit
+          # ahead of main" state and refuse loudly so the operator
+          # merges the existing PR (or deletes the branch) before
+          # re-dispatching. 0 or 1 commit ahead = safe overwrite
+          # (no human edits, just a prior bump); >1 = unsafe.
           if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
-            git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+            git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" "+refs/heads/main:refs/remotes/origin/main"
             REMOTE_SHA=$(git rev-parse "refs/remotes/origin/${BRANCH}")
+            MAIN_SHA=$(git rev-parse "refs/remotes/origin/main")
+            AHEAD=$(git rev-list --count "${MAIN_SHA}..${REMOTE_SHA}" 2>/dev/null || echo "many")
+            if [ "$AHEAD" != "0" ] && [ "$AHEAD" != "1" ]; then
+              echo "::error::Remote branch ${BRANCH} is ${AHEAD} commits ahead of main; force-pushing would clobber human edits on the existing release PR."
+              echo "::error::Merge or close the existing release PR first, then re-dispatch. If the branch is stale, 'git push origin --delete ${BRANCH}' and re-run."
+              exit 1
+            fi
             git push --force-with-lease="refs/heads/${BRANCH}:${REMOTE_SHA}" origin "${BRANCH}"
           else
             git push origin "${BRANCH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,21 @@
 name: Release
 
+# Opens a release PR that bumps package.json (and npm-shrinkwrap.json
+# if present) to the next semver. The PR goes through whatever
+# branch-protection rules `main` has configured (review, code
+# scanning, CODEOWNERS, thread resolution) exactly like any other
+# change; the bot does not push directly to main. Once the PR
+# merges, a separate `tag-on-main.yml` workflow creates the
+# matching `v<version>` tag.
+#
+# Publishing does NOT auto-chain: tags pushed with the default
+# `GITHUB_TOKEN` do not trigger `on: push: tags` workflows (GitHub
+# design, to prevent workflow recursion). After the tag lands,
+# dispatch `publish.yml` against the tag via Actions UI (documented
+# in README `## Releasing`). To remove that manual step, swap the
+# tag-push credential in `tag-on-main.yml` for a GitHub App token
+# or fine-grained PAT.
+
 on:
   workflow_dispatch:
     inputs:
@@ -14,40 +30,145 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
+
+# Serialize release dispatches so two operators can't race on the
+# same `release/v<version>` branch. A queued run picks up after
+# the earlier one finishes.
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  release:
-    name: Bump version & tag
+  open-release-pr:
+    name: Open release PR
     runs-on: ubuntu-latest
 
     steps:
+      - name: Refuse dispatch from non-main refs
+        # `workflow_dispatch` can be fired from the UI against any
+        # ref. We want the run to show as FAILED with a clear
+        # error when an operator accidentally picks a feature
+        # branch, not skipped/green the way a job-level `if` would
+        # render. Releases always cut from main.
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Release workflow must be dispatched from main; got ${{ github.ref }}."
+          echo "::error::Switch the branch selector in the Actions UI to \`main\` and retry."
+          exit 1
+
       - uses: actions/checkout@v4
         with:
+          # Defensive double-belt: even if the dispatch came from
+          # a non-main ref and the early step above is somehow
+          # bypassed, explicitly check out main so the bump commit
+          # is always parented to it.
+          ref: main
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
-
-      - name: Install dev deps
-        run: npm ci
-
-      - name: Validate + test before bump
-        run: |
-          npm run validate
-          npm test
+          # No `cache: npm` here: this job only runs `npm version
+          # --no-git-tag-version --ignore-scripts`, which touches
+          # package.json/npm-shrinkwrap.json but never installs
+          # anything. Caching would add setup overhead with no
+          # install step to benefit from it.
 
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Bump version
+      - name: Bump version on a release branch
+        id: bump
         run: |
-          npm version ${{ inputs.bump }} -m "chore(release): v%s"
+          # Read current to detect no-op bumps (shouldn't happen with
+          # npm version <bump>, but bail loudly if it does).
+          BEFORE=$(node -p "require('./package.json').version")
+          # --ignore-scripts: npm version runs preversion/version/
+          # postversion lifecycle scripts by default. None are defined
+          # today, but a future addition (or a transitive one via a
+          # config change) would silently run in CI with write access
+          # to the repo. Keep the bump bounded to version files only.
+          # Note: this repo also has a `prepare: husky` script; npm
+          # version does not invoke `prepare`, but --ignore-scripts
+          # makes the guarantee explicit.
+          npm version ${{ inputs.bump }} --no-git-tag-version --ignore-scripts
+          AFTER=$(node -p "require('./package.json').version")
+          if [ "$BEFORE" = "$AFTER" ]; then
+            echo "::error::npm version produced no change ($BEFORE == $AFTER)"
+            exit 1
+          fi
 
-      - name: Push commit and tag
+          BRANCH="release/v${AFTER}"
+          echo "version=${AFTER}" >> "$GITHUB_OUTPUT"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+          # Use -B so a stale branch from a prior failed attempt is
+          # reset in place rather than making us error out.
+          git checkout -B "${BRANCH}"
+          git add package.json
+          # This repo ships `npm-shrinkwrap.json` (the opt-in form of
+          # package-lock.json that npm publishes). Guard the add with
+          # a presence check so the same workflow keeps working if a
+          # future change removes the shrinkwrap. Include the plain
+          # package-lock.json as well for the same reason.
+          if [ -f npm-shrinkwrap.json ]; then
+            git add npm-shrinkwrap.json
+          fi
+          if [ -f package-lock.json ]; then
+            git add package-lock.json
+          fi
+          git commit -m "release: v${AFTER}"
+
+          # Push safely whether or not the branch pre-exists on the
+          # remote. actions/checkout does NOT seed remote-tracking
+          # refs for arbitrary release branches, so bare
+          # `--force-with-lease` has no base and can degrade to
+          # unsafe behaviour. We fetch the remote branch first (if
+          # it exists) and then force-with-lease using the EXPLICIT
+          # ref:sha form so the lease is actually enforced against
+          # a known SHA. If the branch doesn't exist on the remote
+          # yet, a plain push is sufficient and safe.
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+            REMOTE_SHA=$(git rev-parse "refs/remotes/origin/${BRANCH}")
+            git push --force-with-lease="refs/heads/${BRANCH}:${REMOTE_SHA}" origin "${BRANCH}"
+          else
+            git push origin "${BRANCH}"
+          fi
+
+      - name: Open or update the release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push origin HEAD
-          git push origin --tags
+          VERSION="${{ steps.bump.outputs.version }}"
+          BRANCH="${{ steps.bump.outputs.branch }}"
+          # Assemble the PR body with printf so every paragraph sits
+          # at column 0 in the final string. A single quoted string
+          # split across yaml lines preserves the script indentation
+          # on every continuation line and makes GitHub render the
+          # PR body as a <pre> code block.
+          BODY="$(printf '%s\n\n%s\n\n%s' \
+            "Automated release PR created by \`release.yml\`. Bumps package.json (and npm-shrinkwrap.json, if present) to \`v${VERSION}\`." \
+            "Once this PR merges to main, \`tag-on-main.yml\` creates the matching \`v${VERSION}\` tag. After the tag lands, dispatch \`publish.yml\` against \`v${VERSION}\` via Actions to publish the package to npm (see README \`## Releasing\` for why this step is manual)." \
+            "Review the diff for any surprises (shrinkwrap regeneration drift, etc.) before approving.")"
+
+          # `gh pr view "$BRANCH"` matches closed/merged PRs too, so
+          # a previous release attempt that left a closed PR on the
+          # same head branch would cause this step to silently edit
+          # the closed PR and never open a new one; the operator
+          # would see the workflow succeed but have no PR to merge.
+          # Filter explicitly to open PRs for this head branch.
+          OPEN_PR_NUMBER="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          if [ -n "$OPEN_PR_NUMBER" ]; then
+            gh pr edit "$OPEN_PR_NUMBER" --title "release: v${VERSION}" --body "$BODY"
+            echo "Updated existing open release PR #$OPEN_PR_NUMBER for $BRANCH"
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "release: v${VERSION}" \
+              --body "$BODY"
+          fi

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -1,0 +1,225 @@
+name: Tag release on main
+
+# Fires on every push to main. Decides whether this push IS a
+# release (package.json version changed relative to the previous
+# main SHA) and, if so, creates the matching `v<version>` tag.
+# Non-release commits are a fast no-op.
+#
+# The paired `release.yml` workflow opens a bump PR; merging that
+# PR triggers this workflow, which then creates the tag. The tag
+# push does NOT auto-trigger `publish.yml`: the default
+# `GITHUB_TOKEN` cannot fire other workflows (GitHub design, to
+# prevent workflow recursion). Publishing is a separate manual
+# `workflow_dispatch` on the tag, documented in README
+# `## Releasing`. Swap this step's credential for a GitHub App
+# token or PAT to remove the manual step.
+#
+# Why the version-change gate: without it, any non-release commit
+# landing on main after a release would see the existing
+# `v<current-version>` tag at a different commit than HEAD and
+# (correctly, in isolation) flag it as the orphan-tag failure
+# mode. But after a normal release, the tag SHOULD keep pointing
+# at the release commit while main moves forward; that's the
+# canonical state, not an error. We only treat "tag exists
+# elsewhere" as an error when THIS push was itself a release
+# (i.e. the version number just changed).
+#
+# Tag push is NOT blocked by the branch ruleset: rules target
+# refs/heads/main only; refs/tags/* is a separate namespace. The
+# default GITHUB_TOKEN is sufficient; no bypass actor needed.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+# Serialize pushes to main so two concurrent release merges can't
+# both observe the tag as absent and then race on `git push`.
+# cancel-in-progress:false because every run MUST complete:
+# cancelling a run would skip tagging a legitimate release commit.
+concurrency:
+  group: tag-on-main
+  cancel-in-progress: false
+
+jobs:
+  maybe-tag:
+    name: Tag current main if package.json version is new
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          # No `cache: npm` here: this job only uses `node -p` to
+          # read package.json and `git show ... | node` to extract
+          # the previous version. It never runs npm install/ci, so
+          # caching would add setup overhead with no install step
+          # to benefit from it.
+
+      - name: Detect whether this push changed the package version
+        id: version
+        env:
+          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
+        # Set strict shell options explicitly so this step behaves
+        # predictably across environments regardless of Actions'
+        # defaults. `pipefail` makes `git show ... | node` fail
+        # loudly when an upstream command fails (instead of silently
+        # passing empty input through), and `-u` catches
+        # unset-variable typos. The `|| true` on `git show` remains
+        # the explicit opt-out for the one case where absence is
+        # intentional.
+        shell: bash
+        run: |
+          set -euo pipefail
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          TAG="v${CURRENT_VERSION}"
+          echo "version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+          # `github.event.before` is 40 zeros on the very first push
+          # to a new branch (or for unusual event shapes). In those
+          # cases we can't compute a diff; be conservative and treat
+          # the push as a release attempt so the tag gets created.
+          ZERO_SHA="0000000000000000000000000000000000000000"
+          if [ -z "$GITHUB_EVENT_BEFORE" ] || [ "$GITHUB_EVENT_BEFORE" = "$ZERO_SHA" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "No previous SHA on this push; treating as release by default."
+            exit 0
+          fi
+
+          # Compare the version at this push's starting SHA to HEAD.
+          # If git can't read package.json at the before-SHA (file
+          # introduced in this push, tree rewritten, etc.), we treat
+          # the absence as a version change; the conservative
+          # direction that produces a tag rather than silently
+          # skipping. `|| true` keeps the pipeline's exit status 0
+          # under bash -eo pipefail so the step continues.
+          PREV_JSON=$(git show "${GITHUB_EVENT_BEFORE}:package.json" 2>/dev/null || true)
+          if [ -z "$PREV_JSON" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Previous package.json not readable at ${GITHUB_EVENT_BEFORE}; treating as change."
+            exit 0
+          fi
+          PREV_VERSION=$(printf '%s' "$PREV_JSON" | node -e "
+            let buf = ''
+            process.stdin.on('data', c => buf += c)
+            process.stdin.on('end', () => {
+              try { process.stdout.write(JSON.parse(buf).version || '') }
+              catch { process.stdout.write('') }
+            })
+          ")
+          if [ -z "$PREV_VERSION" ] || [ "$PREV_VERSION" != "$CURRENT_VERSION" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version changed: ${PREV_VERSION:-<unknown>} -> ${CURRENT_VERSION}; this is a release commit."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged at ${CURRENT_VERSION}; non-release commit, no-op."
+          fi
+
+      - name: Check whether the tag already exists on the remote
+        id: check
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          HEAD_SHA=$(git rev-parse HEAD)
+
+          # `git ls-remote --tags` distinguishes tag shapes:
+          #   - annotated tag: two lines, tag OBJECT sha
+          #     (refs/tags/<tag>) and dereferenced commit sha
+          #     (refs/tags/<tag>^{})
+          #   - lightweight tag: one line, commit sha under
+          #     refs/tags/<tag>
+          # Filtering on the exact refname (refs/tags/<tag>)
+          # suppresses the ^{} line, so we MUST ask for both
+          # refspecs explicitly. Otherwise the comparison below
+          # would pick the tag-object sha on annotated tags and
+          # always fail the legitimate-rerun equality check.
+          REMOTE_OUT=$(git ls-remote --tags origin \
+            "refs/tags/${TAG}" \
+            "refs/tags/${TAG}^{}" \
+            2>/dev/null || true)
+          if [ -z "$REMOTE_OUT" ]; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Prefer the dereferenced sha (commit) when the remote
+          # returns both. Fall back to the single-line form for
+          # lightweight tags.
+          REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '/\^\{\}$/ {print $1}')
+          if [ -z "$REMOTE_SHA" ]; then
+            REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '{print $1; exit}')
+          fi
+
+          if [ "$REMOTE_SHA" = "$HEAD_SHA" ]; then
+            # Tag already points at the commit we'd tag anyway,
+            # a legitimate rerun on the same main commit. No-op.
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} already points at HEAD ($HEAD_SHA); nothing to do."
+          else
+            # This push changed the version AND a tag for the new
+            # version already exists at a different commit. Classic
+            # orphan-tag failure mode: publish.yml would not fire
+            # for the current release, and the tag would stay
+            # pointed at a stale commit. Fail loudly.
+            echo "::error::Tag ${TAG} exists on the remote but points at ${REMOTE_SHA}, not the current main HEAD ${HEAD_SHA}."
+            echo "::error::This is the orphan-tag failure mode. Delete the stale tag and re-run:"
+            echo "::error::  git push origin --delete ${TAG}"
+            exit 1
+          fi
+
+      - name: Create and push the tag
+        if: steps.version.outputs.changed == 'true' && steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          TAG="${{ steps.version.outputs.tag }}"
+          git tag -a "${TAG}" -m "release ${TAG}"
+
+          # Tolerate "already exists" as success. The concurrency
+          # group above serialises runs on main, but a belt-and-
+          # suspenders guard closes the residual race where a user
+          # (or another workflow) created the same tag between our
+          # ls-remote check above and this push. We only swallow the
+          # specific "already exists" failure; any other push error
+          # still surfaces.
+          set +e
+          PUSH_OUT=$(git push origin "refs/tags/${TAG}" 2>&1)
+          PUSH_STATUS=$?
+          set -e
+          echo "$PUSH_OUT"
+          if [ $PUSH_STATUS -eq 0 ]; then
+            echo "Created and pushed tag ${TAG}"
+          elif echo "$PUSH_OUT" | grep -q "already exists"; then
+            # Someone (or something) created this tag between our
+            # ls-remote check above and this push. "already exists"
+            # alone is not enough to treat as success: the concurrent
+            # creator may have tagged a different commit, in which
+            # case this release is orphaned (publish.yml fires for
+            # their commit, not ours). Re-read the remote tag and
+            # compare to HEAD before declaring success.
+            HEAD_SHA=$(git rev-parse HEAD)
+            VERIFY_OUT=$(git ls-remote --tags origin \
+              "refs/tags/${TAG}" \
+              "refs/tags/${TAG}^{}" \
+              2>/dev/null || true)
+            VERIFY_SHA=$(echo "$VERIFY_OUT" | awk '/\^\{\}$/ {print $1}')
+            if [ -z "$VERIFY_SHA" ]; then
+              VERIFY_SHA=$(echo "$VERIFY_OUT" | awk '{print $1; exit}')
+            fi
+            if [ "$VERIFY_SHA" = "$HEAD_SHA" ]; then
+              echo "Tag ${TAG} was created concurrently at HEAD ($HEAD_SHA); treating as success."
+            else
+              echo "::error::Tag ${TAG} was created concurrently but points at ${VERIFY_SHA:-<unknown>}, not HEAD ${HEAD_SHA}."
+              echo "::error::Another actor tagged a different commit. This release is orphaned. Delete the stale tag and re-run:"
+              echo "::error::  git push origin --delete ${TAG}"
+              exit 1
+            fi
+          else
+            exit $PUSH_STATUS
+          fi

--- a/.github/workflows/tag-on-main.yml
+++ b/.github/workflows/tag-on-main.yml
@@ -32,8 +32,10 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
+# Tighten default permissions at workflow scope to nothing; the
+# one job that needs to push a tag grants itself `contents: write`
+# explicitly below. Future jobs don't silently inherit write.
+permissions: {}
 
 # Serialize pushes to main so two concurrent release merges can't
 # both observe the tag as absent and then race on `git push`.
@@ -47,6 +49,8 @@ jobs:
   maybe-tag:
     name: Tag current main if package.json version is new
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # push refs/tags/v<version>
 
     steps:
       - uses: actions/checkout@v4
@@ -106,14 +110,14 @@ jobs:
             echo "Previous package.json not readable at ${GITHUB_EVENT_BEFORE}; treating as change."
             exit 0
           fi
-          PREV_VERSION=$(printf '%s' "$PREV_JSON" | node -e "
-            let buf = ''
-            process.stdin.on('data', c => buf += c)
-            process.stdin.on('end', () => {
-              try { process.stdout.write(JSON.parse(buf).version || '') }
-              catch { process.stdout.write('') }
-            })
-          ")
+          # Parse the prior package.json version via a direct
+          # `node -e` with the JSON passed as argv, not via stdin.
+          # The stdin-streaming form buys nothing when the content
+          # is already a shell variable and obscures intent. A
+          # parse error falls back to the empty string, which the
+          # change check below treats as "version unknown, assume
+          # changed".
+          PREV_VERSION=$(PREV_JSON="$PREV_JSON" node -e 'try { process.stdout.write(JSON.parse(process.env.PREV_JSON).version || "") } catch { process.stdout.write("") }')
           if [ -z "$PREV_VERSION" ] || [ "$PREV_VERSION" != "$CURRENT_VERSION" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "Version changed: ${PREV_VERSION:-<unknown>} -> ${CURRENT_VERSION}; this is a release commit."
@@ -125,35 +129,26 @@ jobs:
       - name: Check whether the tag already exists on the remote
         id: check
         if: steps.version.outputs.changed == 'true'
+        shell: bash
         run: |
+          set -euo pipefail
           TAG="${{ steps.version.outputs.tag }}"
           HEAD_SHA=$(git rev-parse HEAD)
 
-          # `git ls-remote --tags` distinguishes tag shapes:
-          #   - annotated tag: two lines, tag OBJECT sha
-          #     (refs/tags/<tag>) and dereferenced commit sha
-          #     (refs/tags/<tag>^{})
-          #   - lightweight tag: one line, commit sha under
-          #     refs/tags/<tag>
-          # Filtering on the exact refname (refs/tags/<tag>)
-          # suppresses the ^{} line, so we MUST ask for both
-          # refspecs explicitly. Otherwise the comparison below
-          # would pick the tag-object sha on annotated tags and
-          # always fail the legitimate-rerun equality check.
-          REMOTE_OUT=$(git ls-remote --tags origin \
-            "refs/tags/${TAG}" \
-            "refs/tags/${TAG}^{}" \
-            2>/dev/null || true)
-          if [ -z "$REMOTE_OUT" ]; then
+          # Query for the dereferenced commit sha first (annotated
+          # tag shape). If the tag is annotated, this returns its
+          # commit; if absent OR lightweight, this returns nothing,
+          # and we fall back to the bare refspec (commit sha for
+          # lightweight tags). Two narrow calls beat parsing a
+          # fragile `^{}`-suffix regex on a combined ls-remote.
+          REMOTE_SHA=$(git ls-remote --tags origin "refs/tags/${TAG}^{}" 2>/dev/null | awk '{print $1; exit}')
+          if [ -z "$REMOTE_SHA" ]; then
+            REMOTE_SHA=$(git ls-remote --tags origin "refs/tags/${TAG}" 2>/dev/null | awk '{print $1; exit}')
+          fi
+
+          if [ -z "$REMOTE_SHA" ]; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
             exit 0
-          fi
-          # Prefer the dereferenced sha (commit) when the remote
-          # returns both. Fall back to the single-line form for
-          # lightweight tags.
-          REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '/\^\{\}$/ {print $1}')
-          if [ -z "$REMOTE_SHA" ]; then
-            REMOTE_SHA=$(echo "$REMOTE_OUT" | awk '{print $1; exit}')
           fi
 
           if [ "$REMOTE_SHA" = "$HEAD_SHA" ]; then
@@ -188,8 +183,14 @@ jobs:
           # ls-remote check above and this push. We only swallow the
           # specific "already exists" failure; any other push error
           # still surfaces.
+          #
+          # LC_ALL=C pins git's error text to the C locale so the
+          # grep below is not dependent on the runner's locale.
+          # Without this, a localised runner would turn the race
+          # path into a hard failure because the English substring
+          # "already exists" would be absent.
           set +e
-          PUSH_OUT=$(git push origin "refs/tags/${TAG}" 2>&1)
+          PUSH_OUT=$(LC_ALL=C git push origin "refs/tags/${TAG}" 2>&1)
           PUSH_STATUS=$?
           set -e
           echo "$PUSH_OUT"
@@ -204,13 +205,12 @@ jobs:
             # their commit, not ours). Re-read the remote tag and
             # compare to HEAD before declaring success.
             HEAD_SHA=$(git rev-parse HEAD)
-            VERIFY_OUT=$(git ls-remote --tags origin \
-              "refs/tags/${TAG}" \
-              "refs/tags/${TAG}^{}" \
-              2>/dev/null || true)
-            VERIFY_SHA=$(echo "$VERIFY_OUT" | awk '/\^\{\}$/ {print $1}')
+            # Same two-call pattern as the `check` step: prefer the
+            # dereferenced commit sha (annotated tag); fall back to
+            # the bare refspec (lightweight tag).
+            VERIFY_SHA=$(git ls-remote --tags origin "refs/tags/${TAG}^{}" 2>/dev/null | awk '{print $1; exit}')
             if [ -z "$VERIFY_SHA" ]; then
-              VERIFY_SHA=$(echo "$VERIFY_OUT" | awk '{print $1; exit}')
+              VERIFY_SHA=$(git ls-remote --tags origin "refs/tags/${TAG}" 2>/dev/null | awk '{print $1; exit}')
             fi
             if [ "$VERIFY_SHA" = "$HEAD_SHA" ]; then
               echo "Tag ${TAG} was created concurrently at HEAD ($HEAD_SHA); treating as success."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,13 +79,19 @@ node --test tests/*.test.mjs
 - Unit tests cover `scripts/lib/` helpers and the marker-merge logic.
 - E2E tests run the installer against a throwaway scratch directory under `/tmp`, never touching any real project.
 
-## Publishing
+## Releasing
 
-Tagged releases publish to npm automatically via GitHub Actions:
+Releases are PR-gated; the bot does not push to `main` directly. One dispatch + one PR merge + one dispatch ships the package.
 
-1. `npm run validate && npm test` green on main.
-2. Run the Release workflow manually; pick the version bump type.
-3. The Publish workflow fires on the new tag and pushes to npm.
+1. **Actions → Release → Run workflow**. Branch selector: `main` (any other ref is rejected). Version bump: `patch` / `minor` / `major`.
+2. The workflow bumps `package.json` (and `npm-shrinkwrap.json` when present) on a `release/v<version>` branch and opens a release PR.
+3. Review + merge the PR.
+4. `tag-on-main.yml` detects the version change on the merge commit, creates the annotated `v<version>` tag, and pushes it.
+5. **Actions → Publish to npm → Run workflow** on the new `v<version>` tag. The workflow runs `npm ci + preflight + validate + lint + test`, verifies tag/version agreement, and runs `npm publish --access public --provenance`.
+
+The tag push does NOT auto-chain into publish: `GITHUB_TOKEN` cannot trigger further workflows. Step 5 is a manual dispatch until a GitHub App token or fine-grained PAT is wired into `tag-on-main.yml`'s tag-push step.
+
+Full operator walkthrough (including troubleshooting for stale or orphan tags, non-main dispatches, and the "Allow GitHub Actions to create and approve pull requests" org-level policy) lives in the [Releasing section of the README](README.md#releasing).
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -71,3 +71,48 @@ The scripts self-locate via `import.meta.url`, so they work regardless of where 
 - `design/`: MASTER-PLAN, DECISIONS, ARCHITECTURE, OPEN-QUESTIONS, RISKS.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) to add skills, rules, or seeds. See [INSTALL.md](INSTALL.md) for the full install reference including update and uninstall.
+
+## Releasing
+
+Releases are PR-gated. Version bumps land on `main` through a review gate like any other change; only the tag push is automated.
+
+### One-time setup
+
+Enable these on the repo before your first release:
+
+- Repository secret `NPM_TOKEN` set to an npm access token with publish rights on the `@ctxr` scope (`npm token create`).
+- **Settings → Actions → General → Workflow permissions**: enable **Allow GitHub Actions to create and approve pull requests** so `release.yml` can open its version-bump PR with `GITHUB_TOKEN`. If the checkbox is greyed out, an organization-level Actions policy is restricting it; ask an org admin to unlock the setting first.
+- (Optional, recommended) GitHub-managed CodeQL default setup: Security → Code security → enable default setup for `javascript-typescript` and `actions`.
+- (Optional) A branch ruleset on `main` requiring PR review + code scanning. The release flow works without it; gates are strictly stricter when enabled.
+
+### Cutting a release
+
+1. **Actions → Release → Run workflow**.
+   - Branch selector: `main` (the workflow refuses any other ref).
+   - Version bump: `patch` / `minor` / `major`.
+   - Click **Run workflow**.
+2. The workflow bumps `package.json` (and `npm-shrinkwrap.json` when present) on a fresh `release/v<version>` branch and opens a PR to `main` titled `release: v<version>`.
+3. Review the PR (diff is just version fields). Approve + merge.
+4. On merge, `tag-on-main.yml` fires automatically:
+   - Detects the version change.
+   - Creates and pushes the annotated `v<version>` tag via `GITHUB_TOKEN`.
+5. **Actions → Publish to npm → Run workflow** on the `v<version>` tag. The workflow runs `npm ci + preflight + validate + lint + test`, verifies the tag matches `package.json`, and publishes the package to npm.
+
+> **Why a manual dispatch for step 5?** GitHub's built-in `GITHUB_TOKEN` cannot trigger further workflows (`on: push: tags` won't fire when a workflow pushed the tag). So the tag auto-creation stops at the tag. Publishing is one extra click. To make it fully automatic, swap the push credential in `tag-on-main.yml` for a GitHub App token or fine-grained PAT stored as a repo secret, then the `push: tags` trigger on `publish.yml` will fire and step 5 happens by itself.
+
+From **Run workflow** on Release to **published on npm** is one dispatch + one PR merge + one dispatch (or one dispatch + one PR merge, once a PAT/App-token is wired in).
+
+See [GitHub Releases](https://github.com/ctxr-dev/agent-staff-engineer/releases) for the changelog.
+
+### Troubleshooting
+
+- **Release workflow fails with "dispatched from non-main ref"**: you selected a feature branch in the Actions UI. Re-dispatch with `main`.
+- **`tag-on-main` fails with "Tag vX.Y.Z exists but points at …"**: a stale or orphan tag from a prior failed release. Delete and re-run:
+
+  ```bash
+  git push origin --delete vX.Y.Z
+  ```
+
+  Then merge a trivial no-op PR to `main` (or revert-and-re-merge the release PR) to retrigger `tag-on-main`. Direct pushes to `main` may be blocked by branch protection, so the PR path is the reliable retrigger.
+- **`publish.yml` fails on "Verify version matches tag"**: tag and `package.json` disagree. Investigate the merge commit; this should not happen under the PR-based flow.
+- **GitHub Actions is not permitted to create pull requests**: org or enterprise policy blocks the `GITHUB_TOKEN` from opening PRs. Enable **Allow GitHub Actions to create and approve pull requests** at the org level (Settings → Actions → General → Workflow permissions), or ask the enterprise admin to unlock the setting.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ See [GitHub Releases](https://github.com/ctxr-dev/agent-staff-engineer/releases)
 
 ### Troubleshooting
 
-- **Release workflow fails with "dispatched from non-main ref"**: you selected a feature branch in the Actions UI. Re-dispatch with `main`.
-- **`tag-on-main` fails with "Tag vX.Y.Z exists but points at …"**: a stale or orphan tag from a prior failed release. Delete and re-run:
+- **Release workflow fails with "Release workflow must be dispatched from main"**: you selected a feature branch in the Actions UI. Re-dispatch with `main`.
+- **`tag-on-main` fails with "Tag vX.Y.Z exists on the remote but points at …"**: a stale or orphan tag from a prior failed release. Delete and re-run:
 
   ```bash
   git push origin --delete vX.Y.Z


### PR DESCRIPTION
## Summary

Replaces the legacy `release.yml` pattern (bot pushes bump commit + tag directly to `main`) with the hardened three-workflow PR-gated flow, copied from the sibling `ctxr-dev-skills/skill-code-review` repo and adapted for this repo's specifics. The old shape breaks the moment a branch ruleset lands on `main`; the new shape routes every version bump through a reviewable PR and auto-creates the tag only after merge.

All 25 hardening fixes from `skill-code-review`'s 6-round Copilot review loop are baked into the first commit. A second commit applies 7 additional Important findings from this repo's local `skill-code-review` pass before this PR was opened.

## Changes

- `.github/workflows/release.yml`: full rewrite. `workflow_dispatch` with `patch|minor|major` choice, serialized concurrency, explicit non-main refusal step + defensive `ref: main` checkout, `npm version --no-git-tag-version --ignore-scripts`, stage `package.json` + `npm-shrinkwrap.json` (guarded), human-edit guard before force-push (refuses if the release branch has reviewer commits beyond the prior bump), lease-safe `--force-with-lease=ref:sha`, `gh pr list --state open` gating to avoid editing closed PRs, `printf`-assembled PR body that anchors paragraphs at column 0.
- `.github/workflows/tag-on-main.yml`: new. Push-to-main trigger, version-change detection vs `github.event.before` with zero-SHA handling, `ls-remote` dual narrow refspec (dereferenced first, bare fallback) for annotated/lightweight tag parity, orphan-tag refusal with remediation hint, concurrent-create "already exists" re-verify, `LC_ALL=C` pinning on the parsed `git push` error.
- `.github/workflows/publish.yml`: non-tag-ref refusal as first step, explicit `preflight / validate / lint / test` sequence, tag/version mismatch guard, `npm publish --access public --provenance` with `id-token: write` scoped to this job only.
- All three workflows: workflow-level `permissions: {}` with job-level explicit grants (principle of least privilege; new jobs do not silently inherit write).
- `release.yml` input handling: `${{ inputs.bump }}` passed via `env: BUMP` + explicit `case` allowlist so a future refactor to `type: string` can't open a script-injection sink.
- `README.md`: new `## Releasing` section (one-time setup, cutting-a-release walkthrough, troubleshooting). Troubleshooting quotes match the actual error wording the workflows emit.
- `CONTRIBUTING.md`: `## Publishing` rewritten as `## Releasing` with accurate manual-publish step. Removes the old (and wrong) auto-chain claim.

## Repository-specific substitutions

- Node 22 across all workflows (matches existing `ci.yml`).
- Probe list: `preflight / validate / lint / test` (no `index:build`; this repo doesn't have one).
- This repo publishes `npm-shrinkwrap.json`; `release.yml` stages it when present alongside `package.json` / `package-lock.json`.
- Bot email: `41898282+github-actions[bot]@users.noreply.github.com`.

## Test plan

- [ ] Merge this PR. Confirm `tag-on-main.yml` fires on the merge commit, sees no version change (this PR only touches CI + docs), and no-ops.
- [ ] Actions → Release → Run workflow with `bump: patch`. Confirm it opens `release/v<next>`. Review + merge.
- [ ] `tag-on-main.yml` creates and pushes the annotated `v<next>` tag.
- [ ] Actions → Publish to npm → Run workflow on the new tag. Confirm non-tag-ref guard passes, probe list runs, tag/version match succeeds, and `@ctxr/agent-staff-engineer@<next>` appears on npm.

## Notes

- Local `skill-code-review` returned CONDITIONAL on the first pass (no Critical, 7 Important, several Minor). All 7 Important findings were addressed in commit 2 before this PR was opened. Minor findings deferred per runbook.
- Publish auto-chain is deliberately NOT in scope: the default `GITHUB_TOKEN` cannot trigger further workflows, so step 5 is a manual dispatch. Documented inline and in README. PAT/App-token wiring is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)