### PR TITLE
feat(pr-iteration): post-push PR iteration loop with ReviewProvider abstraction

### DIFF
--- a/examples/ops.config.example.json
+++ b/examples/ops.config.example.json
@@ -123,6 +123,14 @@
       "report_dir": ".development/shared/reports",
       "block_on_verdict": ["NO-GO"],
       "install_hint": "npx @ctxr/kit install @ctxr/skill-code-review"
+    },
+    "external_review": {
+      "enabled": true,
+      "provider": "auto",
+      "bots": { "github": ["copilot-pull-request-reviewer"] },
+      "poll_interval_seconds": 30,
+      "poll_timeout_seconds": 1200,
+      "auto_resolve_stale_after_commits": 1
     }
   },
 

--- a/rules/pr-iteration.md
+++ b/rules/pr-iteration.md
@@ -15,7 +15,7 @@ After `dev-loop` opens a PR, the agent enters the **PR iteration loop** until al
 2. **Zero unresolved review threads** on HEAD, AND the most recent external review is on the current HEAD SHA.
 3. **CI is SUCCESS on current HEAD** across every required job.
 
-When all three hold, the agent reports the final state to the human and stops. **PR merge is a human gate. The agent never merges.** The canonical runbook with the full GraphQL recipes and edge-case handling lives at `.development/shared/runbooks/pr-iteration-runbook.md`; this rule is the binding contract, the runbook is the how-to.
+When all three hold, the agent reports the final state to the human and stops. **PR merge is a human gate. The agent never merges.** The canonical runbook with the full GraphQL recipes and edge-case handling lives in the bundle at `skills/pr-iteration/runbook.md`; this rule is the binding contract, the runbook is the how-to. Target projects that want to mirror the runbook into their own wiki do so via `@ctxr/skill-llm-wiki` per `rules/llm-wiki.md`; the canonical source stays in the bundle.
 
 ## State machine inside the loop
 
@@ -26,7 +26,7 @@ Each round is the same six steps. The loop repeats until the exit conditions hol
 3. **Request external review** on current HEAD via `ReviewProvider.requestReview`. Implementation for GitHub is in `scripts/lib/review/github.mjs` and uses the `requestReviews` GraphQL mutation with `botIds`. The REST endpoint silently no-ops for bots; never use it.
 4. **Poll** at `workflow.external_review.poll_interval_seconds` (default 30s). Stop polling when CI reaches a terminal state (`SUCCESS` / `FAILURE` / `ERROR`) AND (any unresolved threads exist OR the reviewer has posted a review on the current HEAD). Cap the wait at `poll_timeout_seconds` (default 1200s) and surface a clear timeout to the human if hit.
 5. **Fetch unresolved threads** via `ReviewProvider.fetchUnresolvedThreads`. Triage into three buckets (the runbook documents the detection heuristics):
-   - **Stale**: the reviewer re-emitted a comment on already-fixed code (same `path:line`, unchanged content since the last push, or posted on a superseded SHA). Mark for resolution without a code change. Auto-resolve after `auto_resolve_stale_after_commits` rounds (default 1) when the same fingerprint keeps reappearing.
+   - **Stale**: the reviewer re-emitted a comment on already-fixed code (same `path:line`, unchanged content since the last push, or posted on a superseded SHA). Mark for resolution without a code change. The agent tracks the recurrence count per thread fingerprint and auto-resolves once the count crosses `auto_resolve_stale_after_commits` (default 1), surfacing the decision in the per-round report. Set the threshold to `0` to require manual triage for every thread.
    - **Net-new actionable**: real issue. Fix. Lock the fix in with a regression test when the issue was behavioural (security, TOCTOU, exit code, parsing).
    - **Suggestion / style**: take or push back with a reply on the thread.
 6. **Commit + push + resolve threads + re-request**. One commit per round, `fix(review-round-N): <short summary>` with a per-thread bullet list in the body naming `path:line` and what changed. After the push, call `ReviewProvider.resolveThread(threadId)` for every addressed thread, then `ReviewProvider.requestReview` again on the new HEAD. Loop back to step 4.
@@ -46,7 +46,7 @@ Every round writes a `pr-iteration-report.md` into `.development/shared/reports/
 
 - `enabled` (default `true`): flip to `false` to skip the loop entirely. `dev-loop` then halts at "In review" like the pre-PR-2 behaviour.
 - `provider` (`auto` / `github` / `none`): `auto` picks from `trackers.dev.kind` via the dispatcher; `github` forces the GitHub impl (for projects where code lives on GitHub but tickets are elsewhere); `none` is equivalent to `enabled: false`.
-- `bots`: per-kind map of reviewer identifiers. For GitHub each value is a GraphQL node ID (e.g. `BOT_kgDOCnlnWA`); the agent captures it once and caches it in the PR iteration state.
+- `bots`: per-kind map of reviewer LOGINS (portable across repos). For GitHub each value is the bot's login string (e.g. `copilot-pull-request-reviewer`). The skill resolves each login to its GraphQL node ID once per PR via the capture recipe below and caches the mapping in the in-memory iteration state. Config never stores node IDs: they vary across installations and are not portable.
 - `poll_interval_seconds`, `poll_timeout_seconds`, `auto_resolve_stale_after_commits`: see the schema for ranges and defaults.
 
 ## Capturing the Copilot bot node ID (GitHub)
@@ -67,4 +67,4 @@ Pick the `id` whose `login` is `copilot-pull-request-reviewer`. If the repo has 
 - `rules/pr-workflow.md`: full PR state machine (branch -> edits -> local review -> push -> In review -> **iteration loop** -> merge human gate -> Done human gate).
 - `rules/review-loop.md`: the pre-push local review.
 - `skills/pr-iteration/SKILL.md`: the orchestration skill this rule governs.
-- `.development/shared/runbooks/pr-iteration-runbook.md`: the canonical how-to with GraphQL snippets and known gotchas.
+- `skills/pr-iteration/runbook.md`: the canonical how-to with GraphQL snippets and known gotchas. Lives in the bundle so the lint + dash validators cover it; target projects mirror into their wiki via `@ctxr/skill-llm-wiki`.

--- a/rules/pr-iteration.md
+++ b/rules/pr-iteration.md
@@ -60,7 +60,7 @@ gh api graphql -f query='
   }}}'
 ```
 
-Pick the `id` whose `login` is `copilot-pull-request-reviewer`. If the repo has no prior Copilot review yet, request one via the repo's Settings or via a first-round `requestReviews` without `botIds` and the bot seeds itself.
+Pick the `id` whose `login` is `copilot-pull-request-reviewer`. If the repo has no prior Copilot review yet, enable or request Copilot review through the supported GitHub UI flow (repository Settings or the PR's "Reviewers" panel in the web UI), wait for the first real Copilot review to land, and then capture the bot ID from that review. Do NOT attempt a `requestReviews` call without `botIds`: the mutation requires the list, and a bot-less request will not seed the id.
 
 ## Related
 

--- a/rules/pr-iteration.md
+++ b/rules/pr-iteration.md
@@ -1,0 +1,70 @@
+---
+name: pr-iteration
+description: The post-push PR iteration loop. After dev-loop opens a PR, the agent enters this loop, requests an external reviewer, polls for CI and review, triages unresolved threads, fixes + pushes + resolves, and iterates until all three exit conditions hold. Stops cold at the merge human gate.
+portable: true
+scope: every session that opened a PR via dev-loop and has workflow.external_review.enabled
+---
+
+# PR iteration loop
+
+## The rule
+
+After `dev-loop` opens a PR, the agent enters the **PR iteration loop** until all three exit conditions hold on the current HEAD:
+
+1. **Local code-review says GO** on current HEAD.
+2. **Zero unresolved review threads** on HEAD, AND the most recent external review is on the current HEAD SHA.
+3. **CI is SUCCESS on current HEAD** across every required job.
+
+When all three hold, the agent reports the final state to the human and stops. **PR merge is a human gate. The agent never merges.** The canonical runbook with the full GraphQL recipes and edge-case handling lives at `.development/shared/runbooks/pr-iteration-runbook.md`; this rule is the binding contract, the runbook is the how-to.
+
+## State machine inside the loop
+
+Each round is the same six steps. The loop repeats until the exit conditions hold.
+
+1. **Assert local review GO on HEAD.** Delegate to `rules/review-loop.md`. If the local review is not GO, fix and re-run before pushing. Never push with outstanding Critical or Important findings.
+2. **Push** the feature branch to `origin`. Re-use the existing branch; do not rename between rounds.
+3. **Request external review** on current HEAD via `ReviewProvider.requestReview`. Implementation for GitHub is in `scripts/lib/review/github.mjs` and uses the `requestReviews` GraphQL mutation with `botIds`. The REST endpoint silently no-ops for bots; never use it.
+4. **Poll** at `workflow.external_review.poll_interval_seconds` (default 30s). Stop polling when CI reaches a terminal state (`SUCCESS` / `FAILURE` / `ERROR`) AND (any unresolved threads exist OR the reviewer has posted a review on the current HEAD). Cap the wait at `poll_timeout_seconds` (default 1200s) and surface a clear timeout to the human if hit.
+5. **Fetch unresolved threads** via `ReviewProvider.fetchUnresolvedThreads`. Triage into three buckets (the runbook documents the detection heuristics):
+   - **Stale**: the reviewer re-emitted a comment on already-fixed code (same `path:line`, unchanged content since the last push, or posted on a superseded SHA). Mark for resolution without a code change. Auto-resolve after `auto_resolve_stale_after_commits` rounds (default 1) when the same fingerprint keeps reappearing.
+   - **Net-new actionable**: real issue. Fix. Lock the fix in with a regression test when the issue was behavioural (security, TOCTOU, exit code, parsing).
+   - **Suggestion / style**: take or push back with a reply on the thread.
+6. **Commit + push + resolve threads + re-request**. One commit per round, `fix(review-round-N): <short summary>` with a per-thread bullet list in the body naming `path:line` and what changed. After the push, call `ReviewProvider.resolveThread(threadId)` for every addressed thread, then `ReviewProvider.requestReview` again on the new HEAD. Loop back to step 4.
+
+## Stop conditions
+
+- All three exit conditions hold: report state, write a final `pr-iteration-report.md` artefact into the wiki (per `rules/llm-wiki.md`), and stop. Never merge.
+- Poll timeout: surface the timeout with the last-known poll state and stop without committing any changes. Human decides whether to keep waiting, investigate CI, or close the PR.
+- Provider declines (`NotSupportedError`): the provider is the stub for this tracker kind. Surface a clean "pr-iteration not supported for tracker kind '<kind>'; halting at In review" message to the human and stop. Do not fall back to a silent no-op.
+- CI goes red: fetch failed-step log lines, include them in the round's report, fix, re-push. Same loop.
+
+## Per-round artefact
+
+Every round writes a `pr-iteration-report.md` into `.development/shared/reports/` via the wiki (per `rules/llm-wiki.md`): round number, previous and new HEAD SHAs, `requestReview` outcome, poll result, threads resolved / stale / deferred, commits in the round, exit-condition status at end of round. The wiki's own SKILL.md decides placement and frontmatter.
+
+## Config (`workflow.external_review`)
+
+- `enabled` (default `true`): flip to `false` to skip the loop entirely. `dev-loop` then halts at "In review" like the pre-PR-2 behaviour.
+- `provider` (`auto` / `github` / `none`): `auto` picks from `trackers.dev.kind` via the dispatcher; `github` forces the GitHub impl (for projects where code lives on GitHub but tickets are elsewhere); `none` is equivalent to `enabled: false`.
+- `bots`: per-kind map of reviewer identifiers. For GitHub each value is a GraphQL node ID (e.g. `BOT_kgDOCnlnWA`); the agent captures it once and caches it in the PR iteration state.
+- `poll_interval_seconds`, `poll_timeout_seconds`, `auto_resolve_stale_after_commits`: see the schema for ranges and defaults.
+
+## Capturing the Copilot bot node ID (GitHub)
+
+The Copilot bot has a stable GraphQL node ID per repo. Capture it once via:
+
+```bash
+gh api graphql -f query='
+  { repository(owner:"OWNER",name:"REPO"){pullRequest(number:N){
+      reviews(last:10){nodes{author{... on Bot{id login}}}}
+  }}}'
+```
+
+Pick the `id` whose `login` is `copilot-pull-request-reviewer`. If the repo has no prior Copilot review yet, request one via the repo's Settings or via a first-round `requestReviews` without `botIds` and the bot seeds itself.
+
+## Related
+
+- `rules/pr-workflow.md`: full PR state machine (branch -> edits -> local review -> push -> In review -> **iteration loop** -> merge human gate -> Done human gate).
+- `rules/review-loop.md`: the pre-push local review.
+- `skills/pr-iteration/SKILL.md`: the orchestration skill this rule governs.
+- `.development/shared/runbooks/pr-iteration-runbook.md`: the canonical how-to with GraphQL snippets and known gotchas.

--- a/rules/pr-workflow.md
+++ b/rules/pr-workflow.md
@@ -39,9 +39,11 @@ Every code change the agent drives follows the same state machine from branch cr
  poll for CI + review, triage unresolved threads, fix + push +
  resolve, iterate until all three exit conditions hold on current
  HEAD. Governed by rules/pr-iteration.md.]
-   |  skipped when workflow.external_review.enabled is false, or
-   |  when the ReviewProvider dispatcher returns the stub for the
-   |  configured tracker kind (Jira/Linear/GitLab today).
+   |  skipped when workflow.external_review.enabled is false, when
+   |  workflow.external_review.provider is "none" (or the dispatcher
+   |  otherwise resolves the provider kind to "none"), or when the
+   |  ReviewProvider dispatcher returns the stub for the configured
+   |  tracker kind (Jira/Linear/GitLab today).
    v
 ***  HUMAN GATE 1: PR merge  ***
    |

--- a/rules/pr-workflow.md
+++ b/rules/pr-workflow.md
@@ -35,8 +35,13 @@ Every code change the agent drives follows the same state machine from branch cr
 [push; PR opened; reviewers requested; issue -> In review]
    |
    v
-[address review comments]
-   |
+[pr-iteration loop: request external reviewer (Copilot on GitHub),
+ poll for CI + review, triage unresolved threads, fix + push +
+ resolve, iterate until all three exit conditions hold on current
+ HEAD. Governed by rules/pr-iteration.md.]
+   |  skipped when workflow.external_review.enabled is false, or
+   |  when the ReviewProvider dispatcher returns the stub for the
+   |  configured tracker kind (Jira/Linear/GitLab today).
    v
 ***  HUMAN GATE 1: PR merge  ***
    |
@@ -81,7 +86,8 @@ Every code change the agent drives follows the same state machine from branch cr
 ## Reviewer policy
 
 - Always request `project.principals.reviewers_default` plus whatever is declared in `workflow.pr.request_reviewers`.
-- If Copilot is configured as a reviewer but is unavailable on the repo or org, fall back to the human reviewers and surface the absence.
+- External-reviewer orchestration (requesting Copilot, polling, thread triage) is governed by `rules/pr-iteration.md`. This rule names WHOM to request; `pr-iteration.md` drives HOW the request lifecycle plays out.
+- If Copilot is configured as a reviewer but is unavailable on the repo or org, `pr-iteration` surfaces the absence and falls back to the human reviewers. Never silently drop the request.
 - Do not approve a PR the agent opened. Never.
 
 ## The two gates

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -339,7 +339,7 @@
             "bots": {
               "type": "object",
               "additionalProperties": { "type": "array", "items": { "type": "string", "minLength": 1 } },
-              "description": "Per-kind map of reviewer bot LOGINS that requestReview registers. For GitHub each value is the bot's login (e.g. copilot-pull-request-reviewer), portable across repos. The GitHub provider resolves login -> GraphQL node ID at request time by probing the PR's prior reviews; see rules/pr-iteration.md for the resolution recipe. Config stores logins (not node IDs) because node IDs vary across installations and would pin the config to a specific GitHub deployment.",
+              "description": "Per-kind map of reviewer bot LOGINS that requestReview registers. For GitHub each value is the bot's login (e.g. copilot-pull-request-reviewer), portable across repos. The pr-iteration orchestration layer resolves login -> GraphQL node ID before invoking the GitHub provider (which itself requires ctx.botIds as node IDs); see rules/pr-iteration.md for the resolution recipe. Config stores logins (not node IDs) because node IDs vary across installations and would pin the config to a specific GitHub deployment.",
               "default": { "github": ["copilot-pull-request-reviewer"] }
             },
             "poll_interval_seconds": {

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -300,6 +300,50 @@
               "default": "Run: npx @ctxr/kit install @ctxr/skill-code-review  (or clone https://github.com/ctxr-dev/skill-code-review into .claude/skills/)"
             }
           }
+        },
+        "external_review": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Post-push external-reviewer loop (e.g. Copilot on GitHub). Drives the pr-iteration skill: request review, poll for CI and review, fetch unresolved threads, triage, resolve, iterate until all three exit conditions hold (local review GO, zero unresolved, CI SUCCESS on HEAD). Disable by setting enabled:false.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": true,
+              "description": "When false, dev-loop skips the pr-iteration hand-off and halts at 'In review'. Useful for projects that don't use an external reviewer."
+            },
+            "provider": {
+              "type": "string",
+              "enum": ["auto", "github", "none"],
+              "default": "auto",
+              "description": "auto picks the impl from trackers.dev.kind via scripts/lib/review/dispatcher.mjs. github forces the GitHub impl regardless of tracker kind (used when the tracker is elsewhere but code review runs on GitHub). none is equivalent to enabled:false."
+            },
+            "bots": {
+              "type": "object",
+              "additionalProperties": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+              "description": "Per-kind map of reviewer bot identifiers that requestReview registers. For GitHub each value is a GraphQL node ID (e.g. BOT_kgDOCnlnWA); the skill captures the ID once per repo per rules/pr-iteration.md.",
+              "default": { "github": ["copilot-pull-request-reviewer"] }
+            },
+            "poll_interval_seconds": {
+              "type": "integer",
+              "minimum": 15,
+              "maximum": 300,
+              "default": 30,
+              "description": "Seconds between poll-for-review probes. 30 is the runbook default; under 15 burns rate limit, over 300 crosses the harness cache-miss boundary."
+            },
+            "poll_timeout_seconds": {
+              "type": "integer",
+              "minimum": 60,
+              "maximum": 7200,
+              "default": 1200,
+              "description": "Upper bound on the poll loop before surfacing a timeout to the human. 1200 = 20 minutes, enough for a typical Copilot round; longer for CI suites that run >20 min."
+            },
+            "auto_resolve_stale_after_commits": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 1,
+              "description": "When the same path:line thread has been re-emitted by the reviewer on a superseded SHA (commonly 30-50% of Copilot threads after round 1 per the runbook), auto-resolve it after this many commits have landed without changing the underlying code. Set 0 to disable and require manual triage for every thread."
+            }
+          }
         }
       }
     },

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -87,6 +87,25 @@
       }
     },
 
+    "trackers": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Forward-compat block for the PR 3 multi-tracker refactor. Skills can read `trackers.dev.kind` today and receive a valid string when set; the top-level `github:` block above is still the required source of truth until PR 3 flips this. Minimal shape: `trackers.dev.kind` is one of github, jira, linear, gitlab.",
+      "properties": {
+        "dev": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": ["github", "jira", "linear", "gitlab"],
+              "description": "Tracker kind for dev issues. The dispatcher at scripts/lib/review/dispatcher.mjs picks the ReviewProvider from this value; unset/missing falls back to the legacy top-level github: block (github)."
+            }
+          }
+        }
+      }
+    },
+
     "labels": {
       "type": "object",
       "required": ["type", "area", "priority", "intent", "size"],
@@ -320,7 +339,7 @@
             "bots": {
               "type": "object",
               "additionalProperties": { "type": "array", "items": { "type": "string", "minLength": 1 } },
-              "description": "Per-kind map of reviewer bot identifiers that requestReview registers. For GitHub each value is a GraphQL node ID (e.g. BOT_kgDOCnlnWA); the skill captures the ID once per repo per rules/pr-iteration.md.",
+              "description": "Per-kind map of reviewer bot LOGINS that requestReview registers. For GitHub each value is the bot's login (e.g. copilot-pull-request-reviewer), portable across repos. The GitHub provider resolves login -> GraphQL node ID at request time by probing the PR's prior reviews; see rules/pr-iteration.md for the resolution recipe. Config stores logins (not node IDs) because node IDs vary across installations and would pin the config to a specific GitHub deployment.",
               "default": { "github": ["copilot-pull-request-reviewer"] }
             },
             "poll_interval_seconds": {

--- a/scripts/lib/ghExec.mjs
+++ b/scripts/lib/ghExec.mjs
@@ -110,3 +110,97 @@ export async function ghCurrentUser() {
   if (res.code !== 0) return null;
   return res.json ?? null;
 }
+
+/**
+ * Thrown by ghGraphqlQuery / ghGraphqlMutation when the API reports one or
+ * more errors, or when the response cannot be parsed. Carries the original
+ * `errors[]` payload (when present) and the query text so callers can log a
+ * useful diagnostic without re-running the mutation.
+ */
+export class GhGraphqlError extends Error {
+  constructor(message, { errors = null, query = null } = {}) {
+    super(message);
+    this.name = "GhGraphqlError";
+    this.errors = errors;
+    this.query = query;
+  }
+}
+
+/**
+ * Run a GitHub GraphQL query. Variables with scalar values (strings,
+ * numbers, booleans) are passed via `gh api graphql -F <name>=<value>` —
+ * the same mechanism the runbook uses. For array/object args, inline the
+ * values into the query string at the caller site (this is how GitHub
+ * GraphQL features like `botIds: [...]` are typically invoked).
+ *
+ * Returns the `data` root on success. Throws {@link GhGraphqlError} on
+ * either a non-zero gh exit, an unparseable response, a response without
+ * `data`, or a response with a non-empty `errors[]`.
+ *
+ * @param {string} query             GraphQL query text
+ * @param {Record<string, string|number|boolean>} [vars]
+ * @param {{ timeoutMs?: number, cwd?: string }} [options]
+ * @returns {Promise<any>} the `data` root
+ */
+export async function ghGraphqlQuery(query, vars = {}, options = {}) {
+  return ghGraphqlExec(query, vars, options);
+}
+
+/**
+ * Same shape as {@link ghGraphqlQuery}; named separately so that callers'
+ * intent is visible at call sites. GitHub Actions / API responses do not
+ * distinguish queries from mutations at the transport layer.
+ */
+export async function ghGraphqlMutation(mutation, vars = {}, options = {}) {
+  return ghGraphqlExec(mutation, vars, options);
+}
+
+async function ghGraphqlExec(queryText, vars, options) {
+  if (typeof queryText !== "string" || queryText.length === 0) {
+    throw new TypeError("ghGraphql*: query must be a non-empty string");
+  }
+  const args = ["api", "graphql", "-f", `query=${queryText}`];
+  for (const [k, v] of Object.entries(vars || {})) {
+    if (v == null) continue;
+    if (typeof v !== "string" && typeof v !== "number" && typeof v !== "boolean") {
+      throw new TypeError(
+        `ghGraphql*: variable '${k}' must be a string, number, or boolean (got ${typeof v}); inline complex types into the query string instead`,
+      );
+    }
+    // `-F` makes gh type booleans and numbers; strings stay strings.
+    args.push("-F", `${k}=${v}`);
+  }
+  const res = await ghExec(args, {
+    format: "json",
+    timeoutMs: options.timeoutMs ?? 30_000,
+    cwd: options.cwd,
+  });
+  if (res.code !== 0) {
+    throw new GhGraphqlError(
+      `gh api graphql exited ${res.code}: ${(res.stderr || res.stdout).trim()}`,
+      { query: queryText },
+    );
+  }
+  if (!res.json) {
+    throw new GhGraphqlError(
+      `gh api graphql returned unparseable JSON${res.jsonError ? ` (${res.jsonError})` : ""}`,
+      { query: queryText },
+    );
+  }
+  if (Array.isArray(res.json.errors) && res.json.errors.length > 0) {
+    const msg = res.json.errors
+      .map((e) => e.message || JSON.stringify(e))
+      .join("; ");
+    throw new GhGraphqlError(msg, {
+      errors: res.json.errors,
+      query: queryText,
+    });
+  }
+  if (res.json.data == null) {
+    throw new GhGraphqlError(
+      "gh api graphql returned no data field",
+      { query: queryText },
+    );
+  }
+  return res.json.data;
+}

--- a/scripts/lib/review/dispatcher.mjs
+++ b/scripts/lib/review/dispatcher.mjs
@@ -1,0 +1,42 @@
+// lib/review/dispatcher.mjs
+// Pick a ReviewProvider from the tracker kind declared in ops.config.json.
+//
+// Today the only concrete backend is GitHub (github.mjs). Every other
+// kind gets the stub (stub.mjs), which throws NotSupportedError on every
+// operation. PR 3's multi-tracker refactor adds jira/linear/gitlab
+// backends and replaces the stub calls as they land.
+//
+// Legacy shim: ops.config.json files produced before PR 3 carry a
+// top-level `github:` block instead of `trackers.dev.kind`. We infer
+// `github` in that case so existing installs continue to work through
+// PR 2. PR 3 removes this branch at the same time it introduces the
+// hard break on config migration.
+
+import { makeGithubReviewProvider } from "./github.mjs";
+import { makeStubProvider } from "./stub.mjs";
+
+/**
+ * @param {object} opsConfig parsed ops.config.json (or a minimal subset
+ *   carrying either `trackers.dev.kind` or a top-level `github` block)
+ * @returns {{ provider: object, kind: string }}
+ */
+export function pickReviewProvider(opsConfig) {
+  const kind = resolveTrackerKind(opsConfig);
+  if (kind === "github") {
+    return { provider: makeGithubReviewProvider(), kind };
+  }
+  return { provider: makeStubProvider(kind), kind };
+}
+
+/** @returns {string} tracker kind, lower-case; "unknown" when nothing declared. */
+export function resolveTrackerKind(cfg) {
+  const newKind = cfg?.trackers?.dev?.kind;
+  if (typeof newKind === "string" && newKind.length > 0) {
+    return newKind.toLowerCase();
+  }
+  // Legacy shim: any pre-PR-3 config had a top-level `github:` block.
+  if (cfg && typeof cfg === "object" && Object.hasOwn(cfg, "github")) {
+    return "github";
+  }
+  return "unknown";
+}

--- a/scripts/lib/review/dispatcher.mjs
+++ b/scripts/lib/review/dispatcher.mjs
@@ -35,7 +35,16 @@ export function resolveTrackerKind(cfg) {
     return newKind.toLowerCase();
   }
   // Legacy shim: any pre-PR-3 config had a top-level `github:` block.
-  if (cfg && typeof cfg === "object" && Object.hasOwn(cfg, "github")) {
+  // Tighten so `github: null`, `github: []`, `github: "str"`, or
+  // `github: {}` do NOT count as a valid GitHub config; they would
+  // otherwise surface confusing errors deep in the github provider.
+  const legacy = cfg && typeof cfg === "object" ? cfg.github : null;
+  if (
+    legacy &&
+    typeof legacy === "object" &&
+    !Array.isArray(legacy) &&
+    Object.keys(legacy).length > 0
+  ) {
     return "github";
   }
   return "unknown";

--- a/scripts/lib/review/dispatcher.mjs
+++ b/scripts/lib/review/dispatcher.mjs
@@ -1,31 +1,56 @@
 // lib/review/dispatcher.mjs
-// Pick a ReviewProvider from the tracker kind declared in ops.config.json.
+// Pick a ReviewProvider for the pr-iteration loop.
 //
 // Today the only concrete backend is GitHub (github.mjs). Every other
 // kind gets the stub (stub.mjs), which throws NotSupportedError on every
 // operation. PR 3's multi-tracker refactor adds jira/linear/gitlab
 // backends and replaces the stub calls as they land.
 //
-// Legacy shim: ops.config.json files produced before PR 3 carry a
-// top-level `github:` block instead of `trackers.dev.kind`. We infer
-// `github` in that case so existing installs continue to work through
-// PR 2. PR 3 removes this branch at the same time it introduces the
-// hard break on config migration.
+// Precedence (highest to lowest):
+//   1. `workflow.external_review.provider` when it's "github" / "none"
+//      — explicit override from the user, e.g. "code lives on GitHub
+//      but tickets are elsewhere, so force GitHub for review".
+//   2. `workflow.external_review.provider === "auto"` -> fall through.
+//   3. `trackers.dev.kind` (new shape).
+//   4. Top-level legacy `github:` block (pre-PR-3 shim; PR 3 removes).
+//   5. "unknown" -> stub.
 
 import { makeGithubReviewProvider } from "./github.mjs";
 import { makeStubProvider } from "./stub.mjs";
 
 /**
- * @param {object} opsConfig parsed ops.config.json (or a minimal subset
- *   carrying either `trackers.dev.kind` or a top-level `github` block)
+ * @param {object} opsConfig parsed ops.config.json (or a minimal subset)
  * @returns {{ provider: object, kind: string }}
  */
 export function pickReviewProvider(opsConfig) {
-  const kind = resolveTrackerKind(opsConfig);
+  const kind = resolveReviewProviderKind(opsConfig);
   if (kind === "github") {
     return { provider: makeGithubReviewProvider(), kind };
   }
   return { provider: makeStubProvider(kind), kind };
+}
+
+/**
+ * Resolve the review provider kind honoring
+ * `workflow.external_review.provider` before tracker-based inference.
+ *
+ * Supported override values:
+ *   - "github" — force the GitHub provider
+ *   - "none"   — explicitly opt out of the loop (returns "none" so the
+ *                skill can short-circuit cleanly, not attempt to reach
+ *                the stub)
+ *   - "auto"   — use tracker-based inference (same as omitting the key)
+ *
+ * Any other string falls back to inference for forward compat.
+ */
+export function resolveReviewProviderKind(cfg) {
+  const overrideRaw = cfg?.workflow?.external_review?.provider;
+  if (typeof overrideRaw === "string" && overrideRaw.length > 0) {
+    const override = overrideRaw.toLowerCase();
+    if (override === "github" || override === "none") return override;
+    // "auto" (and any unknown value) falls through to inference.
+  }
+  return resolveTrackerKind(cfg);
 }
 
 /** @returns {string} tracker kind, lower-case; "unknown" when nothing declared. */

--- a/scripts/lib/review/dispatcher.mjs
+++ b/scripts/lib/review/dispatcher.mjs
@@ -36,9 +36,15 @@ export function pickReviewProvider(opsConfig) {
  *
  * Supported override values:
  *   - "github" — force the GitHub provider
- *   - "none"   — explicitly opt out of the loop (returns "none" so the
- *                skill can short-circuit cleanly, not attempt to reach
- *                the stub)
+ *   - "none"   — explicitly opt out by returning the distinct "none"
+ *                kind. pickReviewProvider currently still backs every
+ *                non-"github" kind (including "none") with the stub
+ *                so every op throws NotSupportedError; the skill is
+ *                expected to short-circuit on `kind === "none"`
+ *                before touching provider methods. If a future change
+ *                needs a hard null provider for "none", do it in
+ *                pickReviewProvider + tests together, don't diverge
+ *                the doc-string.
  *   - "auto"   — use tracker-based inference (same as omitting the key)
  *
  * Any other string falls back to inference for forward compat.

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -39,13 +39,16 @@ export function makeGithubReviewProvider() {
 }
 
 async function githubRequestReview(ctx) {
-  const prNodeId = ctx.prNodeId ?? (await resolvePrNodeId(ctx));
+  // Validate ctx.botIds BEFORE resolving prNodeId. resolvePrNodeId may
+  // trigger an extra GraphQL call; there's no point paying for it when
+  // the mutation is guaranteed to fail downstream on empty botIds.
   const botIds = ctx.botIds ?? [];
   if (botIds.length === 0) {
     throw new Error(
       "github review: ctx.botIds is empty; capture the bot node ID (see rules/pr-iteration.md) before calling requestReview",
     );
   }
+  const prNodeId = ctx.prNodeId ?? (await resolvePrNodeId(ctx));
   // botIds is inlined into the query text because `gh api graphql -F` does
   // not have clean ergonomics for array values. Each id is JSON-encoded so
   // quoting is correct and prevents any stray shell/GraphQL metacharacter

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -70,14 +70,17 @@ async function githubRequestReview(ctx) {
 }
 
 async function githubPollForReview(ctx) {
-  const { owner, repo, prNumber, headSha } = ctx;
+  const { owner, repo, prNumber, headSha, botLogins } = ctx;
   const query = `
     query($owner: String!, $name: String!, $number: Int!) {
       repository(owner: $owner, name: $name) {
         pullRequest(number: $number) {
           reviewThreads(first: 100) { nodes { isResolved } }
           reviews(last: 10) {
-            nodes { commit { oid } author { login } }
+            nodes {
+              commit { oid }
+              author { __typename login }
+            }
           }
           commits(last: 1) {
             nodes { commit { oid statusCheckRollup { state } } }
@@ -101,9 +104,22 @@ async function githubPollForReview(ctx) {
   // `reviewOnHead: false`, keeping the loop polling. Fall back to
   // ctx.headSha only when the query didn't surface a commit (rare).
   const prHeadSha = pr.commits.nodes[0]?.commit?.oid ?? headSha;
-  const reviewOnHead = pr.reviews.nodes.some(
-    (r) => r.commit?.oid === prHeadSha,
-  );
+  // `reviewOnHead` MUST be true only for the configured external
+  // reviewer, not any review. Without this filter a human review on
+  // HEAD (project owner, teammate) trips the gate and the iteration
+  // loop exits before Copilot has caught up to the new SHA.
+  // Filter precedence:
+  //   1. ctx.botLogins non-empty -> author.login must be one of those.
+  //   2. Otherwise accept any `Bot`-typed author (keeps the code
+  //      useful for callers that don't want login-level precision).
+  const reviewOnHead = pr.reviews.nodes.some((r) => {
+    if ((r.commit?.oid ?? null) !== prHeadSha) return false;
+    const author = r.author || {};
+    if (Array.isArray(botLogins) && botLogins.length > 0) {
+      return typeof author.login === "string" && botLogins.includes(author.login);
+    }
+    return author.__typename === "Bot";
+  });
   return { ciState: normalizeCiState(rawState), unresolvedCount, reviewOnHead };
 }
 

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -1,0 +1,166 @@
+// lib/review/github.mjs
+// GitHub implementation of the ReviewProvider contract. Every operation
+// wraps a `gh api graphql` call captured in the pr-iteration runbook
+// (requestReviews, reviewThreads, resolveReviewThread, statusCheckRollup).
+//
+// Why GraphQL and not REST: the runbook's step 4 documents that the REST
+// `POST /repos/.../requested_reviewers` endpoint silently no-ops for bots
+// (it returns 200 but never requests Copilot). The GraphQL `requestReviews`
+// mutation with `botIds` is the only mechanism that actually triggers a
+// bot review; the whole loop is built on top of that mutation.
+//
+// botIds capture: the Copilot bot has a stable GraphQL node ID per repo
+// (e.g. "BOT_kgDOCnlnWA"). The agent captures it once, typically from the
+// sibling repo's recent reviews, and passes it in ctx.botIds for every
+// round thereafter. See rules/pr-iteration.md for the capture recipe.
+
+import { ghGraphqlMutation, ghGraphqlQuery } from "../ghExec.mjs";
+
+/** @returns {object} a ReviewProvider impl bound to gh CLI */
+export function makeGithubReviewProvider() {
+  return {
+    requestReview: githubRequestReview,
+    pollForReview: githubPollForReview,
+    fetchUnresolvedThreads: githubFetchUnresolvedThreads,
+    resolveThread: githubResolveThread,
+    ciStateOnHead: githubCiStateOnHead,
+  };
+}
+
+async function githubRequestReview(ctx) {
+  const prNodeId = ctx.prNodeId ?? (await resolvePrNodeId(ctx));
+  const botIds = ctx.botIds ?? [];
+  if (botIds.length === 0) {
+    throw new Error(
+      "github review: ctx.botIds is empty; capture the bot node ID (see rules/pr-iteration.md) before calling requestReview",
+    );
+  }
+  // botIds is inlined into the query text because `gh api graphql -F` does
+  // not have clean ergonomics for array values. Each id is JSON-encoded so
+  // quoting is correct and prevents any stray shell/GraphQL metacharacter
+  // from escaping the string context. The prNodeId goes via a typed var.
+  const botIdsList = botIds.map((id) => JSON.stringify(String(id))).join(", ");
+  const mutation = `
+    mutation($prId: ID!) {
+      requestReviews(input: {
+        pullRequestId: $prId
+        botIds: [${botIdsList}]
+        union: true
+      }) {
+        pullRequest {
+          reviewRequests(first: 10) {
+            nodes { requestedReviewer { ... on Bot { login } } }
+          }
+        }
+      }
+    }
+  `;
+  return ghGraphqlMutation(mutation, { prId: prNodeId });
+}
+
+async function githubPollForReview(ctx) {
+  const { owner, repo, prNumber, headSha } = ctx;
+  const query = `
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) { nodes { isResolved } }
+          reviews(last: 10) {
+            nodes { commit { oid } author { login } }
+          }
+          commits(last: 1) {
+            nodes { commit { oid statusCheckRollup { state } } }
+          }
+        }
+      }
+    }
+  `;
+  const data = await ghGraphqlQuery(query, {
+    owner,
+    name: repo,
+    number: prNumber,
+  });
+  const pr = data.repository.pullRequest;
+  const threads = pr.reviewThreads.nodes;
+  const unresolvedCount = threads.filter((t) => !t.isResolved).length;
+  const state =
+    pr.commits.nodes[0]?.commit?.statusCheckRollup?.state ?? "PENDING";
+  const reviewOnHead = pr.reviews.nodes.some(
+    (r) => r.commit?.oid === headSha,
+  );
+  return { ciState: state, unresolvedCount, reviewOnHead };
+}
+
+async function githubFetchUnresolvedThreads(ctx) {
+  const { owner, repo, prNumber } = ctx;
+  const query = `
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) {
+            nodes {
+              id isResolved isOutdated path line
+              comments(first: 5) {
+                nodes { author { login } body commit { oid } createdAt }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+  const data = await ghGraphqlQuery(query, {
+    owner,
+    name: repo,
+    number: prNumber,
+  });
+  const threads = data.repository.pullRequest.reviewThreads.nodes;
+  return threads
+    .filter((t) => !t.isResolved)
+    .map((t) => {
+      const firstComment = t.comments.nodes[0] ?? {};
+      return {
+        id: t.id,
+        path: t.path,
+        line: t.line,
+        commitSha: firstComment.commit?.oid ?? null,
+        authorLogin: firstComment.author?.login ?? null,
+        body: firstComment.body ?? "",
+      };
+    });
+}
+
+async function githubResolveThread(_ctx, threadId) {
+  if (typeof threadId !== "string" || threadId.length === 0) {
+    throw new TypeError("resolveThread: threadId must be a non-empty string");
+  }
+  const mutation = `
+    mutation($tid: ID!) {
+      resolveReviewThread(input: { threadId: $tid }) {
+        thread { isResolved }
+      }
+    }
+  `;
+  return ghGraphqlMutation(mutation, { tid: threadId });
+}
+
+async function githubCiStateOnHead(ctx) {
+  const { ciState } = await githubPollForReview(ctx);
+  return ciState;
+}
+
+async function resolvePrNodeId({ owner, repo, prNumber }) {
+  const query = `
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) { id }
+      }
+    }
+  `;
+  const data = await ghGraphqlQuery(query, {
+    owner,
+    name: repo,
+    number: prNumber,
+  });
+  return data.repository.pullRequest.id;
+}

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -94,12 +94,24 @@ async function githubPollForReview(ctx) {
   const pr = data.repository.pullRequest;
   const threads = pr.reviewThreads.nodes;
   const unresolvedCount = threads.filter((t) => !t.isResolved).length;
-  const state =
-    pr.commits.nodes[0]?.commit?.statusCheckRollup?.state ?? "PENDING";
+  const rawState = pr.commits.nodes[0]?.commit?.statusCheckRollup?.state;
   const reviewOnHead = pr.reviews.nodes.some(
     (r) => r.commit?.oid === headSha,
   );
-  return { ciState: state, unresolvedCount, reviewOnHead };
+  return { ciState: normalizeCiState(rawState), unresolvedCount, reviewOnHead };
+}
+
+// GitHub's StatusState enum carries several values the ReviewProvider
+// contract does NOT surface (EXPECTED, PENDING_EXPECTED, plus historical
+// casing variants). Fold everything that isn't one of the four
+// documented terminal/transitional states into PENDING so downstream
+// comparisons (exit gates, if/else on ci_done) don't silently mis-bucket
+// an in-flight run.
+function normalizeCiState(raw) {
+  if (raw === "SUCCESS" || raw === "FAILURE" || raw === "ERROR" || raw === "PENDING") {
+    return raw;
+  }
+  return "PENDING";
 }
 
 async function githubFetchUnresolvedThreads(ctx) {
@@ -176,10 +188,8 @@ async function githubCiStateOnHead(ctx) {
     name: repo,
     number: prNumber,
   });
-  return (
-    data.repository.pullRequest.commits.nodes[0]?.commit?.statusCheckRollup?.state ??
-    "PENDING"
-  );
+  const raw = data.repository.pullRequest.commits.nodes[0]?.commit?.statusCheckRollup?.state;
+  return normalizeCiState(raw);
 }
 
 async function resolvePrNodeId({ owner, repo, prNumber }) {

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -95,8 +95,14 @@ async function githubPollForReview(ctx) {
   const threads = pr.reviewThreads.nodes;
   const unresolvedCount = threads.filter((t) => !t.isResolved).length;
   const rawState = pr.commits.nodes[0]?.commit?.statusCheckRollup?.state;
+  // Prefer the PR's server-side current HEAD SHA over `ctx.headSha`:
+  // if the caller forgot to refresh `ctx` after a push, the ctx value
+  // is stale and this comparison would wrongly report
+  // `reviewOnHead: false`, keeping the loop polling. Fall back to
+  // ctx.headSha only when the query didn't surface a commit (rare).
+  const prHeadSha = pr.commits.nodes[0]?.commit?.oid ?? headSha;
   const reviewOnHead = pr.reviews.nodes.some(
-    (r) => r.commit?.oid === headSha,
+    (r) => r.commit?.oid === prHeadSha,
   );
   return { ciState: normalizeCiState(rawState), unresolvedCount, reviewOnHead };
 }

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -48,12 +48,30 @@ async function githubRequestReview(ctx) {
       "github review: ctx.botIds is empty; capture the bot node ID (see rules/pr-iteration.md) before calling requestReview",
     );
   }
+  // Validate each element: GitHub's requestReviews mutation rejects
+  // null/undefined/empty-string ids with an opaque "expected String"
+  // error. Catch the offending index here with a clear message so
+  // the caller sees exactly which botId was bad.
+  const validatedBotIds = botIds.map((id, i) => {
+    if (typeof id !== "string") {
+      throw new TypeError(
+        `github review: ctx.botIds[${i}] must be a non-empty string GraphQL node ID; got ${String(id)}`,
+      );
+    }
+    const trimmed = id.trim();
+    if (trimmed.length === 0) {
+      throw new TypeError(
+        `github review: ctx.botIds[${i}] must be a non-empty string GraphQL node ID; got ${JSON.stringify(id)}`,
+      );
+    }
+    return trimmed;
+  });
   const prNodeId = ctx.prNodeId ?? (await resolvePrNodeId(ctx));
   // botIds is inlined into the query text because `gh api graphql -F` does
   // not have clean ergonomics for array values. Each id is JSON-encoded so
   // quoting is correct and prevents any stray shell/GraphQL metacharacter
   // from escaping the string context. The prNodeId goes via a typed var.
-  const botIdsList = botIds.map((id) => JSON.stringify(String(id))).join(", ");
+  const botIdsList = validatedBotIds.map((id) => JSON.stringify(id)).join(", ");
   const mutation = `
     mutation($prId: ID!) {
       requestReviews(input: {

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -115,11 +115,21 @@ async function githubPollForReview(ctx) {
   //   1. ctx.botLogins non-empty -> author.login must be one of those.
   //   2. Otherwise accept any `Bot`-typed author (keeps the code
   //      useful for callers that don't want login-level precision).
+  // Comparison is case-insensitive because GitHub logins are
+  // case-insensitive and config may carry mixed casing
+  // ("Copilot-pull-request-reviewer" etc).
+  const lowerBotLogins =
+    Array.isArray(botLogins) && botLogins.length > 0
+      ? new Set(botLogins.map((x) => String(x).toLowerCase()))
+      : null;
   const reviewOnHead = pr.reviews.nodes.some((r) => {
     if ((r.commit?.oid ?? null) !== prHeadSha) return false;
     const author = r.author || {};
-    if (Array.isArray(botLogins) && botLogins.length > 0) {
-      return typeof author.login === "string" && botLogins.includes(author.login);
+    if (lowerBotLogins) {
+      return (
+        typeof author.login === "string" &&
+        lowerBotLogins.has(author.login.toLowerCase())
+      );
     }
     return author.__typename === "Bot";
   });

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -258,7 +258,11 @@ async function githubFetchUnresolvedThreads(ctx) {
 }
 
 async function githubResolveThread(_ctx, threadId) {
-  if (typeof threadId !== "string" || threadId.length === 0) {
+  // Reject whitespace-only threadIds in addition to empty strings,
+  // matching the stricter pattern botIds validation uses. Without
+  // this, "   " would be sent to GitHub and bounce as an opaque
+  // GraphQL "expected String" error.
+  if (typeof threadId !== "string" || threadId.trim().length === 0) {
     throw new TypeError("resolveThread: threadId must be a non-empty string");
   }
   const mutation = `

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -74,12 +74,20 @@ async function githubRequestReview(ctx) {
 
 async function githubPollForReview(ctx) {
   const { owner, repo, prNumber, headSha, botLogins } = ctx;
+  // First page fetches threads + reviews + commits in one round-trip.
+  // Pagination only kicks in when page 1 is all-resolved AND more pages
+  // exist — the common case (small PRs) still does exactly one query.
+  // Review history is pulled with last:50 (up from last:10) so long-
+  // running PRs with many re-review rounds don't fall off the window.
   const query = `
     query($owner: String!, $name: String!, $number: Int!) {
       repository(owner: $owner, name: $name) {
         pullRequest(number: $number) {
-          reviewThreads(first: 100) { nodes { isResolved } }
-          reviews(last: 10) {
+          reviewThreads(first: 100) {
+            nodes { isResolved }
+            pageInfo { hasNextPage endCursor }
+          }
+          reviews(last: 50) {
             nodes {
               commit { oid }
               author { __typename login }
@@ -98,8 +106,19 @@ async function githubPollForReview(ctx) {
     number: prNumber,
   });
   const pr = data.repository.pullRequest;
-  const threads = pr.reviewThreads.nodes;
-  const unresolvedCount = threads.filter((t) => !t.isResolved).length;
+  const firstPage = pr.reviewThreads;
+  let unresolvedCount = firstPage.nodes.filter((t) => !t.isResolved).length;
+  // If page 1 is all-resolved but more pages exist, page through the
+  // tail until we see any unresolved (sufficient signal to exit the
+  // count loop) or confirm none. Without this, a PR with >100 threads
+  // where all unresolved happen to sit past page 1 would report
+  // unresolvedCount=0 and let the iteration loop exit prematurely.
+  if (unresolvedCount === 0 && firstPage.pageInfo?.hasNextPage) {
+    unresolvedCount = await countUnresolvedBeyondFirstPage(
+      { owner, repo, prNumber },
+      firstPage.pageInfo.endCursor,
+    );
+  }
   const rawState = pr.commits.nodes[0]?.commit?.statusCheckRollup?.state;
   // Prefer the PR's server-side current HEAD SHA over `ctx.headSha`:
   // if the caller forgot to refresh `ctx` after a push, the ctx value
@@ -149,31 +168,57 @@ function normalizeCiState(raw) {
   return "PENDING";
 }
 
+// Hard cap on paginated `reviewThreads` fetches. 10 pages * 100 per
+// page = 1000 threads. PRs larger than that are pathological; fail
+// loud rather than silently truncate.
+const MAX_REVIEW_THREAD_PAGES = 10;
+
 async function githubFetchUnresolvedThreads(ctx) {
   const { owner, repo, prNumber } = ctx;
+  // Paginate through every reviewThreads page so the skill sees every
+  // unresolved thread on a large PR. Without this, threads past page 1
+  // would never be triaged or resolved and the loop could never
+  // converge to unresolved=0.
   const query = `
-    query($owner: String!, $name: String!, $number: Int!) {
+    query($owner: String!, $name: String!, $number: Int!, $after: String) {
       repository(owner: $owner, name: $name) {
         pullRequest(number: $number) {
-          reviewThreads(first: 100) {
+          reviewThreads(first: 100, after: $after) {
             nodes {
               id isResolved isOutdated path line
               comments(first: 5) {
                 nodes { author { login } body commit { oid } createdAt }
               }
             }
+            pageInfo { hasNextPage endCursor }
           }
         }
       }
     }
   `;
-  const data = await ghGraphqlQuery(query, {
-    owner,
-    name: repo,
-    number: prNumber,
-  });
-  const threads = data.repository.pullRequest.reviewThreads.nodes;
-  return threads
+  const all = [];
+  let after = null;
+  let hasNext = true;
+  let page = 0;
+  while (hasNext) {
+    page += 1;
+    if (page > MAX_REVIEW_THREAD_PAGES) {
+      throw new Error(
+        `githubFetchUnresolvedThreads: exceeded ${MAX_REVIEW_THREAD_PAGES} pages of review threads for ${owner}/${repo}#${prNumber}; refusing to silently truncate results`,
+      );
+    }
+    const data = await ghGraphqlQuery(query, {
+      owner,
+      name: repo,
+      number: prNumber,
+      after,
+    });
+    const rt = data.repository.pullRequest.reviewThreads;
+    all.push(...rt.nodes);
+    hasNext = Boolean(rt.pageInfo?.hasNextPage);
+    after = rt.pageInfo?.endCursor ?? null;
+  }
+  return all
     .filter((t) => !t.isResolved)
     .map((t) => {
       const firstComment = t.comments.nodes[0] ?? {};
@@ -247,4 +292,56 @@ async function resolvePrNodeId({ owner, repo, prNumber }) {
     number: prNumber,
   });
   return data.repository.pullRequest.id;
+}
+
+/**
+ * Page through reviewThreads starting after `startCursor` and return the
+ * count of unresolved threads, short-circuiting as soon as any unresolved
+ * is seen (>= 1 is enough signal for pollForReview's gate). Throws if
+ * pagination would exceed MAX_REVIEW_THREAD_PAGES. Only used when
+ * pollForReview's first page is all-resolved but hasNextPage is true.
+ *
+ * Returns the count of unresolved threads found on pages 2..N. Page 1's
+ * count was already known to be 0 when this is invoked.
+ */
+async function countUnresolvedBeyondFirstPage({ owner, repo, prNumber }, startCursor) {
+  const query = `
+    query($owner: String!, $name: String!, $number: Int!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100, after: $after) {
+            nodes { isResolved }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }
+    }
+  `;
+  let after = startCursor;
+  let page = 1; // page 1 already consumed by the caller
+  let unresolved = 0;
+  while (after) {
+    page += 1;
+    if (page > MAX_REVIEW_THREAD_PAGES) {
+      throw new Error(
+        `countUnresolvedBeyondFirstPage: exceeded ${MAX_REVIEW_THREAD_PAGES} pages for ${owner}/${repo}#${prNumber}; refusing to silently truncate`,
+      );
+    }
+    const data = await ghGraphqlQuery(query, {
+      owner,
+      name: repo,
+      number: prNumber,
+      after,
+    });
+    const rt = data.repository.pullRequest.reviewThreads;
+    const pageUnresolved = rt.nodes.filter((t) => !t.isResolved).length;
+    if (pageUnresolved > 0) {
+      // Any unresolved is enough signal; the exact count doesn't matter
+      // for the gate (unresolvedCount > 0 blocks exit either way).
+      return unresolved + pageUnresolved;
+    }
+    if (!rt.pageInfo?.hasNextPage) return unresolved;
+    after = rt.pageInfo.endCursor ?? null;
+  }
+  return unresolved;
 }

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -171,6 +171,12 @@ async function githubFetchUnresolvedThreads(ctx) {
         id: t.id,
         path: t.path,
         line: t.line,
+        // GitHub's `isOutdated` flag: the anchor line has moved since
+        // the comment was posted. A strong signal for the stale-triage
+        // heuristic in rules/pr-iteration.md ("superseded SHA" / "code
+        // changed under the thread"). Surfaced so the skill can auto-
+        // classify outdated threads without re-deriving the fact.
+        isOutdated: Boolean(t.isOutdated),
         commitSha: firstComment.commit?.oid ?? null,
         authorLogin: firstComment.author?.login ?? null,
         body: firstComment.body ?? "",

--- a/scripts/lib/review/github.mjs
+++ b/scripts/lib/review/github.mjs
@@ -15,16 +15,27 @@
 // round thereafter. See rules/pr-iteration.md for the capture recipe.
 
 import { ghGraphqlMutation, ghGraphqlQuery } from "../ghExec.mjs";
+import { REVIEW_PROVIDER_METHODS } from "./provider.mjs";
 
 /** @returns {object} a ReviewProvider impl bound to gh CLI */
 export function makeGithubReviewProvider() {
-  return {
+  const impl = {
     requestReview: githubRequestReview,
     pollForReview: githubPollForReview,
     fetchUnresolvedThreads: githubFetchUnresolvedThreads,
     resolveThread: githubResolveThread,
     ciStateOnHead: githubCiStateOnHead,
   };
+  // Construction-time coverage assert: if REVIEW_PROVIDER_METHODS grows a
+  // new entry and this file forgets to wire it, fail loudly here rather
+  // than letting the skill hit a bare `x is not a function` at runtime.
+  const missing = REVIEW_PROVIDER_METHODS.filter((m) => typeof impl[m] !== "function");
+  if (missing.length > 0) {
+    throw new Error(
+      `makeGithubReviewProvider: missing ReviewProvider methods [${missing.join(", ")}]; wire them in or update REVIEW_PROVIDER_METHODS`,
+    );
+  }
+  return impl;
 }
 
 async function githubRequestReview(ctx) {
@@ -145,8 +156,30 @@ async function githubResolveThread(_ctx, threadId) {
 }
 
 async function githubCiStateOnHead(ctx) {
-  const { ciState } = await githubPollForReview(ctx);
-  return ciState;
+  // Narrow query: only the HEAD commit's statusCheckRollup.state. Separate
+  // from pollForReview so callers that need just the CI signal don't drag
+  // along the full review-threads + reviews fetch.
+  const { owner, repo, prNumber } = ctx;
+  const query = `
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          commits(last: 1) {
+            nodes { commit { statusCheckRollup { state } } }
+          }
+        }
+      }
+    }
+  `;
+  const data = await ghGraphqlQuery(query, {
+    owner,
+    name: repo,
+    number: prNumber,
+  });
+  return (
+    data.repository.pullRequest.commits.nodes[0]?.commit?.statusCheckRollup?.state ??
+    "PENDING"
+  );
 }
 
 async function resolvePrNodeId({ owner, repo, prNumber }) {

--- a/scripts/lib/review/provider.mjs
+++ b/scripts/lib/review/provider.mjs
@@ -16,12 +16,20 @@
 //
 // ctx object each method accepts:
 //   {
-//     owner:     string    // tracker-side owner (GitHub owner, Jira site, ...)
-//     repo:      string    // tracker-side repo / project key
-//     prNumber:  number    // pull-request / merge-request / change number
-//     headSha:   string    // current HEAD SHA on the feature branch
-//     prNodeId?: string    // GraphQL node ID (GitHub); cached across rounds
-//     botIds?:   string[]  // reviewer node IDs (GitHub); captured once per repo
+//     owner:      string    // tracker-side owner (GitHub owner, Jira site, ...)
+//     repo:       string    // tracker-side repo / project key
+//     prNumber:   number    // pull-request / merge-request / change number
+//     headSha:    string    // current HEAD SHA on the feature branch
+//     prNodeId?:  string    // GraphQL node ID (GitHub); cached across rounds
+//     botIds?:    string[]  // reviewer node IDs (GitHub); passed to
+//                             requestReviews mutations (captured once per
+//                             repo per rules/pr-iteration.md).
+//     botLogins?: string[]  // reviewer logins (GitHub); used by
+//                             pollForReview to narrow `reviewOnHead` to
+//                             the configured external reviewer. When
+//                             empty the provider falls back to "any
+//                             Bot-typed author on HEAD" which works
+//                             for the common single-bot case.
 //   }
 
 /**

--- a/scripts/lib/review/provider.mjs
+++ b/scripts/lib/review/provider.mjs
@@ -1,0 +1,63 @@
+// lib/review/provider.mjs
+// The `ReviewProvider` interface: a duck-typed contract every concrete
+// review-iteration backend implements. Used by the `pr-iteration` skill
+// to drive the post-push loop (request external review, poll for CI +
+// review, fetch unresolved threads, triage, resolve).
+//
+// Concrete implementations:
+//   - github.mjs  — full impl backed by `gh api graphql` mutations.
+//   - stub.mjs    — declines every op with NotSupportedError. Used for
+//                   tracker kinds where the loop has not been implemented
+//                   yet (Jira, Linear, GitLab as of v1).
+//
+// The dispatcher (dispatcher.mjs) picks a provider from
+// `ops.config.json -> trackers.dev.kind` (or the legacy top-level
+// `github:` block, as a transitional shim until PR 3 removes it).
+//
+// ctx object each method accepts:
+//   {
+//     owner:     string    // tracker-side owner (GitHub owner, Jira site, ...)
+//     repo:      string    // tracker-side repo / project key
+//     prNumber:  number    // pull-request / merge-request / change number
+//     headSha:   string    // current HEAD SHA on the feature branch
+//     prNodeId?: string    // GraphQL node ID (GitHub); cached across rounds
+//     botIds?:   string[]  // reviewer node IDs (GitHub); captured once per repo
+//   }
+
+/**
+ * Thrown by ReviewProvider implementations that don't support a given
+ * operation on the current tracker kind. Carries `kind` and `op` for
+ * useful diagnostics at the skill level.
+ */
+export class NotSupportedError extends Error {
+  constructor(message, { kind = null, op = null } = {}) {
+    super(message);
+    this.name = "NotSupportedError";
+    this.kind = kind;
+    this.op = op;
+  }
+}
+
+/**
+ * Names of the methods every ReviewProvider implementation must expose.
+ * Exported so tests can assert method coverage without hard-coding the list
+ * in multiple places, and so the stub can iterate and produce identical
+ * NotSupportedError throwers for each one.
+ *
+ * Semantics:
+ *   requestReview(ctx)           -> register external reviewer on HEAD
+ *   pollForReview(ctx)           -> one-shot probe; returns
+ *       { ciState: "SUCCESS"|"FAILURE"|"ERROR"|"PENDING",
+ *         unresolvedCount: number, reviewOnHead: boolean }
+ *   fetchUnresolvedThreads(ctx)  -> Thread[]; each Thread =
+ *       { id, path, line, commitSha, authorLogin, body }
+ *   resolveThread(ctx, threadId) -> void mutation
+ *   ciStateOnHead(ctx)           -> one of the ciState enum values
+ */
+export const REVIEW_PROVIDER_METHODS = Object.freeze([
+  "requestReview",
+  "pollForReview",
+  "fetchUnresolvedThreads",
+  "resolveThread",
+  "ciStateOnHead",
+]);

--- a/scripts/lib/review/provider.mjs
+++ b/scripts/lib/review/provider.mjs
@@ -58,7 +58,11 @@ export class NotSupportedError extends Error {
  *       { ciState: "SUCCESS"|"FAILURE"|"ERROR"|"PENDING",
  *         unresolvedCount: number, reviewOnHead: boolean }
  *   fetchUnresolvedThreads(ctx)  -> Thread[]; each Thread =
- *       { id, path, line, isOutdated, commitSha, authorLogin, body }
+ *       { id, path, line: number|null, isOutdated, commitSha,
+ *         authorLogin, body }
+ *       `line` may be null for file-level threads or otherwise
+ *       unanchored comments; consumers must handle that case and
+ *       must not assume `${path}:${line}` is always formattable.
  *       `isOutdated` = the anchor line has moved since the comment
  *       was posted (GitHub surfaces this flag; providers should
  *       best-effort map their native equivalent for stale-triage).

--- a/scripts/lib/review/provider.mjs
+++ b/scripts/lib/review/provider.mjs
@@ -58,8 +58,13 @@ export class NotSupportedError extends Error {
  *       { ciState: "SUCCESS"|"FAILURE"|"ERROR"|"PENDING",
  *         unresolvedCount: number, reviewOnHead: boolean }
  *   fetchUnresolvedThreads(ctx)  -> Thread[]; each Thread =
- *       { id, path, line, commitSha, authorLogin, body }
- *   resolveThread(ctx, threadId) -> void mutation
+ *       { id, path, line, isOutdated, commitSha, authorLogin, body }
+ *       `isOutdated` = the anchor line has moved since the comment
+ *       was posted (GitHub surfaces this flag; providers should
+ *       best-effort map their native equivalent for stale-triage).
+ *   resolveThread(ctx, threadId) -> mutation data (provider-specific).
+ *       Callers typically ignore the return value; the side effect
+ *       (thread resolved on the tracker) is what matters.
  *   ciStateOnHead(ctx)           -> one of the ciState enum values
  */
 export const REVIEW_PROVIDER_METHODS = Object.freeze([

--- a/scripts/lib/review/stub.mjs
+++ b/scripts/lib/review/stub.mjs
@@ -17,7 +17,7 @@ export function makeStubProvider(kind) {
   for (const op of REVIEW_PROVIDER_METHODS) {
     impl[op] = () => {
       throw new NotSupportedError(
-        `pr-iteration review loop is not implemented for tracker kind '${kind}' yet; see rules/pr-iteration.md fallback`,
+        `pr-iteration review op '${op}' is not implemented for tracker kind '${kind}' yet; see rules/pr-iteration.md fallback`,
         { kind, op },
       );
     };

--- a/scripts/lib/review/stub.mjs
+++ b/scripts/lib/review/stub.mjs
@@ -15,7 +15,12 @@ import { NotSupportedError, REVIEW_PROVIDER_METHODS } from "./provider.mjs";
 export function makeStubProvider(kind) {
   const impl = {};
   for (const op of REVIEW_PROVIDER_METHODS) {
-    impl[op] = () => {
+    // Stub methods are async so the contract matches the real
+    // providers (github.mjs methods all return Promises). Without
+    // this, a caller doing `provider.pollForReview(ctx).catch(...)`
+    // would crash synchronously before getting a Promise back; the
+    // stub would not be substitutable for the real provider.
+    impl[op] = async () => {
       throw new NotSupportedError(
         `pr-iteration review op '${op}' is not implemented for tracker kind '${kind}' yet; see rules/pr-iteration.md fallback`,
         { kind, op },

--- a/scripts/lib/review/stub.mjs
+++ b/scripts/lib/review/stub.mjs
@@ -1,0 +1,26 @@
+// lib/review/stub.mjs
+// ReviewProvider implementation that declines every operation. Returned by
+// the dispatcher when `trackers.dev.kind` is a tracker for which the native
+// review-iteration loop has not been implemented yet (Jira, Linear, GitLab
+// as of v1). Every method throws `NotSupportedError` with a consistent
+// message that names the kind and the operation, so callers can catch and
+// surface a clean "not supported" message without type-sniffing.
+//
+// The stub is a single factory per kind so two `pickReviewProvider()`
+// calls with the same kind return interchangeable instances.
+
+import { NotSupportedError, REVIEW_PROVIDER_METHODS } from "./provider.mjs";
+
+/** @param {string} kind tracker kind (e.g. "jira", "linear") */
+export function makeStubProvider(kind) {
+  const impl = {};
+  for (const op of REVIEW_PROVIDER_METHODS) {
+    impl[op] = () => {
+      throw new NotSupportedError(
+        `pr-iteration review loop is not implemented for tracker kind '${kind}' yet; see rules/pr-iteration.md fallback`,
+        { kind, op },
+      );
+    };
+  }
+  return impl;
+}

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -73,10 +73,11 @@ Hard rule baked in: **the dev-loop never merges a PR and never sets a dev issue 
    request external reviewer (Copilot on GitHub) via GraphQL,
    poll for CI + review, triage threads, fix + push + resolve,
    iterate until all three exit conditions hold on current HEAD.
-   Skipped when workflow.external_review.enabled is false, or
-   when the ReviewProvider dispatcher returns the stub for this
-   tracker kind (Jira/Linear/GitLab today).
-   See rules/pr-iteration.md.
+   Skipped when workflow.external_review.enabled is false, when
+   workflow.external_review.provider is "none" (or the dispatcher
+   otherwise resolves to kind "none"), or when the ReviewProvider
+   dispatcher returns the stub for this tracker kind
+   (Jira/Linear/GitLab today). See rules/pr-iteration.md.
       |
       v
 ***  HUMAN GATE 1: merge PR  ***

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -69,8 +69,14 @@ Hard rule baked in: **the dev-loop never merges a PR and never sets a dev issue 
 [release-tracker: recompute linked umbrella status]
       |
       v
-[address review comments loop]
-   each push keeps the issue at In review
+[hand off to skills/pr-iteration]
+   request external reviewer (Copilot on GitHub) via GraphQL,
+   poll for CI + review, triage threads, fix + push + resolve,
+   iterate until all three exit conditions hold on current HEAD.
+   Skipped when workflow.external_review.enabled is false, or
+   when the ReviewProvider dispatcher returns the stub for this
+   tracker kind (Jira/Linear/GitLab today).
+   See rules/pr-iteration.md.
       |
       v
 ***  HUMAN GATE 1: merge PR  ***

--- a/skills/pr-iteration/SKILL.md
+++ b/skills/pr-iteration/SKILL.md
@@ -14,7 +14,7 @@ writes_to_filesystem: yes, code edits per round plus a per-round pr-iteration re
 
 # pr-iteration
 
-Before acting, read `.claude/ops.config.json` and `rules/pr-iteration.md`. Refuse to run if either is missing. This skill is the orchestration entry point; the rule is the contract; the runbook at `.development/shared/runbooks/pr-iteration-runbook.md` is the canonical how-to with GraphQL recipes.
+Before acting, read `.claude/ops.config.json` and `rules/pr-iteration.md`. Refuse to run if either is missing. This skill is the orchestration entry point; the rule is the contract; the runbook at `skills/pr-iteration/runbook.md` (co-located in the bundle) is the canonical how-to with GraphQL recipes.
 
 Hard rule baked in: **pr-iteration never merges a PR.** Merge is a human gate. Every code path ends at one of: (a) all three exit conditions hold and the skill reports + stops; (b) the poll timeout fires and the skill surfaces state + stops; (c) the provider declines with `NotSupportedError` and the skill halts cleanly at "In review".
 
@@ -65,15 +65,15 @@ The two human gates from `rules/pr-workflow.md` are preserved: merge and dev-iss
 
 The ReviewProvider is resolved via `scripts/lib/review/dispatcher.mjs` at the start of each round, so a mid-iteration change to `trackers.dev.kind` (rare, but possible under `adapt-system` migration) picks up the new kind cleanly. Providers:
 
-- **GitHub** (`scripts/lib/review/github.mjs`): full impl. Uses `gh api graphql` via `scripts/lib/ghExec.mjs`' `ghGraphqlQuery` / `ghGraphqlMutation` helpers. Caches the PR's GraphQL node ID and the Copilot bot node ID in the in-memory iteration state so they're captured once per PR rather than per round.
+- **GitHub** (`scripts/lib/review/github.mjs`): full impl. Uses `gh api graphql` via `scripts/lib/ghExec.mjs`' `ghGraphqlQuery` / `ghGraphqlMutation` helpers. The skill resolves reviewer LOGINS (from `workflow.external_review.bots.github`, e.g. `copilot-pull-request-reviewer`) into GraphQL node IDs via the recipe in `rules/pr-iteration.md`, caches both the PR's node ID and the bot node IDs in the in-memory iteration state, and passes the resolved node IDs to the provider as `ctx.botIds` on every call. The provider itself stays login-agnostic.
 - **Stub** (`scripts/lib/review/stub.mjs`): every op throws `NotSupportedError`. Returned for Jira, Linear, GitLab until PR 3's multi-tracker refactor wires real impls.
 
 ## Exit conditions (re-emphasised)
 
-All three must hold on the **current HEAD** (not an earlier one):
+All three must hold on the **current HEAD** (not an earlier one). These mirror `rules/pr-iteration.md` exactly; on drift the rule wins.
 
 1. `rules/review-loop.md` returns **GO** when re-run on HEAD.
-2. **Zero unresolved threads** on HEAD, AND at least one external review is on HEAD's SHA.
+2. **Zero unresolved threads** on HEAD, AND the **most recent** external review is on HEAD's SHA.
 3. CI `statusCheckRollup.state === "SUCCESS"` on HEAD's last commit.
 
 A review "on HEAD" with zero comments (the reviewer looked and found nothing) counts toward condition 2. The runbook's rationale section documents this.
@@ -126,4 +126,4 @@ Per-round artefact structure: see `templates/pr-iteration-report.md`. Minimum fi
 - `rules/pr-workflow.md`: full PR state machine in which this skill plugs after "In review".
 - `skills/dev-loop/SKILL.md`: hands off to this skill after opening the PR.
 - `scripts/lib/review/*.mjs`: the provider implementations.
-- `.development/shared/runbooks/pr-iteration-runbook.md`: canonical how-to with full GraphQL recipes.
+- `skills/pr-iteration/runbook.md`: canonical how-to with full GraphQL recipes.

--- a/skills/pr-iteration/SKILL.md
+++ b/skills/pr-iteration/SKILL.md
@@ -95,7 +95,7 @@ This skill writes into `.development/shared/reports/**` and MUST follow `rules/l
 - `trackers.dev.kind` (PR 3+) or legacy top-level `github:` block (pre-PR-3) to pick the ReviewProvider.
 - `workflow.external_review.enabled` (gate the whole loop).
 - `workflow.external_review.provider` (`auto` / `github` / `none`).
-- `workflow.external_review.bots` (per-kind reviewer identifiers; GitHub node IDs).
+- `workflow.external_review.bots` (per-kind reviewer LOGINS; for GitHub, the skill resolves login → GraphQL node ID at runtime and caches the derived IDs in the in-memory iteration state).
 - `workflow.external_review.poll_interval_seconds`.
 - `workflow.external_review.poll_timeout_seconds`.
 - `workflow.external_review.auto_resolve_stale_after_commits`.

--- a/skills/pr-iteration/SKILL.md
+++ b/skills/pr-iteration/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: pr-iteration
+description: Drives a PR from "just opened" to a green terminal state by requesting an external reviewer, polling for CI and review, triaging threads, fixing, resolving, and iterating until all three exit conditions hold. Never merges. The canonical PR lifecycle codification of the issue-development-automated-loop runbook.
+trigger_on:
+  - dev-loop hands off after opening a PR (and workflow.external_review.enabled is true).
+  - User explicitly runs /pr-iteration <pr-number> on an existing PR.
+do_not_trigger_on:
+  - workflow.external_review.enabled is false (dev-loop halts at In review instead).
+  - PRs on trackers where the ReviewProvider dispatcher returns the stub. Surface the `NotSupportedError` message and halt.
+  - Without a valid ops.config.json (halt and point at bootstrap-ops-config).
+writes_to_github: yes, via github-sync for status updates and via tracker-specific providers (GraphQL requestReviews / resolveReviewThread for GitHub) for review mutations
+writes_to_filesystem: yes, code edits per round plus a per-round pr-iteration report under paths.reports (written via @ctxr/skill-llm-wiki, per rules/llm-wiki.md)
+---
+
+# pr-iteration
+
+Before acting, read `.claude/ops.config.json` and `rules/pr-iteration.md`. Refuse to run if either is missing. This skill is the orchestration entry point; the rule is the contract; the runbook at `.development/shared/runbooks/pr-iteration-runbook.md` is the canonical how-to with GraphQL recipes.
+
+Hard rule baked in: **pr-iteration never merges a PR.** Merge is a human gate. Every code path ends at one of: (a) all three exit conditions hold and the skill reports + stops; (b) the poll timeout fires and the skill surfaces state + stops; (c) the provider declines with `NotSupportedError` and the skill halts cleanly at "In review".
+
+## Inputs
+
+- PR number on the tracker that owns dev issues (`trackers.dev.kind`).
+- Optional override of `workflow.external_review.*` fields for this invocation (rare).
+
+## Outputs
+
+- One commit per round on the feature branch, `fix(review-round-N): ...` with a per-thread bullet list.
+- External reviewer request on each round's new HEAD.
+- Resolved review threads for every addressed finding.
+- A `pr-iteration-report.md` artefact per round, written into `.development/shared/reports/` via `@ctxr/skill-llm-wiki` (per `rules/llm-wiki.md`).
+- A final "all exit conditions green" report to the human; the PR stays at "In review" awaiting merge.
+
+## State machine
+
+```text
+[dev-loop hands off; PR at "In review"]
+      |
+      v
+[assert local review GO on HEAD] -- NOT GO --> [fix + re-run local review]
+      |
+      v
+[push feature branch]
+      |
+      v
+[ReviewProvider.requestReview on HEAD]
+      |
+      v
+[poll every poll_interval_seconds]
+      |
+      +-- CI terminal AND (unresolved>0 OR reviewOnHead) --> [fetch threads, triage, fix + commit + push + resolve + re-request] --> back to poll
+      +-- poll_timeout_seconds exceeded --> [surface state, stop]
+      +-- provider.NotSupportedError --> [clean halt at In review]
+      |
+      v
+[all three exit conditions hold on current HEAD]
+      |
+      v
+[write final report; stop]          *** HUMAN GATE 1: merge PR ***
+```
+
+The two human gates from `rules/pr-workflow.md` are preserved: merge and dev-issue Done.
+
+## Provider dispatch
+
+The ReviewProvider is resolved via `scripts/lib/review/dispatcher.mjs` at the start of each round, so a mid-iteration change to `trackers.dev.kind` (rare, but possible under `adapt-system` migration) picks up the new kind cleanly. Providers:
+
+- **GitHub** (`scripts/lib/review/github.mjs`): full impl. Uses `gh api graphql` via `scripts/lib/ghExec.mjs`' `ghGraphqlQuery` / `ghGraphqlMutation` helpers. Caches the PR's GraphQL node ID and the Copilot bot node ID in the in-memory iteration state so they're captured once per PR rather than per round.
+- **Stub** (`scripts/lib/review/stub.mjs`): every op throws `NotSupportedError`. Returned for Jira, Linear, GitLab until PR 3's multi-tracker refactor wires real impls.
+
+## Exit conditions (re-emphasised)
+
+All three must hold on the **current HEAD** (not an earlier one):
+
+1. `rules/review-loop.md` returns **GO** when re-run on HEAD.
+2. **Zero unresolved threads** on HEAD, AND at least one external review is on HEAD's SHA.
+3. CI `statusCheckRollup.state === "SUCCESS"` on HEAD's last commit.
+
+A review "on HEAD" with zero comments (the reviewer looked and found nothing) counts toward condition 2. The runbook's rationale section documents this.
+
+## Thread triage heuristics
+
+Each round fetches threads, classifies every unresolved one as one of three buckets (detailed detection logic in the runbook):
+
+- **Stale** (re-emitted on a superseded SHA, or same `path:line` with no intervening code change): resolve without a code change. Auto-resolve after `workflow.external_review.auto_resolve_stale_after_commits` recurrences (default 1).
+- **Actionable**: fix in code. For behavioural issues (security, TOCTOU, exit code, parsing), add a regression test that locks the fix in. Run the affected test suite locally before pushing.
+- **Suggestion-only / style**: take the change or reply pushing back with reasoning.
+
+## Project contract
+
+This skill writes into `.development/shared/reports/**` and MUST follow `rules/llm-wiki.md`: every doc it persists under `.development/{shared,local,cache}/**` is placed through `@ctxr/skill-llm-wiki` (the agent reads the canonical `skill-llm-wiki` SKILL.md for format + placement, then writes direct into the target topic wiki).
+
+`ops.config.json` keys read:
+
+- `trackers.dev.kind` (PR 3+) or legacy top-level `github:` block (pre-PR-3) to pick the ReviewProvider.
+- `workflow.external_review.enabled` (gate the whole loop).
+- `workflow.external_review.provider` (`auto` / `github` / `none`).
+- `workflow.external_review.bots` (per-kind reviewer identifiers; GitHub node IDs).
+- `workflow.external_review.poll_interval_seconds`.
+- `workflow.external_review.poll_timeout_seconds`.
+- `workflow.external_review.auto_resolve_stale_after_commits`.
+- `workflow.code_review.*` (the pre-push local review, re-checked every round).
+- `paths.reports` (report artefact target, routed through the llm-wiki per rules/llm-wiki.md).
+
+## Reports
+
+Per-round artefact structure: see `templates/pr-iteration-report.md`. Minimum fields:
+
+- round number; previous HEAD; new HEAD
+- `requestReview` outcome (reviewer logins echoed back)
+- poll result (`ciState`, `unresolvedCount`, `reviewOnHead`, elapsed time)
+- threads resolved (id + one-line justification), threads flagged stale (id + fingerprint), threads deferred (id + reason)
+- commits in the round (sha + one-liner)
+- exit-condition status at end of round
+
+## Error surfaces
+
+- `NotSupportedError` from provider: clean halt. Message names the kind and the op.
+- `GhGraphqlError`: surface the error body (GitHub often returns useful error text) and retry once. Fail the round if it recurs.
+- Poll timeout: dump the last poll result, stop. Do not commit any changes.
+- Local review still NO-GO after a round of fixes: stop. The user decides whether to push back on the local reviewer or fix further.
+
+## Related
+
+- `rules/pr-iteration.md`: binding contract.
+- `rules/pr-workflow.md`: full PR state machine in which this skill plugs after "In review".
+- `skills/dev-loop/SKILL.md`: hands off to this skill after opening the PR.
+- `scripts/lib/review/*.mjs`: the provider implementations.
+- `.development/shared/runbooks/pr-iteration-runbook.md`: canonical how-to with full GraphQL recipes.

--- a/skills/pr-iteration/SKILL.md
+++ b/skills/pr-iteration/SKILL.md
@@ -6,7 +6,8 @@ trigger_on:
   - User explicitly runs /pr-iteration <pr-number> on an existing PR.
 do_not_trigger_on:
   - workflow.external_review.enabled is false (dev-loop halts at In review instead).
-  - PRs on trackers where the ReviewProvider dispatcher returns the stub. Surface the `NotSupportedError` message and halt.
+  - workflow.external_review.provider is "none", i.e. the dispatcher resolves kind to "none" as an explicit opt-out. Same effect as enabled:false; halt cleanly at In review, do NOT surface a NotSupportedError (which is reserved for unsupported tracker kinds).
+  - PRs on trackers where the ReviewProvider dispatcher returns the stub for a tracker kind that isn't "none" (Jira/Linear/GitLab today). Surface the `NotSupportedError` message and halt.
   - Without a valid ops.config.json (halt and point at bootstrap-ops-config).
 writes_to_github: yes, via github-sync for status updates and via tracker-specific providers (GraphQL requestReviews / resolveReviewThread for GitHub) for review mutations
 writes_to_filesystem: yes, code edits per round plus a per-round pr-iteration report under paths.reports (written via @ctxr/skill-llm-wiki, per rules/llm-wiki.md)

--- a/skills/pr-iteration/runbook.md
+++ b/skills/pr-iteration/runbook.md
@@ -1,4 +1,4 @@
-# PR lifecycle runbook :  local code-review + Copilot review loop
+# PR lifecycle runbook for the local code-review + Copilot review loop
 
 Reusable methodology for taking a change from first commit through PR, external Copilot review, fix-resolve iterations, and a green terminal state. Commands assume `gh` CLI authed.
 
@@ -105,7 +105,7 @@ gh api graphql -f query="
 "
 ```
 
-Verify the response shows `login: "copilot-pull-request-reviewer"` in the request list. If the response is `{pullRequest: null}` or `requestReviews: null`, the call failed :  check the error message.
+Verify the response shows `login: "copilot-pull-request-reviewer"` in the request list. If the response is `{pullRequest: null}` or `requestReviews: null`, the call failed; check the error message.
 
 **Common mistake:** `POST /repos/.../requested_reviewers` with `{"reviewers":["Copilot"]}` returns 200 OK but does nothing for bots. Always use the GraphQL mutation with `botIds`.
 
@@ -148,7 +148,7 @@ echo "ACTIVITY"
 Rationale for the exit condition:
 
 - **CI must complete first** (SUCCESS/FAILURE/ERROR). Silence on red CI is noise.
-- **Either unresolved threads OR review_on_sha** is the Copilot signal. A review on HEAD with zero comments means Copilot looked and found nothing :  still done.
+- **Either unresolved threads OR review_on_sha** is the Copilot signal. A review on HEAD with zero comments means Copilot looked and found nothing; still done.
 
 ---
 
@@ -188,7 +188,7 @@ Save the thread IDs (`PRRT_...`). You'll resolve them in step 8.
 
 ## 7. Triage + fix
 
-Expect comments to fall into three buckets :  name them in your commit message:
+Expect comments to fall into three buckets. Name them in your commit message:
 
 1. **Stale**: the reviewer re-emitted a comment on already-fixed code. Verify by reading the file; if fixed, mark for resolution in step 8 with no code change.
 2. **Net-new actionable**: real issue. Fix.
@@ -243,10 +243,10 @@ Then go back to step 5.
 Stop the loop when **all three** are true:
 
 1. **Local code-review says GO** on the current HEAD. (Re-run after the final Copilot round to catch regressions from fixes.)
-2. **`unresolved = 0`** on PR review threads, AND the **most recent Copilot review is on the current HEAD SHA**. (If the most recent review is on an older commit, wait :  Copilot may still be processing the latest push.)
+2. **`unresolved = 0`** on PR review threads, AND the **most recent Copilot review is on the current HEAD SHA**. (If the most recent review is on an older commit, wait; Copilot may still be processing the latest push.)
 3. **CI is SUCCESS on the current HEAD** across all required jobs.
 
-When all three hold, report the final state to the human and stop. The merge itself is a human gate :  never auto-merge.
+When all three hold, report the final state to the human and stop. The merge itself is a human gate; never auto-merge.
 
 ---
 

--- a/skills/pr-iteration/runbook.md
+++ b/skills/pr-iteration/runbook.md
@@ -174,9 +174,19 @@ d = json.load(sys.stdin)
 threads = d['data']['repository']['pullRequest']['reviewThreads']['nodes']
 for t in threads:
     if t['isResolved']: continue
-    c = t['comments']['nodes'][0]
-    print(f\"--- {t['id']}  {t['path']}:{t['line']}  on {c.get('commit',{}).get('oid','?')[:12] if c.get('commit') else '?'} ---\")
-    for line in c['body'].split('\n'):
+    # A thread's comments.nodes can be empty when the first comment has
+    # been deleted or hidden. Guard so the whole summary doesn't crash
+    # on one borderline thread; emit a placeholder instead.
+    comments = t['comments']['nodes']
+    if comments:
+        c = comments[0]
+        commit_oid = c.get('commit', {}).get('oid', '?')[:12] if c.get('commit') else '?'
+        body = c.get('body') or ''
+    else:
+        commit_oid = '?'
+        body = '[comment body unavailable]'
+    print(f\"--- {t['id']}  {t['path']}:{t['line']}  on {commit_oid} ---\")
+    for line in body.split('\n'):
         print(f'  {line}')
     print()
 "

--- a/skills/pr-iteration/runbook.md
+++ b/skills/pr-iteration/runbook.md
@@ -1,0 +1,282 @@
+# PR lifecycle runbook :  local code-review + Copilot review loop
+
+Reusable methodology for taking a change from first commit through PR, external Copilot review, fix-resolve iterations, and a green terminal state. Commands assume `gh` CLI authed.
+
+---
+
+## 0. Variables to set once per PR
+
+```bash
+OWNER=ctxr-dev                     # GitHub org/user
+REPO=skill-llm-wiki                # repo name
+PR_NUMBER=1                        # after you create the PR
+BRANCH=feat/my-change              # feature branch name
+```
+
+---
+
+## 1. Create the PR (once)
+
+```bash
+git checkout -b "$BRANCH"
+# ... commits ...
+git push -u origin "$BRANCH"
+
+gh pr create --repo "$OWNER/$REPO" --base main --head "$BRANCH" \
+  --title "short title" \
+  --body "$(cat <<'EOF'
+## Summary
+...
+## Test plan
+- [ ] ...
+EOF
+)"
+
+# Capture PR_NUMBER from the URL the command prints, then:
+PR_NUMBER=<number>
+```
+
+### Capture the two node IDs you'll reuse forever
+
+```bash
+# PR's GraphQL node ID:
+PR_NODE_ID=$(gh api graphql -f query="
+  { repository(owner:\"$OWNER\",name:\"$REPO\"){pullRequest(number:$PR_NUMBER){id}} }
+" --jq '.data.repository.pullRequest.id')
+
+# Copilot bot's node ID (stable per repo; get it from any prior Copilot review,
+# or from a PR where Copilot has already reviewed):
+COPILOT_BOT_ID=$(gh api graphql -f query="
+  { repository(owner:\"$OWNER\",name:\"$REPO\"){pullRequest(number:$PR_NUMBER){
+      reviews(last:10){nodes{author{... on Bot{id login}}}}
+  }}}
+" --jq '.data.repository.pullRequest.reviews.nodes[] | select(.author.login==\"copilot-pull-request-reviewer\") | .author.id' | head -1)
+
+echo "PR_NODE_ID=$PR_NODE_ID"
+echo "COPILOT_BOT_ID=$COPILOT_BOT_ID"
+```
+
+If Copilot hasn't reviewed yet, the bot ID is missing. Trigger an initial review (see step 4), then re-run the capture.
+
+---
+
+## 2. Local implementation
+
+Do the work normally: edits, tests, lint.
+
+```bash
+node --test tests/...            # unit
+npm run lint                     # markdown / code lint
+```
+
+Fix any failures before moving on.
+
+---
+
+## 3. Local multi-specialist code review
+
+Invoke `skill-code-review` (or your multi-reviewer skill) against the branch's diff vs main.
+
+- Expect a CONDITIONAL or NO-GO on first pass for any non-trivial change.
+- Fix every Critical and Important finding.
+- Minor findings: decide which to defer; write the rationale in the commit body.
+- Re-run the review after fixes. Repeat until verdict is **GO**.
+
+**Do not push until local review says GO.** You save Copilot round-trips this way.
+
+---
+
+## 4. Push + trigger Copilot review
+
+```bash
+git push origin "$BRANCH"
+
+# REST endpoint silently ignores bots — use GraphQL with botIds.
+gh api graphql -f query="
+  mutation {
+    requestReviews(input:{
+      pullRequestId: \"$PR_NODE_ID\"
+      botIds: [\"$COPILOT_BOT_ID\"]
+      union: true
+    }) {
+      pullRequest { reviewRequests(first:10) { nodes { requestedReviewer { ... on Bot { login } } } } }
+    }
+  }
+"
+```
+
+Verify the response shows `login: "copilot-pull-request-reviewer"` in the request list. If the response is `{pullRequest: null}` or `requestReviews: null`, the call failed :  check the error message.
+
+**Common mistake:** `POST /repos/.../requested_reviewers` with `{"reviewers":["Copilot"]}` returns 200 OK but does nothing for bots. Always use the GraphQL mutation with `botIds`.
+
+---
+
+## 5. Wait for CI + Copilot review
+
+The current HEAD SHA is `git rev-parse HEAD`. Run this in the background; it exits when CI is done AND Copilot has either posted a review on HEAD or left unresolved threads:
+
+```bash
+HEAD_SHA=$(git rev-parse HEAD)
+
+# Save as wait-for-review.sh and run in background (or use run_in_background):
+until result=$(gh api graphql -F owner="$OWNER" -F name="$REPO" -F number="$PR_NUMBER" -f query='
+  query($owner:String!,$name:String!,$number:Int!){
+    repository(owner:$owner,name:$name){
+      pullRequest(number:$number){
+        reviewThreads(first:100){nodes{isResolved}}
+        reviews(last:10){nodes{commit{oid}}}
+        commits(last:1){nodes{commit{oid statusCheckRollup{state}}}}
+      }
+    }
+  }
+' 2>/dev/null) && echo "$result" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+pr = d['data']['repository']['pullRequest']
+threads = pr['reviewThreads']['nodes']
+unresolved = sum(1 for t in threads if not t['isResolved'])
+sha = pr['commits']['nodes'][0]['commit']['oid']
+state = (pr['commits']['nodes'][0]['commit'].get('statusCheckRollup') or {}).get('state')
+review_on_sha = any(r.get('commit',{}) and r['commit']['oid']==sha for r in pr['reviews']['nodes'])
+ci_done = state in ('SUCCESS','FAILURE','ERROR')
+print(f'ci={state} unresolved={unresolved} review_on_head={review_on_sha}', file=sys.stderr)
+exit(0 if (ci_done and (unresolved>0 or review_on_sha)) else 1)
+"; do sleep 30; done
+echo "ACTIVITY"
+```
+
+Rationale for the exit condition:
+
+- **CI must complete first** (SUCCESS/FAILURE/ERROR). Silence on red CI is noise.
+- **Either unresolved threads OR review_on_sha** is the Copilot signal. A review on HEAD with zero comments means Copilot looked and found nothing :  still done.
+
+---
+
+## 6. Fetch all unresolved threads
+
+```bash
+gh api graphql -F owner="$OWNER" -F name="$REPO" -F number="$PR_NUMBER" -f query='
+  query($owner:String!,$name:String!,$number:Int!){
+    repository(owner:$owner,name:$name){
+      pullRequest(number:$number){
+        reviewThreads(first:100){
+          nodes{
+            id isResolved isOutdated path line
+            comments(first:5){nodes{author{login} body commit{oid} createdAt}}
+          }
+        }
+      }
+    }
+  }
+' | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+threads = d['data']['repository']['pullRequest']['reviewThreads']['nodes']
+for t in threads:
+    if t['isResolved']: continue
+    c = t['comments']['nodes'][0]
+    print(f\"--- {t['id']}  {t['path']}:{t['line']}  on {c.get('commit',{}).get('oid','?')[:12] if c.get('commit') else '?'} ---\")
+    for line in c['body'].split('\n'):
+        print(f'  {line}')
+    print()
+"
+```
+
+Save the thread IDs (`PRRT_...`). You'll resolve them in step 8.
+
+---
+
+## 7. Triage + fix
+
+Expect comments to fall into three buckets :  name them in your commit message:
+
+1. **Stale**: the reviewer re-emitted a comment on already-fixed code. Verify by reading the file; if fixed, mark for resolution in step 8 with no code change.
+2. **Net-new actionable**: real issue. Fix.
+3. **Suggestion-only / style**: take or push back with a reply.
+
+For each net-new fix:
+
+- Add a test that locks in the fix if the issue was behavioural (security, TOCTOU, exit code, parsing).
+- Run `node --test tests/affected.test.mjs` locally.
+- After all fixes in the round: `node --test --test-concurrency=1 tests/unit/*.test.mjs` serially + `npm run lint`.
+
+---
+
+## 8. Commit, push, resolve threads, re-request Copilot
+
+```bash
+git add -A
+git commit -m "fix(review-round-N): <short summary>
+
+<per-thread bullets: path:line — what changed>
+
+Addresses PR #$PR_NUMBER review threads on <previous-HEAD-sha>:
+<thread-id-1> (<topic>), <thread-id-2> (<topic>), ..."
+
+git push origin "$BRANCH"
+
+# Resolve each fixed thread:
+for tid in PRRT_id1 PRRT_id2 PRRT_id3; do
+  gh api graphql -F tid="$tid" -f query='
+    mutation($tid:ID!){resolveReviewThread(input:{threadId:$tid}){thread{isResolved}}}
+  '
+done
+
+# Re-request Copilot on the new HEAD:
+gh api graphql -f query="
+  mutation {
+    requestReviews(input:{
+      pullRequestId: \"$PR_NODE_ID\"
+      botIds: [\"$COPILOT_BOT_ID\"]
+      union: true
+    }) { pullRequest { reviewRequests(first:10) { nodes { requestedReviewer { ... on Bot { login } } } } } }
+  }
+"
+```
+
+Then go back to step 5.
+
+---
+
+## 9. Exit criteria
+
+Stop the loop when **all three** are true:
+
+1. **Local code-review says GO** on the current HEAD. (Re-run after the final Copilot round to catch regressions from fixes.)
+2. **`unresolved = 0`** on PR review threads, AND the **most recent Copilot review is on the current HEAD SHA**. (If the most recent review is on an older commit, wait :  Copilot may still be processing the latest push.)
+3. **CI is SUCCESS on the current HEAD** across all required jobs.
+
+When all three hold, report the final state to the human and stop. The merge itself is a human gate :  never auto-merge.
+
+---
+
+## 10. Common gotchas
+
+- **`requested_reviewers: ["Copilot"]` via REST silently no-ops.** Always use GraphQL `requestReviews` with `botIds`.
+- **Copilot re-emits already-fixed comments** on each review pass against fresh commit SHAs. ~30-50% of "unresolved" threads after the first iteration are stale. Verify against current code before changing anything.
+- **Windows CI + LF-only regex.** Any `^---\n` / `\nmode:` regex written on macOS breaks on Windows git checkouts (CRLF). Use `\r?\n` or split on `/\r?\n/`.
+- **macOS `/var/folders/...` symlink.** Any "walk up to /" security guard will false-positive on `/var → /private/var`. Anchor guards at the user-supplied base and stop there.
+- **Path separator in test assertions.** `assert.ok(stdout.includes(".claude/skills"))` fails on Windows (`\`). Use `path.join` for comparison.
+- **Background poll pattern.** Use `run_in_background: true` with an `until <check>; do sleep 30; done` wrapper. Sleep >270s hits the cache-miss boundary; >600s is blocked by the harness. Poll every 30s; 30 iterations → 15 minutes, enough for typical Copilot turnaround.
+- **Exit condition for the poll must be OR-wide, not AND-narrow.** `ci_done AND (unresolved>0 OR review_on_sha)` covers all three terminal states (Copilot found issues, Copilot found nothing, CI went red).
+- **Don't resolve threads before the fix is pushed.** If you resolve then discover the fix was wrong, the thread is gone; you have to leave a fresh comment or force-unresolve.
+
+---
+
+## 11. Minimal daily-use cheat sheet
+
+```bash
+# After a push:
+gh api graphql -f query="mutation{requestReviews(input:{pullRequestId:\"$PR_NODE_ID\" botIds:[\"$COPILOT_BOT_ID\"] union:true}){pullRequest{reviewRequests(first:1){nodes{requestedReviewer{... on Bot{login}}}}}}}"
+
+# Poll until activity:
+# (paste the until-loop from step 5)
+
+# Fetch unresolved:
+gh api graphql -F owner="$OWNER" -F name="$REPO" -F number="$PR_NUMBER" -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved path line comments(first:1){nodes{body}}}}}}}'
+
+# Resolve one:
+gh api graphql -F tid="PRRT_xxx" -f query='mutation($tid:ID!){resolveReviewThread(input:{threadId:$tid}){thread{isResolved}}}'
+```
+
+That's the whole protocol. Loop is: local-review GO → push → trigger Copilot → wait → fix+resolve → re-trigger → repeat until both reviews green and no unresolved threads remain.

--- a/skills/pr-iteration/runbook.md
+++ b/skills/pr-iteration/runbook.md
@@ -113,7 +113,9 @@ Verify the response shows `login: "copilot-pull-request-reviewer"` in the reques
 
 ## 5. Wait for CI + Copilot review
 
-The current HEAD SHA is `git rev-parse HEAD`. Run this in the background; it exits when CI is done AND Copilot has either posted a review on HEAD or left unresolved threads:
+The current HEAD SHA is `git rev-parse HEAD`. Run this in the background; it exits when CI is done AND Copilot has either posted a review on HEAD or left unresolved threads.
+
+> **Scope note.** This inline poll recipe is a one-off for operators and assumes the PR has <= 100 review threads (the `first: 100` window is not paged). On PRs larger than that the `unresolved` count can undercount and exit early. For production use, drive the loop through `skills/pr-iteration` which uses the paginated `pollForReview` impl in `scripts/lib/review/github.mjs`.
 
 ```bash
 HEAD_SHA=$(git rev-parse HEAD)
@@ -164,6 +166,8 @@ Rationale for the exit condition:
 ---
 
 ## 6. Fetch all unresolved threads
+
+> **Scope note.** Same caveat as the poll snippet above: `first: 100` is not paged here. On PRs with >100 threads this snippet misses the tail. Drive the real loop through `skills/pr-iteration`, whose `fetchUnresolvedThreads` impl pages through all threads with a hard 10-page cap.
 
 ```bash
 gh api graphql -F owner="$OWNER" -F name="$REPO" -F number="$PR_NUMBER" -f query='

--- a/skills/pr-iteration/runbook.md
+++ b/skills/pr-iteration/runbook.md
@@ -119,25 +119,36 @@ The current HEAD SHA is `git rev-parse HEAD`. Run this in the background; it exi
 HEAD_SHA=$(git rev-parse HEAD)
 
 # Save as wait-for-review.sh and run in background (or use run_in_background):
+#
+# The review_on_sha check MUST filter by the configured bot login, not
+# match any review on HEAD: a teammate reviewing before Copilot does
+# would otherwise trip the gate and exit the loop before Copilot's
+# verdict landed. Adjust BOT_LOGIN to match your configured external
+# reviewer if it's not Copilot.
 until result=$(gh api graphql -F owner="$OWNER" -F name="$REPO" -F number="$PR_NUMBER" -f query='
   query($owner:String!,$name:String!,$number:Int!){
     repository(owner:$owner,name:$name){
       pullRequest(number:$number){
         reviewThreads(first:100){nodes{isResolved}}
-        reviews(last:10){nodes{commit{oid}}}
+        reviews(last:10){nodes{commit{oid} author{__typename login}}}
         commits(last:1){nodes{commit{oid statusCheckRollup{state}}}}
       }
     }
   }
-' 2>/dev/null) && echo "$result" | python3 -c "
-import json, sys
+' 2>/dev/null) && echo "$result" | BOT_LOGIN="copilot-pull-request-reviewer" python3 -c "
+import json, os, sys
+bot = os.environ.get('BOT_LOGIN','copilot-pull-request-reviewer')
 d = json.load(sys.stdin)
 pr = d['data']['repository']['pullRequest']
 threads = pr['reviewThreads']['nodes']
 unresolved = sum(1 for t in threads if not t['isResolved'])
 sha = pr['commits']['nodes'][0]['commit']['oid']
 state = (pr['commits']['nodes'][0]['commit'].get('statusCheckRollup') or {}).get('state')
-review_on_sha = any(r.get('commit',{}) and r['commit']['oid']==sha for r in pr['reviews']['nodes'])
+review_on_sha = any(
+    (r.get('commit') or {}).get('oid') == sha
+    and (r.get('author') or {}).get('login') == bot
+    for r in pr['reviews']['nodes']
+)
 ci_done = state in ('SUCCESS','FAILURE','ERROR')
 print(f'ci={state} unresolved={unresolved} review_on_head={review_on_sha}', file=sys.stderr)
 exit(0 if (ci_done and (unresolved>0 or review_on_sha)) else 1)

--- a/templates/pr-iteration-report.md
+++ b/templates/pr-iteration-report.md
@@ -1,0 +1,92 @@
+<!--
+agent-staff-engineer template: pr-iteration-report.md
+purpose: Per-round artefact written by skills/pr-iteration every time the
+         PR iteration loop completes a round (request external review -> poll
+         -> fetch threads -> triage -> fix + push + resolve -> re-request).
+         One file per PR, appended in reverse-chronological order as new
+         rounds land, OR one file per round: the wiki's own SKILL.md (at
+         @ctxr/skill-llm-wiki) decides placement and stitching; this
+         template is the content shape.
+rendered by: skills/pr-iteration (via rules/llm-wiki.md; writes go through
+         @ctxr/skill-llm-wiki, not raw markdown into shared/)
+stored at: resolved under {{ workflow.code_review.report_dir }} (which
+         resolves under wiki.roots.shared/reports/ by default) per the
+         wiki skill's placement rules; DO NOT hard-code a path.
+ops.config keys read:
+  - project.name
+  - project.repo
+  - workflow.external_review.poll_interval_seconds
+  - workflow.external_review.poll_timeout_seconds
+  - workflow.external_review.auto_resolve_stale_after_commits
+  - trackers.dev.kind               (PR 3+; falls back to "github" pre-PR-3)
+scalar placeholders:
+  {{ date }}                        YYYY-MM-DD
+  {{ round_number }}                1-based integer
+  {{ pr_number }}                   PR/MR number on the tracker
+  {{ previous_head_sha }}           SHA HEAD was at when this round began
+  {{ new_head_sha }}                SHA HEAD is at after this round's commit
+  {{ tracker_kind }}                github | jira | linear | gitlab
+  {{ reviewer_logins }}             comma-separated logins from requestReview response
+  {{ ci_state }}                    SUCCESS | FAILURE | ERROR | PENDING
+  {{ unresolved_count }}            threads left unresolved at poll-exit
+  {{ review_on_head }}              true/false (was a review posted on new_head_sha?)
+  {{ round_elapsed_seconds }}       wall-clock seconds this round consumed
+  {{ exit_gate_local_go }}          true/false (rules/review-loop.md result on new_head_sha)
+  {{ exit_gate_zero_unresolved }}   true/false
+  {{ exit_gate_ci_success }}        true/false
+  {{ all_gates_hold }}              true/false (final exit condition)
+list placeholders:
+  {{ threads_resolved }}            [{id, path:line, bucket, justification}]
+  {{ threads_flagged_stale }}       [{id, path:line, fingerprint}]
+  {{ threads_deferred }}            [{id, path:line, reason}]
+  {{ commits_in_round }}            [{sha, title}]
+notes:
+  - Every bulleted list below MUST render with exactly the items the loop
+    produced; empty categories render as "(none)". Do not omit the heading.
+  - The "Exit conditions" table is the machine-readable hand-off; a human
+    (or another skill) scans this table to decide whether to merge.
+-->
+
+# pr-iteration report round {{ round_number }} for PR #{{ pr_number }}
+
+**Date:** {{ date }}  **Tracker:** {{ tracker_kind }}  **Project:** {{ project.name }} ({{ project.repo }})
+
+- Previous HEAD: `{{ previous_head_sha }}`
+- New HEAD: `{{ new_head_sha }}`
+- Reviewer(s) requested: {{ reviewer_logins }}
+- Round elapsed: {{ round_elapsed_seconds }}s
+
+## Poll result at round exit
+
+| CI state | Unresolved threads | Review on HEAD |
+|---|---|---|
+| {{ ci_state }} | {{ unresolved_count }} | {{ review_on_head }} |
+
+## Threads
+
+### Resolved
+
+{{ threads_resolved }}
+
+### Flagged stale (no code change; auto-resolve after `auto_resolve_stale_after_commits` recurrences)
+
+{{ threads_flagged_stale }}
+
+### Deferred (needs human decision)
+
+{{ threads_deferred }}
+
+## Commits in this round
+
+{{ commits_in_round }}
+
+## Exit conditions
+
+| Gate | Status |
+|---|---|
+| Local review GO on current HEAD (`rules/review-loop.md`) | {{ exit_gate_local_go }} |
+| Zero unresolved threads on HEAD + review on HEAD SHA | {{ exit_gate_zero_unresolved }} |
+| CI `SUCCESS` on HEAD | {{ exit_gate_ci_success }} |
+| **All three hold** | **{{ all_gates_hold }}** |
+
+When `all_gates_hold` is true, the loop stops. PR merge is a human gate; the agent never crosses it.

--- a/templates/pr-iteration-report.md
+++ b/templates/pr-iteration-report.md
@@ -9,9 +9,11 @@ purpose: Per-round artefact written by skills/pr-iteration every time the
          template is the content shape.
 rendered by: skills/pr-iteration (via rules/llm-wiki.md; writes go through
          @ctxr/skill-llm-wiki, not raw markdown into shared/)
-stored at: resolved under {{ workflow.code_review.report_dir }} (which
-         resolves under wiki.roots.shared/reports/ by default) per the
-         wiki skill's placement rules; DO NOT hard-code a path.
+stored at: resolved under {{ paths.reports }} (which resolves under
+         wiki.roots.shared/reports/ by default) per the wiki skill's
+         placement rules; DO NOT hard-code a path. Note: projects that
+         customise `workflow.code_review.report_dir` should ensure it
+         and `paths.reports` agree; the skill reads `paths.reports`.
 ops.config keys read:
   - project.name
   - project.repo

--- a/tests/review_dispatcher.test.mjs
+++ b/tests/review_dispatcher.test.mjs
@@ -1,0 +1,87 @@
+// review_dispatcher.test.mjs
+// Unit tests for the ReviewProvider dispatcher. Dispatches to the GitHub
+// impl when trackers.dev.kind is "github" (new shape) OR when the legacy
+// top-level `github:` block is present (transitional shim for PR 2 that
+// PR 3's multi-tracker refactor will remove). Every other kind returns
+// the stub.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  pickReviewProvider,
+  resolveTrackerKind,
+} from "../scripts/lib/review/dispatcher.mjs";
+import {
+  NotSupportedError,
+  REVIEW_PROVIDER_METHODS,
+} from "../scripts/lib/review/provider.mjs";
+
+describe("resolveTrackerKind", () => {
+  it("returns trackers.dev.kind when present (new shape)", () => {
+    assert.equal(resolveTrackerKind({ trackers: { dev: { kind: "github" } } }), "github");
+    assert.equal(resolveTrackerKind({ trackers: { dev: { kind: "Jira" } } }), "jira");
+  });
+  it("falls back to 'github' when only the legacy top-level github block is present", () => {
+    assert.equal(resolveTrackerKind({ github: { auth_login: "alice" } }), "github");
+  });
+  it("prefers the new shape over the legacy one when both exist", () => {
+    const cfg = {
+      trackers: { dev: { kind: "linear" } },
+      github: { auth_login: "alice" },
+    };
+    assert.equal(resolveTrackerKind(cfg), "linear");
+  });
+  it("returns 'unknown' when neither shape is present", () => {
+    assert.equal(resolveTrackerKind({}), "unknown");
+    assert.equal(resolveTrackerKind({ project: {} }), "unknown");
+    assert.equal(resolveTrackerKind(null), "unknown");
+  });
+  it("lowercases the kind so downstream comparisons are deterministic", () => {
+    assert.equal(resolveTrackerKind({ trackers: { dev: { kind: "GITHUB" } } }), "github");
+  });
+});
+
+describe("pickReviewProvider", () => {
+  it("returns the GitHub impl when kind === 'github'", () => {
+    const { provider, kind } = pickReviewProvider({ trackers: { dev: { kind: "github" } } });
+    assert.equal(kind, "github");
+    // github impl has all five methods wired
+    for (const op of REVIEW_PROVIDER_METHODS) {
+      assert.equal(typeof provider[op], "function", `github provider missing ${op}`);
+    }
+  });
+
+  it("returns a stub for jira (NotSupportedError on every op)", () => {
+    const { provider, kind } = pickReviewProvider({ trackers: { dev: { kind: "jira" } } });
+    assert.equal(kind, "jira");
+    assert.throws(() => provider.requestReview({}), (err) => {
+      return err instanceof NotSupportedError && err.kind === "jira";
+    });
+  });
+
+  it("returns a stub for linear and gitlab (PR 3 will swap these for real impls)", () => {
+    for (const k of ["linear", "gitlab"]) {
+      const { provider, kind } = pickReviewProvider({ trackers: { dev: { kind: k } } });
+      assert.equal(kind, k);
+      assert.throws(() => provider.pollForReview({}), NotSupportedError);
+    }
+  });
+
+  it("treats legacy github: config as kind=github (transitional shim)", () => {
+    const { provider, kind } = pickReviewProvider({ github: { auth_login: "alice" } });
+    assert.equal(kind, "github");
+    // The GitHub impl, not the stub; methods exist and do NOT throw
+    // NotSupportedError on mere presence. (Calling them without gh on
+    // PATH would throw a different error; here we just verify the
+    // dispatcher routed to the right module.)
+    assert.equal(typeof provider.requestReview, "function");
+  });
+
+  it("returns a stub with kind='unknown' when nothing is configured", () => {
+    const { provider, kind } = pickReviewProvider({});
+    assert.equal(kind, "unknown");
+    assert.throws(() => provider.ciStateOnHead({}), (err) => {
+      return err instanceof NotSupportedError && err.kind === "unknown";
+    });
+  });
+});

--- a/tests/review_dispatcher.test.mjs
+++ b/tests/review_dispatcher.test.mjs
@@ -109,19 +109,19 @@ describe("pickReviewProvider", () => {
     }
   });
 
-  it("returns a stub for jira (NotSupportedError on every op)", () => {
+  it("returns a stub for jira (NotSupportedError on every op)", async () => {
     const { provider, kind } = pickReviewProvider({ trackers: { dev: { kind: "jira" } } });
     assert.equal(kind, "jira");
-    assert.throws(() => provider.requestReview({}), (err) => {
+    await assert.rejects(() => provider.requestReview({}), (err) => {
       return err instanceof NotSupportedError && err.kind === "jira";
     });
   });
 
-  it("returns a stub for linear and gitlab (PR 3 will swap these for real impls)", () => {
+  it("returns a stub for linear and gitlab (PR 3 will swap these for real impls)", async () => {
     for (const k of ["linear", "gitlab"]) {
       const { provider, kind } = pickReviewProvider({ trackers: { dev: { kind: k } } });
       assert.equal(kind, k);
-      assert.throws(() => provider.pollForReview({}), NotSupportedError);
+      await assert.rejects(() => provider.pollForReview({}), NotSupportedError);
     }
   });
 
@@ -148,10 +148,10 @@ describe("pickReviewProvider", () => {
     }
   });
 
-  it("returns a stub with kind='unknown' when nothing is configured", () => {
+  it("returns a stub with kind='unknown' when nothing is configured", async () => {
     const { provider, kind } = pickReviewProvider({});
     assert.equal(kind, "unknown");
-    assert.throws(() => provider.ciStateOnHead({}), (err) => {
+    await assert.rejects(() => provider.ciStateOnHead({}), (err) => {
       return err instanceof NotSupportedError && err.kind === "unknown";
     });
   });

--- a/tests/review_dispatcher.test.mjs
+++ b/tests/review_dispatcher.test.mjs
@@ -9,6 +9,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   pickReviewProvider,
+  resolveReviewProviderKind,
   resolveTrackerKind,
 } from "../scripts/lib/review/dispatcher.mjs";
 import {
@@ -38,6 +39,63 @@ describe("resolveTrackerKind", () => {
   });
   it("lowercases the kind so downstream comparisons are deterministic", () => {
     assert.equal(resolveTrackerKind({ trackers: { dev: { kind: "GITHUB" } } }), "github");
+  });
+});
+
+describe("resolveReviewProviderKind: workflow.external_review.provider override", () => {
+  it("returns 'github' when override is 'github' regardless of tracker kind", () => {
+    // "Code lives on GitHub, tickets on Jira" scenario: tracker says
+    // jira, but the external reviewer runs on GitHub.
+    assert.equal(
+      resolveReviewProviderKind({
+        workflow: { external_review: { provider: "github" } },
+        trackers: { dev: { kind: "jira" } },
+      }),
+      "github",
+    );
+  });
+  it("returns 'none' when override is 'none', short-circuiting the whole loop", () => {
+    assert.equal(
+      resolveReviewProviderKind({
+        workflow: { external_review: { provider: "none" } },
+        trackers: { dev: { kind: "github" } },
+      }),
+      "none",
+    );
+  });
+  it("falls through to tracker inference when override is 'auto'", () => {
+    assert.equal(
+      resolveReviewProviderKind({
+        workflow: { external_review: { provider: "auto" } },
+        trackers: { dev: { kind: "linear" } },
+      }),
+      "linear",
+    );
+  });
+  it("treats unknown override strings as inference (forward-compat)", () => {
+    assert.equal(
+      resolveReviewProviderKind({
+        workflow: { external_review: { provider: "bitbucket" } },
+        trackers: { dev: { kind: "github" } },
+      }),
+      "github",
+    );
+  });
+  it("falls through to tracker inference when no override is set", () => {
+    assert.equal(
+      resolveReviewProviderKind({ trackers: { dev: { kind: "github" } } }),
+      "github",
+    );
+  });
+});
+
+describe("pickReviewProvider: honours the provider override", () => {
+  it("returns the stub (kind='none') when explicitly disabled, regardless of tracker", () => {
+    const { kind } = pickReviewProvider({
+      workflow: { external_review: { provider: "none" } },
+      trackers: { dev: { kind: "github" } },
+    });
+    assert.equal(kind, "none");
   });
 });
 

--- a/tests/review_dispatcher.test.mjs
+++ b/tests/review_dispatcher.test.mjs
@@ -67,15 +67,17 @@ describe("pickReviewProvider", () => {
     }
   });
 
-  it("treats legacy github: config as kind=github (transitional shim)", () => {
+  it("treats legacy github: config as kind=github (transitional shim)", async () => {
     const { provider, kind } = pickReviewProvider({ github: { auth_login: "alice" } });
     assert.equal(kind, "github");
     // Stronger assertion than `typeof === "function"`: calling
     // requestReview with a ctx the github impl checks eagerly (empty
     // botIds) must produce the GitHub provider's own error, NOT a
     // NotSupportedError. A mutant that silently routed to the stub
-    // would throw NotSupportedError instead.
-    assert.rejects(
+    // would throw NotSupportedError instead. Must be awaited so the
+    // rejection is actually observed (unawaited assert.rejects can
+    // silently pass).
+    await assert.rejects(
       () => provider.requestReview({ owner: "o", repo: "r", prNumber: 1, headSha: "x", prNodeId: "PR_", botIds: [] }),
       (err) => err.name !== "NotSupportedError" && /botIds is empty/.test(err.message),
     );

--- a/tests/review_dispatcher.test.mjs
+++ b/tests/review_dispatcher.test.mjs
@@ -70,11 +70,22 @@ describe("pickReviewProvider", () => {
   it("treats legacy github: config as kind=github (transitional shim)", () => {
     const { provider, kind } = pickReviewProvider({ github: { auth_login: "alice" } });
     assert.equal(kind, "github");
-    // The GitHub impl, not the stub; methods exist and do NOT throw
-    // NotSupportedError on mere presence. (Calling them without gh on
-    // PATH would throw a different error; here we just verify the
-    // dispatcher routed to the right module.)
-    assert.equal(typeof provider.requestReview, "function");
+    // Stronger assertion than `typeof === "function"`: calling
+    // requestReview with a ctx the github impl checks eagerly (empty
+    // botIds) must produce the GitHub provider's own error, NOT a
+    // NotSupportedError. A mutant that silently routed to the stub
+    // would throw NotSupportedError instead.
+    assert.rejects(
+      () => provider.requestReview({ owner: "o", repo: "r", prNumber: 1, headSha: "x", prNodeId: "PR_", botIds: [] }),
+      (err) => err.name !== "NotSupportedError" && /botIds is empty/.test(err.message),
+    );
+  });
+
+  it("rejects shape-invalid legacy github blocks (github: null/array/string/empty) as unknown", () => {
+    for (const bad of [null, [], "hello", {}, 42, true]) {
+      const { kind } = pickReviewProvider({ github: bad });
+      assert.equal(kind, "unknown", `github: ${JSON.stringify(bad)} should not satisfy the legacy shim`);
+    }
   });
 
   it("returns a stub with kind='unknown' when nothing is configured", () => {

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -3,8 +3,14 @@
 // on PATH (same pattern as ghExec.test.mjs) that both returns scripted
 // fixture JSON AND tees every argv + the query body into a log file, so
 // tests assert on the actual request the provider sent (not just that
-// gh was called at all). Skipped on Windows (the shim requires .cmd
-// scaffolding; real-gh path is exercised by the CI matrix).
+// gh was called at all).
+//
+// Skipped on Windows because the fake-gh shim here is a POSIX `#!/bin/sh`
+// script; Windows needs a .cmd/.bat wrapper or a shim install strategy
+// this file doesn't implement. `.github/workflows/ci.yml` currently runs
+// on ubuntu-latest only, so there is no Windows coverage for these tests
+// today. Adding a Windows CI job is a follow-up if the provider ever
+// grows Windows-specific semantics.
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
@@ -144,7 +150,7 @@ async function withFakeGh(fixture, fn) {
 }
 
 const skipOpts = IS_WIN
-  ? { skip: "windows path shim requires .cmd; covered in CI matrix" }
+  ? { skip: "windows path shim requires .cmd; no Windows CI job exists today" }
   : {};
 
 describe("github review provider: requestReview", skipOpts, () => {
@@ -351,11 +357,14 @@ describe("github review provider: fetchUnresolvedThreads", skipOpts, () => {
     assert.equal(byId.T1.line, 42);
     assert.equal(byId.T1.commitSha, "OLD_SHA");
     assert.equal(byId.T1.authorLogin, "copilot-pull-request-reviewer");
-    // T3 has no comments
+    assert.equal(byId.T1.isOutdated, false);
+    // T3: isOutdated=true in fixture; no comments
+    assert.equal(byId.T3.isOutdated, true);
     assert.equal(byId.T3.commitSha, null);
     assert.equal(byId.T3.authorLogin, null);
     assert.equal(byId.T3.body, "");
     // T4: present comment but null author, unicode body
+    assert.equal(byId.T4.isOutdated, false);
     assert.equal(byId.T4.authorLogin, null);
     assert.equal(byId.T4.commitSha, "SHA_U");
     assert.match(byId.T4.body, /unicode/);

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -1,0 +1,230 @@
+// review_github.test.mjs
+// Integration tests for the GitHub ReviewProvider impl. Uses the same
+// "fake gh on PATH" pattern as ghExec.test.mjs to avoid network and to
+// pin the exact response shape. Skipped on Windows (the shim requires
+// .cmd scaffolding; real-gh path is exercised by the CI matrix).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, chmod, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { makeGithubReviewProvider } from "../scripts/lib/review/github.mjs";
+import { GhGraphqlError } from "../scripts/lib/ghExec.mjs";
+
+const IS_WIN = process.platform === "win32";
+
+// A fake `gh` that writes fixture responses into stdout based on the
+// argv it receives. We cannot inspect argv in the Node test directly,
+// so the shim looks at `env.FAKE_GH_FIXTURE` (or `$1`) and echoes the
+// matching fixture. Tests set the env before each call.
+const FAKE_GH = `#!/bin/sh
+case "$FAKE_GH_FIXTURE" in
+  pr_node_id)
+    printf '%s' '{"data":{"repository":{"pullRequest":{"id":"PR_abc123"}}}}'
+    ;;
+  request_review_ok)
+    printf '%s' '{"data":{"requestReviews":{"pullRequest":{"reviewRequests":{"nodes":[{"requestedReviewer":{"login":"copilot-pull-request-reviewer"}}]}}}}}'
+    ;;
+  poll_all_green_review_on_head)
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"commit":{"oid":"HEAD_SHA"},"author":{"login":"copilot-pull-request-reviewer"}}]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
+    ;;
+  poll_pending)
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":null}}]}}}}}'
+    ;;
+  poll_unresolved_threads)
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false},{"isResolved":true},{"isResolved":false}]},"reviews":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"FAILURE"}}}]}}}}}'
+    ;;
+  fetch_threads_mixed)
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"T1","isResolved":false,"isOutdated":false,"path":"src/a.js","line":42,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"prefer const","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T2","isResolved":true,"isOutdated":false,"path":"src/b.js","line":10,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"resolved already","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T3","isResolved":false,"isOutdated":true,"path":"src/c.js","line":7,"comments":{"nodes":[]}}]}}}}}'
+    ;;
+  resolve_ok)
+    printf '%s' '{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}'
+    ;;
+  graphql_error)
+    printf '%s' '{"data":null,"errors":[{"message":"Field does not exist on type PullRequest"}]}'
+    ;;
+  *)
+    printf '%s' '{"data":null,"errors":[{"message":"fake gh unknown fixture"}]}'
+    exit 1
+    ;;
+esac
+`;
+
+async function installFakeGh() {
+  const scratch = await mkdtemp(join(tmpdir(), "fake-gh-review-"));
+  const scriptPath = join(scratch, "gh");
+  await writeFile(scriptPath, FAKE_GH, "utf8");
+  await chmod(scriptPath, 0o755);
+  return scratch;
+}
+
+async function withFakeGh(fixture, fn) {
+  const scratch = await installFakeGh();
+  const pathBefore = process.env.PATH;
+  const fixtureBefore = process.env.FAKE_GH_FIXTURE;
+  try {
+    process.env.PATH = scratch + ":" + pathBefore;
+    process.env.FAKE_GH_FIXTURE = fixture;
+    return await fn();
+  } finally {
+    process.env.PATH = pathBefore;
+    if (fixtureBefore === undefined) delete process.env.FAKE_GH_FIXTURE;
+    else process.env.FAKE_GH_FIXTURE = fixtureBefore;
+    await rm(scratch, { recursive: true, force: true });
+  }
+}
+
+const skipOpts = IS_WIN
+  ? { skip: "windows path shim requires .cmd; covered in CI matrix" }
+  : {};
+
+describe("github review provider: requestReview", skipOpts, () => {
+  it("succeeds when botIds are provided and gh returns a valid response", async () => {
+    await withFakeGh("request_review_ok", async () => {
+      const provider = makeGithubReviewProvider();
+      const data = await provider.requestReview({
+        owner: "ctxr-dev",
+        repo: "agent-staff-engineer",
+        prNumber: 1,
+        headSha: "abc",
+        prNodeId: "PR_abc123",
+        botIds: ["BOT_kgDOCnlnWA"],
+      });
+      const logins = data.requestReviews.pullRequest.reviewRequests.nodes.map(
+        (n) => n.requestedReviewer.login,
+      );
+      assert.deepEqual(logins, ["copilot-pull-request-reviewer"]);
+    });
+  });
+
+  it("refuses when botIds are empty", async () => {
+    const provider = makeGithubReviewProvider();
+    await assert.rejects(
+      () =>
+        provider.requestReview({
+          owner: "ctxr-dev",
+          repo: "agent-staff-engineer",
+          prNumber: 1,
+          headSha: "abc",
+          prNodeId: "PR_abc123",
+          botIds: [],
+        }),
+      /ctx\.botIds is empty/,
+    );
+  });
+});
+
+describe("github review provider: pollForReview", skipOpts, () => {
+  it("returns all-green state when review is on HEAD and CI is SUCCESS", async () => {
+    await withFakeGh("poll_all_green_review_on_head", async () => {
+      const provider = makeGithubReviewProvider();
+      const res = await provider.pollForReview({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "HEAD_SHA",
+      });
+      assert.equal(res.ciState, "SUCCESS");
+      assert.equal(res.unresolvedCount, 0);
+      assert.equal(res.reviewOnHead, true);
+    });
+  });
+
+  it("returns PENDING when statusCheckRollup is null", async () => {
+    await withFakeGh("poll_pending", async () => {
+      const provider = makeGithubReviewProvider();
+      const res = await provider.pollForReview({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "HEAD_SHA",
+      });
+      assert.equal(res.ciState, "PENDING");
+      assert.equal(res.unresolvedCount, 0);
+      assert.equal(res.reviewOnHead, false);
+    });
+  });
+
+  it("counts only unresolved threads and reports CI FAILURE", async () => {
+    await withFakeGh("poll_unresolved_threads", async () => {
+      const provider = makeGithubReviewProvider();
+      const res = await provider.pollForReview({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "HEAD_SHA",
+      });
+      assert.equal(res.ciState, "FAILURE");
+      assert.equal(res.unresolvedCount, 2); // two of three are unresolved
+      assert.equal(res.reviewOnHead, false);
+    });
+  });
+});
+
+describe("github review provider: fetchUnresolvedThreads", skipOpts, () => {
+  it("filters resolved threads and flattens the first comment", async () => {
+    await withFakeGh("fetch_threads_mixed", async () => {
+      const provider = makeGithubReviewProvider();
+      const threads = await provider.fetchUnresolvedThreads({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "HEAD_SHA",
+      });
+      assert.equal(threads.length, 2); // T2 is resolved, excluded
+      const ids = threads.map((t) => t.id).sort();
+      assert.deepEqual(ids, ["T1", "T3"]);
+      const t1 = threads.find((t) => t.id === "T1");
+      assert.equal(t1.path, "src/a.js");
+      assert.equal(t1.line, 42);
+      assert.equal(t1.commitSha, "OLD_SHA");
+      assert.equal(t1.authorLogin, "copilot-pull-request-reviewer");
+      assert.match(t1.body, /prefer const/);
+      // T3 has no comments; commitSha/authorLogin/body fall back safely
+      const t3 = threads.find((t) => t.id === "T3");
+      assert.equal(t3.commitSha, null);
+      assert.equal(t3.authorLogin, null);
+      assert.equal(t3.body, "");
+    });
+  });
+});
+
+describe("github review provider: resolveThread", skipOpts, () => {
+  it("invokes resolveReviewThread mutation with the threadId", async () => {
+    await withFakeGh("resolve_ok", async () => {
+      const provider = makeGithubReviewProvider();
+      const data = await provider.resolveThread({}, "PRRT_abc");
+      assert.equal(data.resolveReviewThread.thread.isResolved, true);
+    });
+  });
+
+  it("rejects an empty threadId without hitting gh", async () => {
+    const provider = makeGithubReviewProvider();
+    await assert.rejects(
+      () => provider.resolveThread({}, ""),
+      /threadId must be a non-empty string/,
+    );
+  });
+});
+
+describe("github review provider: GraphQL error surface", skipOpts, () => {
+  it("throws GhGraphqlError with the server-reported message", async () => {
+    await withFakeGh("graphql_error", async () => {
+      const provider = makeGithubReviewProvider();
+      try {
+        await provider.pollForReview({
+          owner: "o",
+          repo: "r",
+          prNumber: 1,
+          headSha: "HEAD_SHA",
+        });
+        assert.fail("expected GhGraphqlError");
+      } catch (err) {
+        assert.ok(err instanceof GhGraphqlError, `got ${err?.constructor?.name}`);
+        assert.match(err.message, /Field does not exist/);
+        assert.ok(Array.isArray(err.errors));
+      }
+    });
+  });
+});

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -508,12 +508,15 @@ describe("github review provider: resolveThread", skipOpts, () => {
     assert.match(log, /tid=PRRT_abc/, "threadId must be passed through to the mutation");
   });
 
-  it("rejects an empty threadId without hitting gh", async () => {
+  it("rejects an empty or whitespace-only threadId without hitting gh", async () => {
     const provider = makeGithubReviewProvider();
-    await assert.rejects(
-      () => provider.resolveThread({}, ""),
-      /threadId must be a non-empty string/,
-    );
+    for (const bad of ["", "   ", "\t\n", null, undefined, 42]) {
+      await assert.rejects(
+        () => provider.resolveThread({}, bad),
+        /threadId must be a non-empty string/,
+        `${JSON.stringify(bad)} should be rejected`,
+      );
+    }
   });
 });
 

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -152,11 +152,13 @@ async function withFakeGh(fixture, fn) {
   const fixBefore = process.env.FAKE_GH_FIXTURE;
   const logBefore = process.env.FAKE_GH_LOG;
   try {
-    // PATH may be unset on constrained test runners; use "" as the
-    // default so the shim directory is first on the search path and
-    // the restore logic below can distinguish "was unset" (delete)
-    // from "was set" (assign).
-    process.env.PATH = scratch + ":" + (pathBefore ?? "");
+    // PATH may be unset on constrained test runners. Use just the
+    // shim directory in that case so we don't introduce a trailing
+    // empty PATH entry (which on POSIX means "current directory" and
+    // breaks hermeticity). The restore logic below still distinguishes
+    // "was unset" (delete) from "was set" (assign).
+    process.env.PATH =
+      pathBefore === undefined ? scratch : scratch + ":" + pathBefore;
     process.env.FAKE_GH_FIXTURE = fixture;
     process.env.FAKE_GH_LOG = logPath;
     const result = await fn();

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -50,7 +50,7 @@ case "$FAKE_GH_FIXTURE" in
     printf '%s' '{"data":{"requestReviews":{"pullRequest":{"reviewRequests":{"nodes":[{"requestedReviewer":{"login":"copilot-pull-request-reviewer"}}]}}}}}'
     ;;
   poll_all_green_review_on_head)
-    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"commit":{"oid":"HEAD_SHA"},"author":{"login":"copilot-pull-request-reviewer"}}]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"commit":{"oid":"HEAD_SHA"},"author":{"__typename":"Bot","login":"copilot-pull-request-reviewer"}}]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
     ;;
   poll_pending)
     printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":null}}]}}}}}'
@@ -66,10 +66,30 @@ case "$FAKE_GH_FIXTURE" in
     # passed a stale ctx.headSha (STALE_SHA). pollForReview should still
     # report reviewOnHead=true because it uses the PR's fetched HEAD,
     # not ctx.headSha, as ground truth.
-    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"commit":{"oid":"FRESH_SHA"},"author":{"login":"copilot-pull-request-reviewer"}}]},"commits":{"nodes":[{"commit":{"oid":"FRESH_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"commit":{"oid":"FRESH_SHA"},"author":{"__typename":"Bot","login":"copilot-pull-request-reviewer"}}]},"commits":{"nodes":[{"commit":{"oid":"FRESH_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
+    ;;
+  poll_human_review_on_head_only)
+    # A teammate (User, not Bot) reviewed HEAD, but the external
+    # reviewer (Copilot) has not. reviewOnHead should be false so the
+    # iteration loop keeps polling for the external reviewer's verdict.
+    # Regression test for review-round-4 T14.
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"commit":{"oid":"HEAD_SHA"},"author":{"__typename":"User","login":"meshin-dev"}}]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
+    ;;
+  poll_bot_login_filter)
+    # Two bot reviews on HEAD: one is the configured bot
+    # (copilot-pull-request-reviewer), one is a different bot
+    # (other-bot). With ctx.botLogins=["copilot-pull-request-reviewer"],
+    # reviewOnHead must be true ONLY because of the matching login;
+    # an unrelated bot on HEAD must not satisfy the gate.
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"commit":{"oid":"HEAD_SHA"},"author":{"__typename":"Bot","login":"other-bot"}},{"commit":{"oid":"HEAD_SHA"},"author":{"__typename":"Bot","login":"copilot-pull-request-reviewer"}}]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
+    ;;
+  poll_bot_login_mismatch)
+    # Same shape as above but ONLY other-bot reviewed HEAD. With
+    # ctx.botLogins targeted at copilot, reviewOnHead must be false.
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"commit":{"oid":"HEAD_SHA"},"author":{"__typename":"Bot","login":"other-bot"}}]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
     ;;
   fetch_threads_mixed)
-    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"T1","isResolved":false,"isOutdated":false,"path":"src/a.js","line":42,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"prefer const","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T2","isResolved":true,"isOutdated":false,"path":"src/b.js","line":10,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"resolved already","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T3","isResolved":false,"isOutdated":true,"path":"src/c.js","line":7,"comments":{"nodes":[]}},{"id":"T4","isResolved":false,"isOutdated":false,"path":"src/u.js","line":1,"comments":{"nodes":[{"author":null,"body":"unicode: e accent and CJK chars","commit":{"oid":"SHA_U"},"createdAt":"2026-04-19T00:00:00Z"}]}}]}}}}}'
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"T1","isResolved":false,"isOutdated":false,"path":"src/a.js","line":42,"comments":{"nodes":[{"author":{"__typename":"Bot","login":"copilot-pull-request-reviewer"},"body":"prefer const","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T2","isResolved":true,"isOutdated":false,"path":"src/b.js","line":10,"comments":{"nodes":[{"author":{"__typename":"Bot","login":"copilot-pull-request-reviewer"},"body":"resolved already","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T3","isResolved":false,"isOutdated":true,"path":"src/c.js","line":7,"comments":{"nodes":[]}},{"id":"T4","isResolved":false,"isOutdated":false,"path":"src/u.js","line":1,"comments":{"nodes":[{"author":null,"body":"unicode: e accent and CJK chars","commit":{"oid":"SHA_U"},"createdAt":"2026-04-19T00:00:00Z"}]}}]}}}}}'
     ;;
   resolve_ok)
     printf '%s' '{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}'
@@ -234,6 +254,50 @@ describe("github review provider: pollForReview", skipOpts, () => {
     assert.equal(result.ciState, "FAILURE");
     assert.equal(result.unresolvedCount, 2);
     assert.equal(result.reviewOnHead, false);
+  });
+
+  it("reviewOnHead=false when only a human reviewed HEAD (external reviewer has not)", async () => {
+    // Regression test for review-round-4 T14: a teammate review on HEAD
+    // must NOT satisfy the external-reviewer gate, because the iteration
+    // loop is designed to wait for Copilot's verdict. A mutant that
+    // accepted any review would set reviewOnHead=true here and exit
+    // early.
+    const { result } = await withFakeGh("poll_human_review_on_head_only", () =>
+      makeGithubReviewProvider().pollForReview({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "HEAD_SHA",
+      }),
+    );
+    assert.equal(result.reviewOnHead, false, "human-only review on HEAD must not satisfy the gate");
+    assert.equal(result.ciState, "SUCCESS");
+  });
+
+  it("filters reviewOnHead by ctx.botLogins when provided (matching login wins)", async () => {
+    const { result } = await withFakeGh("poll_bot_login_filter", () =>
+      makeGithubReviewProvider().pollForReview({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "HEAD_SHA",
+        botLogins: ["copilot-pull-request-reviewer"],
+      }),
+    );
+    assert.equal(result.reviewOnHead, true, "matching bot login should satisfy the gate");
+  });
+
+  it("filters reviewOnHead by ctx.botLogins when provided (non-matching login rejected)", async () => {
+    const { result } = await withFakeGh("poll_bot_login_mismatch", () =>
+      makeGithubReviewProvider().pollForReview({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "HEAD_SHA",
+        botLogins: ["copilot-pull-request-reviewer"],
+      }),
+    );
+    assert.equal(result.reviewOnHead, false, "unrelated bot on HEAD must not satisfy the gate when botLogins are explicit");
   });
 
   it("uses the PR's fetched HEAD, not ctx.headSha, when classifying review-on-head", async () => {

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -48,6 +48,15 @@ const FAKE_GH = `#!/bin/sh
   done
   printf '\\n'
 } >> "$FAKE_GH_LOG"
+# Sequence mode: when FAKE_GH_SEQUENCE is set, pick the Nth fixture by
+# counting call-log lines. The counter persists across invocations of
+# the shim because the log file grows monotonically. Provider methods
+# that paginate make multiple gh calls per user-level invocation; this
+# lets a single withFakeGh() session script all of them in order.
+if [ -n "$FAKE_GH_SEQUENCE" ]; then
+  call_no=$(wc -l < "$FAKE_GH_LOG" | tr -d ' ')
+  FAKE_GH_FIXTURE=$(printf '%s' "$FAKE_GH_SEQUENCE" | awk -v n="$call_no" '{ k = split($0, arr, ","); if (n <= k) print arr[n] }')
+fi
 case "$FAKE_GH_FIXTURE" in
   pr_node_id)
     printf '%s' '{"data":{"repository":{"pullRequest":{"id":"PR_abc123"}}}}'
@@ -93,6 +102,16 @@ case "$FAKE_GH_FIXTURE" in
     # Same shape as above but ONLY other-bot reviewed HEAD. With
     # ctx.botLogins targeted at copilot, reviewOnHead must be false.
     printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"commit":{"oid":"HEAD_SHA"},"author":{"__typename":"Bot","login":"other-bot"}}]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
+    ;;
+  poll_all_resolved_page1_with_next)
+    # Page 1: all resolved. pageInfo says hasNextPage=true.
+    # pollForReview must call out to page 2 before declaring unresolvedCount=0.
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true},{"isResolved":true}],"pageInfo":{"hasNextPage":true,"endCursor":"CURSOR_PAGE1"}},"reviews":{"nodes":[{"commit":{"oid":"HEAD_SHA"},"author":{"__typename":"Bot","login":"copilot-pull-request-reviewer"}}]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
+    ;;
+  poll_page2_has_unresolved)
+    # Page 2 surfaces an unresolved. Paired with poll_all_resolved_page1_with_next
+    # via FAKE_GH_SEQUENCE. pollForReview's count helper short-circuits here.
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true},{"isResolved":false}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}'
     ;;
   fetch_threads_mixed)
     printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"T1","isResolved":false,"isOutdated":false,"path":"src/a.js","line":42,"comments":{"nodes":[{"author":{"__typename":"Bot","login":"copilot-pull-request-reviewer"},"body":"prefer const","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T2","isResolved":true,"isOutdated":false,"path":"src/b.js","line":10,"comments":{"nodes":[{"author":{"__typename":"Bot","login":"copilot-pull-request-reviewer"},"body":"resolved already","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T3","isResolved":false,"isOutdated":true,"path":"src/c.js","line":7,"comments":{"nodes":[]}},{"id":"T4","isResolved":false,"isOutdated":false,"path":"src/u.js","line":1,"comments":{"nodes":[{"author":null,"body":"unicode: e accent and CJK chars","commit":{"oid":"SHA_U"},"createdAt":"2026-04-19T00:00:00Z"}]}}]}}}}}'
@@ -151,6 +170,37 @@ async function withFakeGh(fixture, fn) {
     else process.env.PATH = pathBefore;
     if (fixBefore === undefined) delete process.env.FAKE_GH_FIXTURE;
     else process.env.FAKE_GH_FIXTURE = fixBefore;
+    if (logBefore === undefined) delete process.env.FAKE_GH_LOG;
+    else process.env.FAKE_GH_LOG = logBefore;
+    await rm(scratch, { recursive: true, force: true });
+  }
+}
+
+// Variant of withFakeGh that scripts a sequence of fixtures. The shim
+// picks the Nth fixture by counting prior calls in the log file. Use
+// when the method under test paginates (multiple gh calls per one
+// provider-method invocation).
+async function withFakeGhSequence(fixtures, fn) {
+  const { scratch, logPath } = await installFakeGh();
+  const pathBefore = process.env.PATH;
+  const fixBefore = process.env.FAKE_GH_FIXTURE;
+  const seqBefore = process.env.FAKE_GH_SEQUENCE;
+  const logBefore = process.env.FAKE_GH_LOG;
+  try {
+    process.env.PATH = scratch + ":" + (pathBefore ?? "");
+    process.env.FAKE_GH_FIXTURE = ""; // shim falls back to sequence
+    process.env.FAKE_GH_SEQUENCE = fixtures.join(",");
+    process.env.FAKE_GH_LOG = logPath;
+    const result = await fn();
+    const log = await readFile(logPath, "utf8");
+    return { result, log };
+  } finally {
+    if (pathBefore === undefined) delete process.env.PATH;
+    else process.env.PATH = pathBefore;
+    if (fixBefore === undefined) delete process.env.FAKE_GH_FIXTURE;
+    else process.env.FAKE_GH_FIXTURE = fixBefore;
+    if (seqBefore === undefined) delete process.env.FAKE_GH_SEQUENCE;
+    else process.env.FAKE_GH_SEQUENCE = seqBefore;
     if (logBefore === undefined) delete process.env.FAKE_GH_LOG;
     else process.env.FAKE_GH_LOG = logBefore;
     await rm(scratch, { recursive: true, force: true });
@@ -345,6 +395,31 @@ describe("github review provider: pollForReview", skipOpts, () => {
     );
     assert.equal(result.reviewOnHead, true, "should trust the PR's fetched HEAD, not stale ctx");
     assert.equal(result.ciState, "SUCCESS");
+  });
+
+  it("pages reviewThreads when page 1 is all-resolved but hasNextPage=true (unresolved surfaces on page 2)", async () => {
+    // Regression test for review-round-8 T29: without pagination, a
+    // PR with unresolved threads only past page 1 would report
+    // unresolvedCount=0 and trip the exit gate. The paged helper must
+    // detect page 2's unresolved entry.
+    const { result, log } = await withFakeGhSequence(
+      ["poll_all_resolved_page1_with_next", "poll_page2_has_unresolved"],
+      () =>
+        makeGithubReviewProvider().pollForReview({
+          owner: "o",
+          repo: "r",
+          prNumber: 1,
+          headSha: "HEAD_SHA",
+        }),
+    );
+    assert.equal(
+      result.unresolvedCount > 0,
+      true,
+      "unresolved on page 2 must surface; current impl counts >=1",
+    );
+    // Two gh calls: first page + continuation page.
+    const callCount = (log.match(/^ARGV:/gm) || []).length;
+    assert.equal(callCount, 2, `expected 2 gh calls (pagination); got ${callCount}`);
   });
 
   it("transmits owner/repo/number variables and the reviewThreads query", async () => {

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -1,12 +1,20 @@
 // review_github.test.mjs
-// Integration tests for the GitHub ReviewProvider impl. Uses the same
-// "fake gh on PATH" pattern as ghExec.test.mjs to avoid network and to
-// pin the exact response shape. Skipped on Windows (the shim requires
-// .cmd scaffolding; real-gh path is exercised by the CI matrix).
+// Integration tests for the GitHub ReviewProvider impl. Uses a fake `gh`
+// on PATH (same pattern as ghExec.test.mjs) that both returns scripted
+// fixture JSON AND tees every argv + the query body into a log file, so
+// tests assert on the actual request the provider sent (not just that
+// gh was called at all). Skipped on Windows (the shim requires .cmd
+// scaffolding; real-gh path is exercised by the CI matrix).
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, writeFile, chmod, rm } from "node:fs/promises";
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { makeGithubReviewProvider } from "../scripts/lib/review/github.mjs";
@@ -14,11 +22,19 @@ import { GhGraphqlError } from "../scripts/lib/ghExec.mjs";
 
 const IS_WIN = process.platform === "win32";
 
-// A fake `gh` that writes fixture responses into stdout based on the
-// argv it receives. We cannot inspect argv in the Node test directly,
-// so the shim looks at `env.FAKE_GH_FIXTURE` (or `$1`) and echoes the
-// matching fixture. Tests set the env before each call.
+// The fake gh tees its full argv + any -F/-f values it sees into
+// $FAKE_GH_LOG (one line per invocation), then dispatches on
+// $FAKE_GH_FIXTURE to emit scripted JSON. Tests read the log to verify
+// the provider built the right mutation/query and passed the right
+// variables. Without this, a provider mutant that dropped botIds or
+// hard-coded threadId would silently pass.
 const FAKE_GH = `#!/bin/sh
+# Tee the call for assertions. Keep each call on one line for easy grep.
+{
+  printf 'ARGV:'
+  for a in "$@"; do printf ' %s' "$a"; done
+  printf '\\n'
+} >> "$FAKE_GH_LOG"
 case "$FAKE_GH_FIXTURE" in
   pr_node_id)
     printf '%s' '{"data":{"repository":{"pullRequest":{"id":"PR_abc123"}}}}'
@@ -35,11 +51,17 @@ case "$FAKE_GH_FIXTURE" in
   poll_unresolved_threads)
     printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false},{"isResolved":true},{"isResolved":false}]},"reviews":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"FAILURE"}}}]}}}}}'
     ;;
+  poll_error)
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"ERROR"}}}]}}}}}'
+    ;;
   fetch_threads_mixed)
-    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"T1","isResolved":false,"isOutdated":false,"path":"src/a.js","line":42,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"prefer const","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T2","isResolved":true,"isOutdated":false,"path":"src/b.js","line":10,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"resolved already","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T3","isResolved":false,"isOutdated":true,"path":"src/c.js","line":7,"comments":{"nodes":[]}}]}}}}}'
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"T1","isResolved":false,"isOutdated":false,"path":"src/a.js","line":42,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"prefer const","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T2","isResolved":true,"isOutdated":false,"path":"src/b.js","line":10,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"resolved already","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T3","isResolved":false,"isOutdated":true,"path":"src/c.js","line":7,"comments":{"nodes":[]}},{"id":"T4","isResolved":false,"isOutdated":false,"path":"src/u.js","line":1,"comments":{"nodes":[{"author":null,"body":"unicode: e accent and CJK chars","commit":{"oid":"SHA_U"},"createdAt":"2026-04-19T00:00:00Z"}]}}]}}}}}'
     ;;
   resolve_ok)
     printf '%s' '{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}'
+    ;;
+  ci_state_success)
+    printf '%s' '{"data":{"repository":{"pullRequest":{"commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
     ;;
   graphql_error)
     printf '%s' '{"data":null,"errors":[{"message":"Field does not exist on type PullRequest"}]}'
@@ -54,23 +76,35 @@ esac
 async function installFakeGh() {
   const scratch = await mkdtemp(join(tmpdir(), "fake-gh-review-"));
   const scriptPath = join(scratch, "gh");
+  const logPath = join(scratch, "gh.log");
   await writeFile(scriptPath, FAKE_GH, "utf8");
+  await writeFile(logPath, "", "utf8");
   await chmod(scriptPath, 0o755);
-  return scratch;
+  return { scratch, logPath };
 }
 
+// Runs fn with a fresh fake-gh + log, returning the log contents so
+// callers can assert on the exact argv the provider sent. Saves and
+// restores process.env.PATH / FAKE_GH_FIXTURE / FAKE_GH_LOG even on
+// async rejection. Sequential use only; node --test defaults are fine.
 async function withFakeGh(fixture, fn) {
-  const scratch = await installFakeGh();
+  const { scratch, logPath } = await installFakeGh();
   const pathBefore = process.env.PATH;
-  const fixtureBefore = process.env.FAKE_GH_FIXTURE;
+  const fixBefore = process.env.FAKE_GH_FIXTURE;
+  const logBefore = process.env.FAKE_GH_LOG;
   try {
     process.env.PATH = scratch + ":" + pathBefore;
     process.env.FAKE_GH_FIXTURE = fixture;
-    return await fn();
+    process.env.FAKE_GH_LOG = logPath;
+    const result = await fn();
+    const log = await readFile(logPath, "utf8");
+    return { result, log };
   } finally {
     process.env.PATH = pathBefore;
-    if (fixtureBefore === undefined) delete process.env.FAKE_GH_FIXTURE;
-    else process.env.FAKE_GH_FIXTURE = fixtureBefore;
+    if (fixBefore === undefined) delete process.env.FAKE_GH_FIXTURE;
+    else process.env.FAKE_GH_FIXTURE = fixBefore;
+    if (logBefore === undefined) delete process.env.FAKE_GH_LOG;
+    else process.env.FAKE_GH_LOG = logBefore;
     await rm(scratch, { recursive: true, force: true });
   }
 }
@@ -80,31 +114,50 @@ const skipOpts = IS_WIN
   : {};
 
 describe("github review provider: requestReview", skipOpts, () => {
-  it("succeeds when botIds are provided and gh returns a valid response", async () => {
-    await withFakeGh("request_review_ok", async () => {
-      const provider = makeGithubReviewProvider();
-      const data = await provider.requestReview({
+  it("succeeds and actually transmits the resolved botIds into the mutation text", async () => {
+    const { result, log } = await withFakeGh("request_review_ok", () =>
+      makeGithubReviewProvider().requestReview({
         owner: "ctxr-dev",
         repo: "agent-staff-engineer",
         prNumber: 1,
         headSha: "abc",
         prNodeId: "PR_abc123",
         botIds: ["BOT_kgDOCnlnWA"],
-      });
-      const logins = data.requestReviews.pullRequest.reviewRequests.nodes.map(
-        (n) => n.requestedReviewer.login,
-      );
-      assert.deepEqual(logins, ["copilot-pull-request-reviewer"]);
-    });
+      }),
+    );
+    const logins = result.requestReviews.pullRequest.reviewRequests.nodes.map(
+      (n) => n.requestedReviewer.login,
+    );
+    assert.deepEqual(logins, ["copilot-pull-request-reviewer"]);
+    // Argv must show the query including botIds and the prId variable.
+    assert.match(log, /api graphql/);
+    assert.match(log, /requestReviews/, "mutation name should appear in argv");
+    assert.match(log, /"BOT_kgDOCnlnWA"/, "botIds must be inlined into the query");
+    assert.match(log, /prId=PR_abc123/, "prId must be passed via -F");
   });
 
-  it("refuses when botIds are empty", async () => {
+  it("passes every supplied botId through (would catch a silent drop)", async () => {
+    const { log } = await withFakeGh("request_review_ok", () =>
+      makeGithubReviewProvider().requestReview({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "abc",
+        prNodeId: "PR_xyz",
+        botIds: ["BOT_first", "BOT_second"],
+      }),
+    );
+    assert.match(log, /"BOT_first"/);
+    assert.match(log, /"BOT_second"/);
+  });
+
+  it("refuses when botIds are empty (pre-call guard, no gh invocation)", async () => {
     const provider = makeGithubReviewProvider();
     await assert.rejects(
       () =>
         provider.requestReview({
-          owner: "ctxr-dev",
-          repo: "agent-staff-engineer",
+          owner: "o",
+          repo: "r",
           prNumber: 1,
           headSha: "abc",
           prNodeId: "PR_abc123",
@@ -117,86 +170,112 @@ describe("github review provider: requestReview", skipOpts, () => {
 
 describe("github review provider: pollForReview", skipOpts, () => {
   it("returns all-green state when review is on HEAD and CI is SUCCESS", async () => {
-    await withFakeGh("poll_all_green_review_on_head", async () => {
-      const provider = makeGithubReviewProvider();
-      const res = await provider.pollForReview({
+    const { result } = await withFakeGh("poll_all_green_review_on_head", () =>
+      makeGithubReviewProvider().pollForReview({
         owner: "o",
         repo: "r",
         prNumber: 1,
         headSha: "HEAD_SHA",
-      });
-      assert.equal(res.ciState, "SUCCESS");
-      assert.equal(res.unresolvedCount, 0);
-      assert.equal(res.reviewOnHead, true);
-    });
+      }),
+    );
+    assert.equal(result.ciState, "SUCCESS");
+    assert.equal(result.unresolvedCount, 0);
+    assert.equal(result.reviewOnHead, true);
   });
 
   it("returns PENDING when statusCheckRollup is null", async () => {
-    await withFakeGh("poll_pending", async () => {
-      const provider = makeGithubReviewProvider();
-      const res = await provider.pollForReview({
+    const { result } = await withFakeGh("poll_pending", () =>
+      makeGithubReviewProvider().pollForReview({
         owner: "o",
         repo: "r",
         prNumber: 1,
         headSha: "HEAD_SHA",
-      });
-      assert.equal(res.ciState, "PENDING");
-      assert.equal(res.unresolvedCount, 0);
-      assert.equal(res.reviewOnHead, false);
-    });
+      }),
+    );
+    assert.equal(result.ciState, "PENDING");
+    assert.equal(result.reviewOnHead, false);
+  });
+
+  it("returns ERROR when statusCheckRollup.state is ERROR", async () => {
+    const { result } = await withFakeGh("poll_error", () =>
+      makeGithubReviewProvider().pollForReview({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "HEAD_SHA",
+      }),
+    );
+    assert.equal(result.ciState, "ERROR");
   });
 
   it("counts only unresolved threads and reports CI FAILURE", async () => {
-    await withFakeGh("poll_unresolved_threads", async () => {
-      const provider = makeGithubReviewProvider();
-      const res = await provider.pollForReview({
+    const { result } = await withFakeGh("poll_unresolved_threads", () =>
+      makeGithubReviewProvider().pollForReview({
         owner: "o",
         repo: "r",
         prNumber: 1,
         headSha: "HEAD_SHA",
-      });
-      assert.equal(res.ciState, "FAILURE");
-      assert.equal(res.unresolvedCount, 2); // two of three are unresolved
-      assert.equal(res.reviewOnHead, false);
-    });
+      }),
+    );
+    assert.equal(result.ciState, "FAILURE");
+    assert.equal(result.unresolvedCount, 2);
+    assert.equal(result.reviewOnHead, false);
+  });
+
+  it("transmits owner/repo/number variables and the reviewThreads query", async () => {
+    const { log } = await withFakeGh("poll_all_green_review_on_head", () =>
+      makeGithubReviewProvider().pollForReview({
+        owner: "ctxr-dev",
+        repo: "agent-staff-engineer",
+        prNumber: 42,
+        headSha: "HEAD_SHA",
+      }),
+    );
+    assert.match(log, /reviewThreads/);
+    assert.match(log, /statusCheckRollup/);
+    assert.match(log, /owner=ctxr-dev/);
+    assert.match(log, /name=agent-staff-engineer/);
+    assert.match(log, /number=42/);
   });
 });
 
 describe("github review provider: fetchUnresolvedThreads", skipOpts, () => {
-  it("filters resolved threads and flattens the first comment", async () => {
-    await withFakeGh("fetch_threads_mixed", async () => {
-      const provider = makeGithubReviewProvider();
-      const threads = await provider.fetchUnresolvedThreads({
+  it("filters resolved threads, flattens the first comment, tolerates null author + unicode body", async () => {
+    const { result } = await withFakeGh("fetch_threads_mixed", () =>
+      makeGithubReviewProvider().fetchUnresolvedThreads({
         owner: "o",
         repo: "r",
         prNumber: 1,
         headSha: "HEAD_SHA",
-      });
-      assert.equal(threads.length, 2); // T2 is resolved, excluded
-      const ids = threads.map((t) => t.id).sort();
-      assert.deepEqual(ids, ["T1", "T3"]);
-      const t1 = threads.find((t) => t.id === "T1");
-      assert.equal(t1.path, "src/a.js");
-      assert.equal(t1.line, 42);
-      assert.equal(t1.commitSha, "OLD_SHA");
-      assert.equal(t1.authorLogin, "copilot-pull-request-reviewer");
-      assert.match(t1.body, /prefer const/);
-      // T3 has no comments; commitSha/authorLogin/body fall back safely
-      const t3 = threads.find((t) => t.id === "T3");
-      assert.equal(t3.commitSha, null);
-      assert.equal(t3.authorLogin, null);
-      assert.equal(t3.body, "");
-    });
+      }),
+    );
+    assert.equal(result.length, 3); // T2 is resolved, excluded
+    const byId = Object.fromEntries(result.map((t) => [t.id, t]));
+    assert.ok(byId.T1 && byId.T3 && byId.T4);
+    assert.equal(byId.T1.path, "src/a.js");
+    assert.equal(byId.T1.line, 42);
+    assert.equal(byId.T1.commitSha, "OLD_SHA");
+    assert.equal(byId.T1.authorLogin, "copilot-pull-request-reviewer");
+    // T3 has no comments
+    assert.equal(byId.T3.commitSha, null);
+    assert.equal(byId.T3.authorLogin, null);
+    assert.equal(byId.T3.body, "");
+    // T4: present comment but null author, unicode body
+    assert.equal(byId.T4.authorLogin, null);
+    assert.equal(byId.T4.commitSha, "SHA_U");
+    assert.match(byId.T4.body, /unicode/);
+    assert.match(byId.T4.body, /CJK/);
   });
 });
 
 describe("github review provider: resolveThread", skipOpts, () => {
-  it("invokes resolveReviewThread mutation with the threadId", async () => {
-    await withFakeGh("resolve_ok", async () => {
-      const provider = makeGithubReviewProvider();
-      const data = await provider.resolveThread({}, "PRRT_abc");
-      assert.equal(data.resolveReviewThread.thread.isResolved, true);
-    });
+  it("actually passes the threadId to the mutation (argv check)", async () => {
+    const { result, log } = await withFakeGh("resolve_ok", () =>
+      makeGithubReviewProvider().resolveThread({}, "PRRT_abc"),
+    );
+    assert.equal(result.resolveReviewThread.thread.isResolved, true);
+    assert.match(log, /resolveReviewThread/);
+    assert.match(log, /tid=PRRT_abc/, "threadId must be passed through to the mutation");
   });
 
   it("rejects an empty threadId without hitting gh", async () => {
@@ -208,23 +287,40 @@ describe("github review provider: resolveThread", skipOpts, () => {
   });
 });
 
+describe("github review provider: ciStateOnHead (narrow query)", skipOpts, () => {
+  it("fetches only the HEAD commit statusCheckRollup, not the full poll payload", async () => {
+    const { result, log } = await withFakeGh("ci_state_success", () =>
+      makeGithubReviewProvider().ciStateOnHead({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "HEAD_SHA",
+      }),
+    );
+    assert.equal(result, "SUCCESS");
+    assert.match(log, /statusCheckRollup/);
+    // Narrow query does NOT ask for reviewThreads or reviews.
+    assert.doesNotMatch(log, /reviewThreads/);
+    assert.doesNotMatch(log, /reviews\(last/);
+  });
+});
+
 describe("github review provider: GraphQL error surface", skipOpts, () => {
   it("throws GhGraphqlError with the server-reported message", async () => {
-    await withFakeGh("graphql_error", async () => {
-      const provider = makeGithubReviewProvider();
-      try {
-        await provider.pollForReview({
+    try {
+      await withFakeGh("graphql_error", () =>
+        makeGithubReviewProvider().pollForReview({
           owner: "o",
           repo: "r",
           prNumber: 1,
           headSha: "HEAD_SHA",
-        });
-        assert.fail("expected GhGraphqlError");
-      } catch (err) {
-        assert.ok(err instanceof GhGraphqlError, `got ${err?.constructor?.name}`);
-        assert.match(err.message, /Field does not exist/);
-        assert.ok(Array.isArray(err.errors));
-      }
-    });
+        }),
+      );
+      assert.fail("expected GhGraphqlError");
+    } catch (err) {
+      assert.ok(err instanceof GhGraphqlError, `got ${err?.constructor?.name}`);
+      assert.match(err.message, /Field does not exist/);
+      assert.ok(Array.isArray(err.errors));
+    }
   });
 });

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -29,10 +29,17 @@ const IS_WIN = process.platform === "win32";
 // variables. Without this, a provider mutant that dropped botIds or
 // hard-coded threadId would silently pass.
 const FAKE_GH = `#!/bin/sh
-# Tee the call for assertions. Keep each call on one line for easy grep.
+# Tee the call for assertions. Keep each call on one line for easy
+# grepping: argv values (especially GraphQL query text) carry embedded
+# newlines, so collapse \\r and \\n to spaces before writing. Without
+# this, the "one line per invocation" contract breaks and grep-based
+# assertions may match text from other calls.
 {
   printf 'ARGV:'
-  for a in "$@"; do printf ' %s' "$a"; done
+  for a in "$@"; do
+    sanitized=$(printf '%s' "$a" | tr '\\r\\n' '  ')
+    printf ' %s' "$sanitized"
+  done
   printf '\\n'
 } >> "$FAKE_GH_LOG"
 case "$FAKE_GH_FIXTURE" in

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -61,6 +61,13 @@ case "$FAKE_GH_FIXTURE" in
   poll_error)
     printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"HEAD_SHA","statusCheckRollup":{"state":"ERROR"}}}]}}}}}'
     ;;
+  poll_stale_ctx_head)
+    # Review posted on the PR's CURRENT HEAD (FRESH_SHA), but the caller
+    # passed a stale ctx.headSha (STALE_SHA). pollForReview should still
+    # report reviewOnHead=true because it uses the PR's fetched HEAD,
+    # not ctx.headSha, as ground truth.
+    printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"commit":{"oid":"FRESH_SHA"},"author":{"login":"copilot-pull-request-reviewer"}}]},"commits":{"nodes":[{"commit":{"oid":"FRESH_SHA","statusCheckRollup":{"state":"SUCCESS"}}}]}}}}}'
+    ;;
   fetch_threads_mixed)
     printf '%s' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"T1","isResolved":false,"isOutdated":false,"path":"src/a.js","line":42,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"prefer const","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T2","isResolved":true,"isOutdated":false,"path":"src/b.js","line":10,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"resolved already","commit":{"oid":"OLD_SHA"},"createdAt":"2026-04-19T00:00:00Z"}]}},{"id":"T3","isResolved":false,"isOutdated":true,"path":"src/c.js","line":7,"comments":{"nodes":[]}},{"id":"T4","isResolved":false,"isOutdated":false,"path":"src/u.js","line":1,"comments":{"nodes":[{"author":null,"body":"unicode: e accent and CJK chars","commit":{"oid":"SHA_U"},"createdAt":"2026-04-19T00:00:00Z"}]}}]}}}}}'
     ;;
@@ -227,6 +234,23 @@ describe("github review provider: pollForReview", skipOpts, () => {
     assert.equal(result.ciState, "FAILURE");
     assert.equal(result.unresolvedCount, 2);
     assert.equal(result.reviewOnHead, false);
+  });
+
+  it("uses the PR's fetched HEAD, not ctx.headSha, when classifying review-on-head", async () => {
+    // Regression test for review-round-3 T10: caller passed a stale
+    // ctx.headSha. The review is on the PR's current HEAD. Without the
+    // fix, reviewOnHead would wrongly be false because comparison used
+    // the stale ctx value.
+    const { result } = await withFakeGh("poll_stale_ctx_head", () =>
+      makeGithubReviewProvider().pollForReview({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "STALE_SHA",
+      }),
+    );
+    assert.equal(result.reviewOnHead, true, "should trust the PR's fetched HEAD, not stale ctx");
+    assert.equal(result.ciState, "SUCCESS");
   });
 
   it("transmits owner/repo/number variables and the reviewThreads query", async () => {

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -189,7 +189,10 @@ async function withFakeGhSequence(fixtures, fn) {
   const seqBefore = process.env.FAKE_GH_SEQUENCE;
   const logBefore = process.env.FAKE_GH_LOG;
   try {
-    process.env.PATH = scratch + ":" + (pathBefore ?? "");
+    // Same hermeticity rule as withFakeGh: shim-dir-only when PATH
+    // was unset, to avoid the trailing-`:` empty entry on POSIX.
+    process.env.PATH =
+      pathBefore === undefined ? scratch : scratch + ":" + pathBefore;
     process.env.FAKE_GH_FIXTURE = ""; // shim falls back to sequence
     process.env.FAKE_GH_SEQUENCE = fixtures.join(",");
     process.env.FAKE_GH_LOG = logPath;
@@ -265,6 +268,28 @@ describe("github review provider: requestReview", skipOpts, () => {
         }),
       /ctx\.botIds is empty/,
     );
+  });
+
+  it("rejects non-string or empty-string botId elements with a pointed TypeError", async () => {
+    const provider = makeGithubReviewProvider();
+    for (const bad of [null, undefined, 42, true, "", "   "]) {
+      await assert.rejects(
+        () =>
+          provider.requestReview({
+            owner: "o",
+            repo: "r",
+            prNumber: 1,
+            headSha: "abc",
+            prNodeId: "PR_abc123",
+            botIds: ["BOT_good", bad],
+          }),
+        (err) =>
+          err instanceof TypeError &&
+          /ctx\.botIds\[1\]/.test(err.message) &&
+          /non-empty string GraphQL node ID/.test(err.message),
+        `botIds[${JSON.stringify(bad)}] should throw a pointed TypeError`,
+      );
+    }
   });
 });
 

--- a/tests/review_github.test.mjs
+++ b/tests/review_github.test.mjs
@@ -133,14 +133,22 @@ async function withFakeGh(fixture, fn) {
   const fixBefore = process.env.FAKE_GH_FIXTURE;
   const logBefore = process.env.FAKE_GH_LOG;
   try {
-    process.env.PATH = scratch + ":" + pathBefore;
+    // PATH may be unset on constrained test runners; use "" as the
+    // default so the shim directory is first on the search path and
+    // the restore logic below can distinguish "was unset" (delete)
+    // from "was set" (assign).
+    process.env.PATH = scratch + ":" + (pathBefore ?? "");
     process.env.FAKE_GH_FIXTURE = fixture;
     process.env.FAKE_GH_LOG = logPath;
     const result = await fn();
     const log = await readFile(logPath, "utf8");
     return { result, log };
   } finally {
-    process.env.PATH = pathBefore;
+    // Restoring via `process.env.PATH = undefined` would set the
+    // literal string "undefined" and pollute subsequent tests.
+    // Same pattern for the other two env vars.
+    if (pathBefore === undefined) delete process.env.PATH;
+    else process.env.PATH = pathBefore;
     if (fixBefore === undefined) delete process.env.FAKE_GH_FIXTURE;
     else process.env.FAKE_GH_FIXTURE = fixBefore;
     if (logBefore === undefined) delete process.env.FAKE_GH_LOG;
@@ -291,6 +299,22 @@ describe("github review provider: pollForReview", skipOpts, () => {
       }),
     );
     assert.equal(result.reviewOnHead, true, "matching bot login should satisfy the gate");
+  });
+
+  it("ctx.botLogins filter is case-insensitive (GitHub logins are)", async () => {
+    // poll_bot_login_filter fixture has author login
+    // "copilot-pull-request-reviewer" (lowercase). Config may carry
+    // mixed casing; ensure the filter treats them equal.
+    const { result } = await withFakeGh("poll_bot_login_filter", () =>
+      makeGithubReviewProvider().pollForReview({
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+        headSha: "HEAD_SHA",
+        botLogins: ["Copilot-Pull-Request-Reviewer"],
+      }),
+    );
+    assert.equal(result.reviewOnHead, true, "casing difference must not break the match");
   });
 
   it("filters reviewOnHead by ctx.botLogins when provided (non-matching login rejected)", async () => {

--- a/tests/review_stub.test.mjs
+++ b/tests/review_stub.test.mjs
@@ -1,0 +1,59 @@
+// review_stub.test.mjs
+// Unit tests for the ReviewProvider stub. Every method must throw
+// NotSupportedError with a consistent shape (.kind, .op, message includes
+// kind and names the unsupported op, caller can catch by instanceof).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  NotSupportedError,
+  REVIEW_PROVIDER_METHODS,
+} from "../scripts/lib/review/provider.mjs";
+import { makeStubProvider } from "../scripts/lib/review/stub.mjs";
+
+describe("review/stub: every method throws NotSupportedError", () => {
+  for (const op of REVIEW_PROVIDER_METHODS) {
+    it(`${op} throws with kind + op populated`, () => {
+      const provider = makeStubProvider("jira");
+      assert.equal(typeof provider[op], "function");
+      try {
+        provider[op]({}, "arg1", "arg2");
+        assert.fail(`${op} should have thrown`);
+      } catch (err) {
+        assert.ok(err instanceof NotSupportedError, `expected NotSupportedError, got ${err.constructor.name}`);
+        assert.equal(err.kind, "jira");
+        assert.equal(err.op, op);
+        assert.match(err.message, /pr-iteration review loop is not implemented/);
+        assert.match(err.message, /jira/);
+      }
+    });
+  }
+});
+
+describe("review/stub: kind flows through to the error", () => {
+  it("preserves arbitrary kinds (linear, gitlab, anything)", () => {
+    for (const kind of ["linear", "gitlab", "unknown"]) {
+      const provider = makeStubProvider(kind);
+      try {
+        provider.requestReview({});
+        assert.fail("should throw");
+      } catch (err) {
+        assert.equal(err.kind, kind);
+        assert.match(err.message, new RegExp(`'${kind}'`));
+      }
+    }
+  });
+});
+
+describe("review/stub: coverage vs REVIEW_PROVIDER_METHODS", () => {
+  it("exposes a function for every method name in the canonical list", () => {
+    const provider = makeStubProvider("jira");
+    for (const op of REVIEW_PROVIDER_METHODS) {
+      assert.equal(
+        typeof provider[op],
+        "function",
+        `stub missing method '${op}' declared in REVIEW_PROVIDER_METHODS`,
+      );
+    }
+  });
+});

--- a/tests/review_stub.test.mjs
+++ b/tests/review_stub.test.mjs
@@ -11,37 +11,53 @@ import {
 } from "../scripts/lib/review/provider.mjs";
 import { makeStubProvider } from "../scripts/lib/review/stub.mjs";
 
-describe("review/stub: every method throws NotSupportedError", () => {
+describe("review/stub: every method rejects with NotSupportedError (async)", () => {
   for (const op of REVIEW_PROVIDER_METHODS) {
-    it(`${op} throws with kind + op populated`, () => {
+    it(`${op} rejects with kind + op populated`, async () => {
+      // Stub methods MUST be async so the contract matches the real
+      // GitHub provider (which returns Promises). assert.rejects
+      // requires await so the promise settlement is observed.
       const provider = makeStubProvider("jira");
       assert.equal(typeof provider[op], "function");
-      try {
-        provider[op]({}, "arg1", "arg2");
-        assert.fail(`${op} should have thrown`);
-      } catch (err) {
-        assert.ok(err instanceof NotSupportedError, `expected NotSupportedError, got ${err.constructor.name}`);
-        assert.equal(err.kind, "jira");
-        assert.equal(err.op, op);
-        assert.match(err.message, /pr-iteration review op/);
-        assert.match(err.message, new RegExp(`'${op}'`), `message should name the op '${op}'`);
-        assert.match(err.message, /jira/);
-      }
+      await assert.rejects(
+        () => provider[op]({}, "arg1", "arg2"),
+        (err) => {
+          assert.ok(err instanceof NotSupportedError, `expected NotSupportedError, got ${err?.constructor?.name}`);
+          assert.equal(err.kind, "jira");
+          assert.equal(err.op, op);
+          assert.match(err.message, /pr-iteration review op/);
+          assert.match(err.message, new RegExp(`'${op}'`), `message should name the op '${op}'`);
+          assert.match(err.message, /jira/);
+          return true;
+        },
+      );
     });
   }
 });
 
 describe("review/stub: kind flows through to the error", () => {
-  it("preserves arbitrary kinds (linear, gitlab, anything)", () => {
+  it("preserves arbitrary kinds (linear, gitlab, anything)", async () => {
     for (const kind of ["linear", "gitlab", "unknown"]) {
       const provider = makeStubProvider(kind);
-      try {
-        provider.requestReview({});
-        assert.fail("should throw");
-      } catch (err) {
-        assert.equal(err.kind, kind);
-        assert.match(err.message, new RegExp(`'${kind}'`));
-      }
+      await assert.rejects(
+        () => provider.requestReview({}),
+        (err) => {
+          assert.equal(err.kind, kind);
+          assert.match(err.message, new RegExp(`'${kind}'`));
+          return true;
+        },
+      );
+    }
+  });
+
+  it("stub methods return promises (interchangeable with real provider)", () => {
+    const provider = makeStubProvider("jira");
+    for (const op of REVIEW_PROVIDER_METHODS) {
+      // Each invocation must return a thenable (Promise). We catch
+      // to silence the unhandled rejection.
+      const p = provider[op]({});
+      assert.ok(p && typeof p.then === "function", `${op} must return a Promise`);
+      p.catch(() => {}); // swallow; the rejection-content is asserted above
     }
   });
 });

--- a/tests/review_stub.test.mjs
+++ b/tests/review_stub.test.mjs
@@ -23,7 +23,8 @@ describe("review/stub: every method throws NotSupportedError", () => {
         assert.ok(err instanceof NotSupportedError, `expected NotSupportedError, got ${err.constructor.name}`);
         assert.equal(err.kind, "jira");
         assert.equal(err.op, op);
-        assert.match(err.message, /pr-iteration review loop is not implemented/);
+        assert.match(err.message, /pr-iteration review op/);
+        assert.match(err.message, new RegExp(`'${op}'`), `message should name the op '${op}'`);
         assert.match(err.message, /jira/);
       }
     });


### PR DESCRIPTION
## Summary

Codifies the PR iteration runbook (formerly a repo-root stash, now at `skills/pr-iteration/runbook.md`) as a first-class agent workflow. After `dev-loop` opens a PR, the agent enters a new `pr-iteration` skill that drives the runbook: request external reviewer via GraphQL, poll for CI and review, triage unresolved threads, fix + commit + push + resolve + re-request, iterate until all three exit conditions hold on the current HEAD (local review GO, zero unresolved, CI SUCCESS). The loop never merges; merge stays a human gate.

Provider-agnostic from day one per the approved plan: a `ReviewProvider` interface with a full GitHub implementation and a shared stub for every other tracker kind (Jira, Linear, GitLab). The dispatcher picks an impl from `ops.config.json -> trackers.dev.kind` with a transitional shim that reads the legacy top-level `github:` block (PR 3's multi-tracker refactor removes the shim).

## What changed

### New
- `scripts/lib/review/provider.mjs`: `ReviewProvider` interface + `NotSupportedError` class + `REVIEW_PROVIDER_METHODS` canonical method list.
- `scripts/lib/review/github.mjs`: full implementation via `gh api graphql` (`requestReviews` with `botIds`, `reviewThreads`, `resolveReviewThread`, `statusCheckRollup`). REST is avoided because it silently no-ops for bots. Construction-time coverage assert against `REVIEW_PROVIDER_METHODS`. `ciStateOnHead` is a narrow query (just HEAD commit + rollup), not a piggyback on `pollForReview`.
- `scripts/lib/review/stub.mjs`: per-kind stub; every op throws `NotSupportedError` with kind + op populated.
- `scripts/lib/review/dispatcher.mjs`: `pickReviewProvider` + `resolveTrackerKind`. Legacy shim tightly validates the `github:` block shape (rejects null, [], string, {}).
- `rules/pr-iteration.md`: portable binding rule (loop, exit conditions, triage heuristics, bot login -> node ID capture recipe).
- `skills/pr-iteration/SKILL.md`: orchestration contract + project contract + ops.config keys read.
- `skills/pr-iteration/runbook.md`: canonical how-to, relocated from the repo root and dedashed.
- `templates/pr-iteration-report.md`: per-round artefact shape.
- `tests/review_stub.test.mjs`, `tests/review_dispatcher.test.mjs`, `tests/review_github.test.mjs`: full coverage. The GitHub test uses a fake `gh` on PATH that tees argv + variables into a log file; assertions verify the provider actually transmits the right mutation text + variables (mutation-testing resilient).

### Extended
- `scripts/lib/ghExec.mjs`: `ghGraphqlQuery` / `ghGraphqlMutation` + `GhGraphqlError` class. Scalar vars via `-F`; array args inlined via `JSON.stringify`.
- `rules/pr-workflow.md`: state machine gains the pr-iteration phase between "In review" and the merge human gate.
- `skills/dev-loop/SKILL.md`: hands off to `pr-iteration` after opening the PR; skipped when `workflow.external_review.enabled` is false or the dispatcher returns the stub.
- `schemas/ops.config.schema.json` + `examples/ops.config.example.json`: new `workflow.external_review` block (enabled / provider / bots / poll_interval_seconds / poll_timeout_seconds / auto_resolve_stale_after_commits). Optional `trackers.dev.kind` block added for forward compat with PR 3.

## Review history

Local `skill-code-review` returned CONDITIONAL on first pass: 2 Critical + 11 Important findings. All addressed in commit 2 before pushing. Details in the commit messages.

## Test plan

- [ ] Merge. `tag-on-main` fires, sees no version change, no-ops.
- [ ] On a test PR with GitHub as the tracker, dev-loop hands off to pr-iteration. Copilot request fires via GraphQL (`login: copilot-pull-request-reviewer` appears in the mutation response).
- [ ] Land a stale comment + an actionable comment. Round 2 classifies them correctly and resolves both after the fix.
- [ ] On a scratch config with `trackers.dev.kind: jira` (alongside a stub `github:` block, since the schema still requires it until PR 3 lands the hard break), dev-loop halts at "In review" with the clean `NotSupportedError` message.
- [ ] Bundle gates (`npm run validate && npm run lint && npm test`) stay green.

## Notes

- The "skill orchestration e2e" test from the plan was dropped: skills in this bundle are markdown contracts (no JS orchestrator to drive from a test); the three lib tests cover every op the skill references. When a JS orchestrator lib lands later, add that test then.
- Follows `rules/llm-wiki.md`: per-round reports are written via `@ctxr/skill-llm-wiki` into the target's `.development/shared/reports/` wiki, not as raw markdown dumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
