### PR TITLE
feat(bundle-index,ambiguity-halt): routing doc + polite-halt contract

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,6 +7,8 @@ description: Staff-engineer agent for any Claude Code project. Auto-bootstraps o
 
 Hello. You are running `agent-staff-engineer`, a portable agent that ships as a self-contained bundle, auto-configures on first run, and orchestrates the full dev loop on behalf of the human on this project.
 
+**Read-first hint.** For any concrete task, consult [`bundle-index.md`](bundle-index.md) first; it routes the request to the minimal doc slice that answers it. Read this AGENT.md's "Hard rules you must honour" section once per session; the rest of AGENT.md is one-shot bootstrap content and stays out of your working context after the first run.
+
 ## First-run self-bootstrap
 
 Before acting on any user request, check the target project's state:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,15 @@ The tag push does NOT auto-chain into publish: `GITHUB_TOKEN` cannot trigger fur
 
 Full operator walkthrough (including troubleshooting for stale or orphan tags, non-main dispatches, and the "Allow GitHub Actions to create and approve pull requests" org-level policy) lives in the [Releasing section of the README](README.md#releasing).
 
+## Editing bundle docs
+
+When you add or rename a skill / rule / template / memory seed, update [bundle-index.md](bundle-index.md) in the same PR. The validator (check #12) enforces two invariants:
+
+- Every markdown link inside `bundle-index.md` points at a file that exists.
+- Every `skills/*/SKILL.md`, `rules/*.md`, `templates/*.md`, `memory-seeds/*.md` appears at least once in `bundle-index.md`.
+
+Orphans and dead links fail `npm run validate`. Edit the appropriate "By intent" and "By surface" sections; add a one-line description; add to the "Don't-read list" if the doc is one-shot or heavy.
+
 ## Questions
 
 Open an issue or a PR. Keep PRs focused; one change per PR keeps review fast.

--- a/bundle-index.md
+++ b/bundle-index.md
@@ -16,7 +16,7 @@ When you add or remove a bundle doc, update this file in the same PR.
 - [README.md](README.md): end-user-facing; skip at runtime unless the user is asking a README question.
 - [INSTALL.md](INSTALL.md): installer reference; skip at runtime.
 - [CONTRIBUTING.md](CONTRIBUTING.md): contributor workflow; skip at runtime.
-- [design/ARCHITECTURE.md](design/ARCHITECTURE.md): 646-line deep dive; load only when debugging structural questions or proposing a cross-cutting change.
+- [design/ARCHITECTURE.md](design/ARCHITECTURE.md): deep dive; load only when debugging structural questions or proposing a cross-cutting change.
 
 ## By intent
 

--- a/bundle-index.md
+++ b/bundle-index.md
@@ -1,0 +1,174 @@
+# Bundle index
+
+Hand-authored routing doc for every skill/rule/template/seed the agent ships. The agent reads this FIRST for any concrete task, then loads only the doc slices it needs. Do not re-read AGENT.md end-to-end for routine operations; it covers one-shot bootstrap.
+
+The validator (`scripts/validate_bundle.mjs` check #12) enforces two invariants:
+
+- Every file referenced here exists.
+- Every `skills/*/SKILL.md`, `rules/*.md`, `templates/*.md`, `memory-seeds/*.md` is referenced at least once here (no orphans).
+
+When you add or remove a bundle doc, update this file in the same PR.
+
+## Read first
+
+- [AGENT.md](AGENT.md): agent entry point. Read the "Hard rules you must honour" section once per session; everything else is one-shot bootstrap.
+- `bundle-index.md` (this file): route by intent / by surface / what to skip.
+- [README.md](README.md): end-user-facing; skip at runtime unless the user is asking a README question.
+- [INSTALL.md](INSTALL.md): installer reference; skip at runtime.
+- [CONTRIBUTING.md](CONTRIBUTING.md): contributor workflow; skip at runtime.
+- [design/ARCHITECTURE.md](design/ARCHITECTURE.md): 646-line deep dive; load only when debugging structural questions or proposing a cross-cutting change.
+
+## By intent
+
+Most skills are triggered by a concrete intent. Map the user's ask to the minimal doc set.
+
+### Opening or driving a dev issue to "In review"
+
+- [skills/dev-loop/SKILL.md](skills/dev-loop/SKILL.md): the state machine (branch, edits, local review, self-review, push, PR open, issue -> In review, hand off to pr-iteration).
+- [rules/pr-workflow.md](rules/pr-workflow.md): the hard rules (two human gates; never merge; never Done).
+- [rules/review-loop.md](rules/review-loop.md): pre-push local stages.
+- [rules/github-source-of-truth.md](rules/github-source-of-truth.md): where state lives.
+- [rules/no-dashes.md](rules/no-dashes.md): authoring rule for issue/PR bodies.
+- [templates/pr.md](templates/pr.md): PR body template dev-loop renders.
+- [templates/code-review-report.md](templates/code-review-report.md): self-review artefact (fallback; primary provider is `ctxr-skill-code-review`).
+
+### Iterating on review comments on an open PR
+
+- [skills/pr-iteration/SKILL.md](skills/pr-iteration/SKILL.md): the post-push loop orchestration.
+- [skills/pr-iteration/runbook.md](skills/pr-iteration/runbook.md): canonical how-to with GraphQL recipes.
+- [rules/pr-iteration.md](rules/pr-iteration.md): loop contract + exit conditions.
+- [rules/ambiguity-halt.md](rules/ambiguity-halt.md): halt-and-ask contract when state is weird.
+- [templates/pr-iteration-report.md](templates/pr-iteration-report.md): per-round artefact.
+
+### Triaging a regression
+
+- [skills/regression-handler/SKILL.md](skills/regression-handler/SKILL.md): the triage flow.
+- [rules/ambiguity-halt.md](rules/ambiguity-halt.md): halt when the reported bug is already closed.
+- [templates/regression-report.md](templates/regression-report.md): the filed report.
+- [templates/issue-bug.md](templates/issue-bug.md): template for a new bug issue.
+
+### Writing / keeping plans in sync
+
+- [skills/plan-keeper/SKILL.md](skills/plan-keeper/SKILL.md): plan lifecycle + one-liner sync.
+- [rules/plan-management.md](rules/plan-management.md): plan file layout, frontmatter, status moves.
+- [rules/ambiguity-halt.md](rules/ambiguity-halt.md): halt when a status flip contradicts PR state.
+- [memory-seeds/plan-lifecycle-moves.md](memory-seeds/plan-lifecycle-moves.md): memory seed for the lifecycle.
+
+### Computing release umbrella state
+
+- [skills/release-tracker/SKILL.md](skills/release-tracker/SKILL.md): umbrella status computation.
+- [templates/issue-release.md](templates/issue-release.md): umbrella issue template.
+- [templates/release-readiness-checklist.md](templates/release-readiness-checklist.md): readiness artefact.
+- [templates/iteration-summary.md](templates/iteration-summary.md): iteration-closing summary.
+
+### Reconciling labels, projects, PRs (the only GitHub writer path)
+
+- [skills/github-sync/SKILL.md](skills/github-sync/SKILL.md): label reconcile, project v2 fields, issue CRUD, PR ops.
+- [rules/github-source-of-truth.md](rules/github-source-of-truth.md): the governing rule.
+
+### Bootstrap + config changes
+
+- [skills/bootstrap-ops-config/SKILL.md](skills/bootstrap-ops-config/SKILL.md): first-install interview.
+- [skills/adapt-system/SKILL.md](skills/adapt-system/SKILL.md): cascading diffs when the project reshapes.
+- [rules/adaptation.md](rules/adaptation.md): adapt-system contract.
+- [rules/ambiguity-halt.md](rules/ambiguity-halt.md): halt when the diff would touch hand-authored files.
+- [memory-seeds/ops-config-usage.md](memory-seeds/ops-config-usage.md): config-access rule.
+
+### Writing docs into `.development/**` (wiki-routed)
+
+- [rules/llm-wiki.md](rules/llm-wiki.md): the skill-llm-wiki contract for project-side wikis.
+- [memory-seeds/wiki-scalable-layout.md](memory-seeds/wiki-scalable-layout.md): memory seed on scalable wiki layout.
+
+### Filing issues (pick template by kind)
+
+- [templates/issue-feature.md](templates/issue-feature.md)
+- [templates/issue-bug.md](templates/issue-bug.md)
+- [templates/issue-task.md](templates/issue-task.md)
+- [templates/issue-refactor.md](templates/issue-refactor.md)
+- [templates/issue-release.md](templates/issue-release.md)
+
+### Memory hygiene
+
+- [rules/memory-hygiene.md](rules/memory-hygiene.md): what the agent captures (and doesn't) in project memory.
+- Memory seeds (see the index below); the installer surfaces the stack-filtered subset as wrapper memory entries.
+
+### Planning and parallel exploration
+
+- [memory-seeds/planning-parallel-agents.md](memory-seeds/planning-parallel-agents.md): when and how to fan out Explore agents during Phase 1 of a plan.
+
+### Commit style + authoring conventions
+
+- [memory-seeds/commit-style-conventional.md](memory-seeds/commit-style-conventional.md): conventional-commits convention.
+- [memory-seeds/dash-free-writing.md](memory-seeds/dash-free-writing.md): the no-em/en-dash rule as a memory.
+
+### Testing discipline
+
+- [memory-seeds/testing-discipline.md](memory-seeds/testing-discipline.md): test categorisation, no mocks at the integration boundary, results-table reporting.
+
+### Stack-specific seeds (loaded only when the project's stack matches)
+
+- [memory-seeds/swift-dst-day-count.md](memory-seeds/swift-dst-day-count.md): Swift `Calendar.date(byAdding:)` over raw-seconds arithmetic.
+- [memory-seeds/xcui-combined-a11y.md](memory-seeds/xcui-combined-a11y.md): XCUITest combined-accessibility-elements gotcha.
+
+## By surface
+
+### Skills (8)
+
+- [skills/adapt-system/SKILL.md](skills/adapt-system/SKILL.md): reshape config/labels/templates/rules/seeds on project-intent changes.
+- [skills/bootstrap-ops-config/SKILL.md](skills/bootstrap-ops-config/SKILL.md): interactive first-install interview.
+- [skills/dev-loop/SKILL.md](skills/dev-loop/SKILL.md): issue -> branch -> local review -> PR open -> In review.
+- [skills/github-sync/SKILL.md](skills/github-sync/SKILL.md): sole GitHub writer; depth-gated per tracker target.
+- [skills/plan-keeper/SKILL.md](skills/plan-keeper/SKILL.md): plan folder / frontmatter / lifecycle.
+- [skills/pr-iteration/SKILL.md](skills/pr-iteration/SKILL.md): post-push loop until exit conditions hold.
+- [skills/regression-handler/SKILL.md](skills/regression-handler/SKILL.md): bug triage + linked-issue proposal.
+- [skills/release-tracker/SKILL.md](skills/release-tracker/SKILL.md): Release umbrella status computation.
+
+### Rules (10)
+
+- [rules/adaptation.md](rules/adaptation.md): when to invoke adapt-system.
+- [rules/ambiguity-halt.md](rules/ambiguity-halt.md): halt-and-ask when state is weird.
+- [rules/github-source-of-truth.md](rules/github-source-of-truth.md): GitHub is the source of truth.
+- [rules/llm-wiki.md](rules/llm-wiki.md): project-side wiki read/write contract.
+- [rules/memory-hygiene.md](rules/memory-hygiene.md): project memory boundaries.
+- [rules/no-dashes.md](rules/no-dashes.md): no em/en dashes in authored text.
+- [rules/plan-management.md](rules/plan-management.md): plan folder + frontmatter + lifecycle.
+- [rules/pr-iteration.md](rules/pr-iteration.md): post-push loop contract.
+- [rules/pr-workflow.md](rules/pr-workflow.md): PR state machine + two human gates.
+- [rules/review-loop.md](rules/review-loop.md): pre-push local review stages.
+
+### Templates (11)
+
+- [templates/code-review-report.md](templates/code-review-report.md): fallback self-review artefact.
+- [templates/issue-bug.md](templates/issue-bug.md): bug issue body.
+- [templates/issue-feature.md](templates/issue-feature.md): feature issue body.
+- [templates/issue-refactor.md](templates/issue-refactor.md): refactor issue body.
+- [templates/issue-release.md](templates/issue-release.md): release umbrella body.
+- [templates/issue-task.md](templates/issue-task.md): task issue body.
+- [templates/iteration-summary.md](templates/iteration-summary.md): iteration-closing summary.
+- [templates/pr-iteration-report.md](templates/pr-iteration-report.md): per-round artefact.
+- [templates/pr.md](templates/pr.md): PR body rendered by dev-loop.
+- [templates/regression-report.md](templates/regression-report.md): regression triage report.
+- [templates/release-readiness-checklist.md](templates/release-readiness-checklist.md): release-readiness artefact.
+
+### Memory seeds (9)
+
+- [memory-seeds/commit-style-conventional.md](memory-seeds/commit-style-conventional.md): conventional commits.
+- [memory-seeds/dash-free-writing.md](memory-seeds/dash-free-writing.md): no-dashes rule seed.
+- [memory-seeds/ops-config-usage.md](memory-seeds/ops-config-usage.md): cite the keys you used.
+- [memory-seeds/plan-lifecycle-moves.md](memory-seeds/plan-lifecycle-moves.md): plan lifecycle states + moves.
+- [memory-seeds/planning-parallel-agents.md](memory-seeds/planning-parallel-agents.md): Phase-1 parallel Explore.
+- [memory-seeds/swift-dst-day-count.md](memory-seeds/swift-dst-day-count.md): Swift DST-safe day counting.
+- [memory-seeds/testing-discipline.md](memory-seeds/testing-discipline.md): test categories, results-table.
+- [memory-seeds/wiki-scalable-layout.md](memory-seeds/wiki-scalable-layout.md): scalable nested wiki layout.
+- [memory-seeds/xcui-combined-a11y.md](memory-seeds/xcui-combined-a11y.md): XCUITest combined-a11y gotcha.
+
+## Don't-read list
+
+For routine operations the agent should NOT load these end-to-end; they are heavy or one-shot:
+
+- [AGENT.md](AGENT.md) (except the "Hard rules" section): the first-run bootstrap covers project setup; on sessions where a valid `ops.config.json` already exists, the bootstrap chapter is dead weight.
+- [design/ARCHITECTURE.md](design/ARCHITECTURE.md): load only when debugging a structural question.
+- [README.md](README.md) and [INSTALL.md](INSTALL.md): end-user / first-install facing.
+- [skills/pr-iteration/runbook.md](skills/pr-iteration/runbook.md): load when the iteration loop hits a recipe-level question (e.g. how to capture the Copilot bot ID); otherwise `skills/pr-iteration/SKILL.md` + `rules/pr-iteration.md` are enough.
+
+When routing between docs, prefer the SKILL.md (short contract) over the runbook (long how-to) unless the contract explicitly says "see the runbook".

--- a/memory-seeds/xcui-combined-a11y.md
+++ b/memory-seeds/xcui-combined-a11y.md
@@ -1,6 +1,6 @@
 ---
 name: XCUITest combined accessibility elements
-description: Containers built with accessibilityElement(children: .combine) do not reliably surface as otherElements. Assert on visible text instead.
+description: "Containers built with accessibilityElement(children: .combine) do not reliably surface as otherElements. Assert on visible text instead."
 type: feedback
 portable: true
 tags:

--- a/rules/ambiguity-halt.md
+++ b/rules/ambiguity-halt.md
@@ -1,0 +1,90 @@
+---
+name: ambiguity-halt
+description: When any skill notices state it cannot classify deterministically (local vs remote divergence, orphan PRs, status contradictions, unexplained branches), halt and ask the user. Never guess; never take a mutating action while the question is open.
+portable: true
+scope: every skill that mutates state on GitHub or on the local filesystem
+---
+
+# Ambiguity halt
+
+## The rule
+
+If a skill is about to act on a reference (branch, PR, issue, plan file) and notices state it cannot classify deterministically as "proceed as-is" or "archived / no-longer-relevant", the skill:
+
+1. **Halts** before any mutating action.
+2. **Surfaces** the ambiguity in one short sentence per observation, using the message shape below.
+3. **Asks** the user how to proceed.
+4. **Resumes** only after the user's answer.
+
+The contract standardises how every skill behaves once ambiguity is noticed. It is not a detector hook: each skill decides WHEN to check; this rule defines WHAT to do after the check says "weird".
+
+## Message shape
+
+One sentence per ambiguity. Plain English. No jargon unless it is the tracker's own vocabulary (PR, issue, branch, commit). No apology framing, no filler.
+
+```text
+I see <observation> on <reference>. <hypothesis, if any>. How do you want me to proceed?
+```
+
+If there are multiple ambiguities, list them as bullets under a single question; do not ask N times.
+
+Example for one:
+
+```text
+I see an open PR (#42) on issue #17, but the branch (feat/17-x) does not exist locally.
+Likely a teammate opened it from another machine. How do you want me to proceed?
+```
+
+Example for several:
+
+```text
+Before proceeding I noticed some things I cannot classify:
+- Branch feat/17-x has 3 unpushed commits none of which match any open PR.
+- Issue #17 is closed, but the plan one-liner still shows `[ ]`.
+How do you want me to proceed?
+```
+
+## Hard never-do list while waiting
+
+While the question is open, the skill MUST NOT:
+
+- Push to any remote (code, tags, release assets).
+- Publish a tag or a GitHub Release.
+- Open / edit / close / merge a PR.
+- Add / edit / resolve a review thread.
+- Add / edit / close / reopen / relabel / reassign / move status on an issue.
+- Delete or rename a local or remote branch.
+- Delete or rename any file the user did not ask about.
+- Invoke `@ctxr/skill-llm-wiki` to extend / rebuild / fix any wiki under `.development/**` (writes into a wiki surface are mutations from the user's perspective).
+- Apply an adapt-system cascade diff (even when previewed and the user has approved a SIBLING diff; ambiguity on one target invalidates the session-level approval).
+
+Read-only work (local file reads, `git fetch`, `git status`, `gh` read queries, `skill-llm-wiki validate` read probes) stays allowed. The agent MAY gather more context to improve the question before asking.
+
+## What counts as "ambiguous"
+
+Examples per skill, indicative, not exhaustive:
+
+- **dev-loop**: dev issue already has an open PR whose branch is unknown locally; user asked to branch from a non-default branch without stating why; the code change would collide with an unmerged sibling PR on the same files.
+- **pr-iteration**: a review thread author is neither a configured bot nor the project owner AND the comment contradicts a prior commit of the loop; the PR's HEAD advanced while the round was in-flight (someone else pushed).
+- **regression-handler**: the bug issue the user referenced is already closed with a resolution comment; a candidate "best match" matches multiple recently-closed issues with near-equal scores.
+- **adapt-system**: the proposed diff would touch a file the validator flags as hand-authored (e.g. `bundle-index.md`, `.gitignore`, `CLAUDE.md` above the managed marker); two different user intents in the same session would cascade to contradictory labels.
+- **plan-keeper**: a plan one-liner flip would contradict the PR's current status as reported by `github-sync` (plan says `[x]`, PR says "In progress").
+
+Each skill's SKILL.md lists its specific trigger conditions. The list above is for orientation; skills own the truth.
+
+## Resume protocol
+
+After the user answers:
+
+- If the user says "proceed as-is" (or equivalent), the skill continues from where it halted.
+- If the user gives a new direction, the skill treats that as the authoritative intent and re-plans from there.
+- If the user says "stop", the skill exits cleanly without mutating anything.
+
+No silent resumption. The skill always confirms in one sentence what it understood before acting ("Okay: proceeding with merge of #42; leaving branch feat/17-x alone.").
+
+## Related
+
+- [rules/github-source-of-truth.md](github-source-of-truth.md): GitHub is authoritative; local files are projections. Ambiguity is usually a local-vs-remote divergence.
+- [rules/pr-workflow.md](pr-workflow.md): the two human gates (merge, Done) are absolute. This rule adds a third class of halt: anything weird.
+- [rules/pr-iteration.md](pr-iteration.md): iteration loop invokes this contract when the three exit conditions cannot be determined.
+- [bundle-index.md](../bundle-index.md): routing doc; this rule is referenced from the "Iterating on review comments", "Triaging a regression", "Writing / keeping plans in sync", and "Bootstrap + config changes" intents.

--- a/rules/llm-wiki.md
+++ b/rules/llm-wiki.md
@@ -2,7 +2,7 @@
 name: llm-wiki
 description: How the agent reads and writes docs under .development/**. Every topical subfolder is an in-place LLM wiki managed by @ctxr/skill-llm-wiki. This rule delegates all format and navigation questions back to that skill so the format lives in one place.
 portable: true
-scope: every session running on a project that installed this agent and has ops.config.json `wiki.required: true`
+scope: every session running on a project that installed this agent and has `wiki.required` set to `true` in ops.config.json
 ---
 
 # LLM wiki

--- a/rules/review-loop.md
+++ b/rules/review-loop.md
@@ -1,6 +1,6 @@
 ---
 name: review-loop
-description: The local review loop every change runs through before push: format, lint, type, unit, integration, e2e where applicable, then the code-review provider. No skipping, no early exit on green stages.
+description: "The local review loop every change runs through before push: format, lint, type, unit, integration, e2e where applicable, then the code-review provider. No skipping, no early exit on green stages."
 portable: true
 scope: dev-loop, any automation that pushes a branch
 ---

--- a/scripts/lib/bundleIndex.mjs
+++ b/scripts/lib/bundleIndex.mjs
@@ -1,0 +1,59 @@
+// lib/bundleIndex.mjs
+// Shared helper used by both validate_bundle.mjs (check #12) and the
+// tests/bundle-index.test.mjs. Keeps the link-extraction regex in ONE
+// place so a future tweak (e.g. "also reject images", "handle escaped
+// parens") updates prod + tests together without drift.
+
+/**
+ * Extract internal markdown link targets from a bundle-index.md-shaped
+ * document. Rules:
+ *   - `[text](path)` forms with a relative `path` are returned (bundle-
+ *     relative targets).
+ *   - External URLs (`http://`, `https://`), `mailto:`, and
+ *     fragment-only (`#section`) targets are excluded.
+ *   - `#anchor` suffixes are stripped from the returned value; the
+ *     caller cares about file existence, not anchor validity.
+ *   - Image references `![alt](path)` are EXCLUDED — this is a
+ *     link/routing helper, not an asset check. An image in the bundle
+ *     index would need its own separate check.
+ *
+ * Returns a `Set<string>` of bundle-relative paths with no `#anchor`.
+ *
+ * @param {string} text raw bundle-index.md contents
+ */
+export function extractIndexLinks(text) {
+  if (typeof text !== "string") {
+    throw new TypeError("extractIndexLinks: text must be a string");
+  }
+  // Negative lookbehind `(?<!!)` rejects `![alt](path)` image syntax
+  // while still matching `[text](path)`. Without the lookbehind, an
+  // image link would be treated as a routing entry and get orphan
+  // credit — silently satisfying the check without actually routing
+  // the file to any reader.
+  const LINK_RE = /(?<!!)\[[^\]]+\]\(([^)\s#][^)\s]*?)(#[^)\s]*)?\)/g;
+  const out = new Set();
+  let m;
+  while ((m = LINK_RE.exec(text)) !== null) {
+    const target = m[1];
+    if (/^https?:\/\//.test(target)) continue;
+    if (target.startsWith("mailto:")) continue;
+    out.add(target);
+  }
+  return out;
+}
+
+/**
+ * The surfaces the bundle-index MUST fully cover. The orphan check
+ * walks each root, applies the filter, and asserts every matching
+ * file appears at least once as a link target in bundle-index.md.
+ *
+ * Sibling non-SKILL docs under `skills/*` (e.g. `pr-iteration/runbook.md`)
+ * are intentionally NOT required — the index author decides whether a
+ * sibling is part of the public surface.
+ */
+export const REQUIRED_INDEX_SURFACES = Object.freeze([
+  { dir: "skills", nameFilter: (rel) => rel.endsWith("/SKILL.md") },
+  { dir: "rules", nameFilter: (rel) => rel.endsWith(".md") },
+  { dir: "templates", nameFilter: (rel) => rel.endsWith(".md") },
+  { dir: "memory-seeds", nameFilter: (rel) => rel.endsWith(".md") },
+]);

--- a/scripts/lib/bundleIndex.mjs
+++ b/scripts/lib/bundleIndex.mjs
@@ -68,11 +68,16 @@ function canonicalizeTarget(raw) {
   if (raw.startsWith("/")) return null;                    // POSIX absolute
   if (/^[a-zA-Z]:[\\/]/.test(raw)) return null;            // Windows drive
   let t = raw.replace(/\\/g, "/");                         // unify separators
-  while (t.startsWith("./")) t = t.slice(2);               // strip leading ./
-  if (t.length === 0) return null;
-  const segments = t.split("/");
+  t = t.replace(/\/+/g, "/");                              // collapse "//" → "/"
+  // Drop both leading and INTERNAL "." segments so "skills/./foo.md",
+  // "./skills/foo.md", and "skills/foo.md" all canonicalise to the
+  // same key. Without this, a stat() on the raw form succeeds (the
+  // OS resolves "." segments) but the orphan check's Set.has(rel)
+  // misses because walkFiles() emits the normalised relpath only.
+  const segments = t.split("/").filter((s) => s !== "" && s !== ".");
   if (segments.some((s) => s === "..")) return null;       // traversal
-  return t;
+  if (segments.length === 0) return null;
+  return segments.join("/");
 }
 
 /**

--- a/scripts/lib/bundleIndex.mjs
+++ b/scripts/lib/bundleIndex.mjs
@@ -28,7 +28,7 @@ export function extractIndexLinks(text) {
   // Negative lookbehind `(?<!!)` rejects `![alt](path)` image syntax
   // while still matching `[text](path)`. Without the lookbehind, an
   // image link would be treated as a routing entry and get orphan
-  // credit — silently satisfying the check without actually routing
+  // credit silently satisfying the check without actually routing
   // the file to any reader.
   const LINK_RE = /(?<!!)\[[^\]]+\]\(([^)\s#][^)\s]*?)(#[^)\s]*)?\)/g;
   const out = new Set();
@@ -37,6 +37,16 @@ export function extractIndexLinks(text) {
     const target = m[1];
     if (/^https?:\/\//.test(target)) continue;
     if (target.startsWith("mailto:")) continue;
+    // Reject anything that escapes the bundle root. The validator
+    // later calls readFile(resolve(BUNDLE_ROOT, target)), and without
+    // this filter an absolute path ("/etc/passwd") or a parent-traversal
+    // ("../../host-file") would be read off the filesystem, making CI
+    // state depend on host layout. Accept only paths that stay inside
+    // the bundle: no leading "/", no ".." segment. This is a defense-in-
+    // depth filter; the validator still re-checks via readFile exist.
+    if (target.startsWith("/")) continue;
+    const segments = target.split("/");
+    if (segments.some((s) => s === "..")) continue;
     out.add(target);
   }
   return out;

--- a/scripts/lib/bundleIndex.mjs
+++ b/scripts/lib/bundleIndex.mjs
@@ -34,22 +34,45 @@ export function extractIndexLinks(text) {
   const out = new Set();
   let m;
   while ((m = LINK_RE.exec(text)) !== null) {
-    const target = m[1];
-    if (/^https?:\/\//.test(target)) continue;
-    if (target.startsWith("mailto:")) continue;
-    // Reject anything that escapes the bundle root. The validator
-    // later calls readFile(resolve(BUNDLE_ROOT, target)), and without
-    // this filter an absolute path ("/etc/passwd") or a parent-traversal
-    // ("../../host-file") would be read off the filesystem, making CI
-    // state depend on host layout. Accept only paths that stay inside
-    // the bundle: no leading "/", no ".." segment. This is a defense-in-
-    // depth filter; the validator still re-checks via readFile exist.
-    if (target.startsWith("/")) continue;
-    const segments = target.split("/");
-    if (segments.some((s) => s === "..")) continue;
-    out.add(target);
+    const raw = m[1];
+    if (/^https?:\/\//.test(raw)) continue;
+    if (raw.startsWith("mailto:")) continue;
+    const canonical = canonicalizeTarget(raw);
+    if (canonical === null) continue;
+    out.add(canonical);
   }
   return out;
+}
+
+/**
+ * Normalise a raw link target to the canonical bundle-relative form
+ * the orphan check compares against (`skills/foo/SKILL.md`), OR return
+ * `null` if the target cannot safely live inside the bundle.
+ *
+ * Rejections (returns null):
+ *   - leading "/" (POSIX absolute)
+ *   - Windows drive prefix ("C:\..." or "C:/...")
+ *   - any ".." segment after separator unification
+ *   - any path that, after normalisation, is empty
+ *
+ * Transformations:
+ *   - "\" separators (Windows-style) unified to "/"
+ *   - leading "./" stripped (so `./foo.md` and `foo.md` both canonicalise
+ *     to `foo.md`, matching the orphan check's canonical form)
+ *
+ * The canonicalisation is cheap and happens at parse time, not at
+ * validate-match time, so downstream callers can use simple
+ * `Set.has(rel)` lookups without per-call normalisation.
+ */
+function canonicalizeTarget(raw) {
+  if (raw.startsWith("/")) return null;                    // POSIX absolute
+  if (/^[a-zA-Z]:[\\/]/.test(raw)) return null;            // Windows drive
+  let t = raw.replace(/\\/g, "/");                         // unify separators
+  while (t.startsWith("./")) t = t.slice(2);               // strip leading ./
+  if (t.length === 0) return null;
+  const segments = t.split("/");
+  if (segments.some((s) => s === "..")) return null;       // traversal
+  return t;
 }
 
 /**

--- a/scripts/validate_bundle.mjs
+++ b/scripts/validate_bundle.mjs
@@ -37,11 +37,21 @@
 //        in bundle-index.md (no orphans);
 //      - when a new bundle doc is added, bundle-index must learn
 //        about it in the same PR.
+//  13. Every SKILL.md / rule / memory-seed frontmatter parses as
+//      real YAML (via gray-matter) AND, for SKILL.md, the
+//      `trigger_on` / `do_not_trigger_on` keys are arrays of
+//      plain strings. The previous regex-only checks missed a
+//      whole class of bug where an unquoted `: ` inside a bullet
+//      silently turned the list entry into a {key: value} mapping,
+//      which downstream consumers (Claude Code runtime) parse as
+//      garbage. Failure classes: `frontmatter-parse:` (hard YAML
+//      error), `frontmatter-type:` (list entry is not a string).
 //
 
 import { readFile, stat } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
 import { preflight } from "./preflight.mjs";
 import { walkFiles, readTextOrNull } from "./lib/fsx.mjs";
 import { validate } from "./lib/schema.mjs";
@@ -409,6 +419,59 @@ async function checkBundleIndex() {
   }
 }
 
+// ---- 13. Frontmatter parses as YAML + lists are string-arrays ----------
+// The earlier checks are regex-based and miss a whole class of bug: an
+// unquoted `: ` inside a list bullet (e.g. "Follow foo: bar") parses as
+// a YAML mapping `{Follow foo: bar}` rather than a plain string, and
+// some descriptions with stray colons make the whole frontmatter
+// unparseable. Both classes pass the regex gates but bite downstream
+// consumers (Claude Code runtime, which parses this as real YAML).
+// This check runs real gray-matter over every SKILL.md, rule, and seed.
+async function checkFrontmatterParses() {
+  const targets = [];
+  for await (const fp of walkFiles(join(BUNDLE_ROOT, "skills"))) {
+    if (fp.endsWith("/SKILL.md")) targets.push({ fp, kind: "skill" });
+  }
+  for await (const fp of walkFiles(join(BUNDLE_ROOT, "rules"))) {
+    if (fp.endsWith(".md")) targets.push({ fp, kind: "rule" });
+  }
+  for await (const fp of walkFiles(join(BUNDLE_ROOT, "memory-seeds"))) {
+    if (fp.endsWith(".md")) targets.push({ fp, kind: "seed" });
+  }
+  for (const { fp, kind } of targets) {
+    const rel = relative(BUNDLE_ROOT, fp);
+    const text = await readTextOrNull(fp);
+    if (text == null) continue;
+    let data;
+    try {
+      data = matter(text).data;
+    } catch (e) {
+      const msg = String(e && e.reason ? e.reason : (e && e.message ? e.message : e))
+        .split("\n")[0];
+      err(`frontmatter-parse: ${rel} (${msg})`);
+      continue;
+    }
+    // For SKILL.md, trigger_on / do_not_trigger_on are list fields that
+    // downstream tooling expects to be string[]. A mapping in there is
+    // the silent-mis-parse bug the round-4 threads flagged.
+    if (kind === "skill") {
+      for (const key of ["trigger_on", "do_not_trigger_on"]) {
+        const val = data[key];
+        if (val === undefined) continue;
+        if (!Array.isArray(val)) {
+          err(`frontmatter-type: ${rel}:${key} must be a list, got ${typeof val}`);
+          continue;
+        }
+        val.forEach((entry, i) => {
+          if (typeof entry !== "string") {
+            err(`frontmatter-type: ${rel}:${key}[${i}] must be a string (got ${typeof entry}; likely an unquoted ': ' turned the bullet into a mapping)`);
+          }
+        });
+      }
+    }
+  }
+}
+
 await checkLiterals();
 await checkDashes();
 await checkSkillStructure();
@@ -420,6 +483,7 @@ await checkSeedFrontmatter();
 await checkNoRawHomePaths();
 await checkWikiRuleReferences();
 await checkBundleIndex();
+await checkFrontmatterParses();
 
 const summary = `validate_bundle: ${errors.length} error(s), ${warnings.length} warning(s)`;
 if (errors.length === 0 && warnings.length === 0) {

--- a/scripts/validate_bundle.mjs
+++ b/scripts/validate_bundle.mjs
@@ -377,8 +377,15 @@ async function checkBundleIndex() {
       // Existence probe only; no need to read the bytes. Using stat()
       // over readFile() lets us distinguish ENOENT from EACCES/EISDIR
       // and include the OS error code in the message so a contributor
-      // can act on it without guessing.
-      await stat(abs);
+      // can act on it without guessing. We also assert the target is
+      // a regular file: a link to `templates/` (no trailing filename)
+      // exists but does not satisfy the bundle-index contract of
+      // "points at a file".
+      const s = await stat(abs);
+      if (!s.isFile()) {
+        const type = s.isDirectory() ? "directory" : "not a regular file";
+        err(`dead-link: bundle-index.md -> ${rel} (${type})`);
+      }
     } catch (e) {
       const code = e && e.code ? e.code : "unknown";
       if (code === "ENOENT") {

--- a/scripts/validate_bundle.mjs
+++ b/scripts/validate_bundle.mjs
@@ -27,7 +27,11 @@
 //      AGENT.md is enforced at the skill level.
 //  12. bundle-index.md is complete and link-valid:
 //      - every markdown link inside bundle-index.md points at a
-//        file that exists on disk;
+//        file that exists on disk (dead-link failures include the
+//        OS error code when it is not a plain "file not found");
+//      - every required surface directory (skills/, rules/,
+//        templates/, memory-seeds/) exists as a directory, not
+//        just "empty or missing" (missing-surface);
 //      - every file under skills/*/SKILL.md, rules/*.md,
 //        templates/*.md, memory-seeds/*.md appears at least once
 //        in bundle-index.md (no orphans);
@@ -35,7 +39,7 @@
 //        about it in the same PR.
 //
 
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { preflight } from "./preflight.mjs";
@@ -343,32 +347,64 @@ async function checkWikiRuleReferences() {
 // plus one `orphan` unless both sides are updated).
 async function checkBundleIndex() {
   const indexPath = join(BUNDLE_ROOT, "bundle-index.md");
-  const indexText = await readFile(indexPath, "utf8").catch(() => null);
-  if (indexText === null) {
-    err("missing-index: bundle-index.md is missing at the bundle root");
-    return;
+  let indexText;
+  try {
+    indexText = await readFile(indexPath, "utf8");
+  } catch (e) {
+    if (e && e.code === "ENOENT") {
+      err("missing-index: bundle-index.md is missing at the bundle root");
+      return;
+    }
+    // Surface EACCES / EISDIR / etc. with their real class instead of
+    // masking them as "missing" — a permission or IO fault is a bug the
+    // contributor needs to see clearly, not a false "just add the file".
+    throw e;
   }
   const referenced = extractIndexLinks(indexText);
   for (const rel of referenced) {
     const abs = resolve(BUNDLE_ROOT, rel);
     try {
-      await readFile(abs, "utf8");
-    } catch {
-      err(`dead-link: bundle-index.md -> ${rel} (file not found)`);
+      // Existence probe only; no need to read the bytes. Using stat()
+      // over readFile() lets us distinguish ENOENT from EACCES/EISDIR
+      // and include the OS error code in the message so a contributor
+      // can act on it without guessing.
+      await stat(abs);
+    } catch (e) {
+      const code = e && e.code ? e.code : "unknown";
+      if (code === "ENOENT") {
+        err(`dead-link: bundle-index.md -> ${rel} (file not found)`);
+      } else {
+        err(`dead-link: bundle-index.md -> ${rel} (${code})`);
+      }
     }
   }
   for (const { dir, nameFilter } of REQUIRED_INDEX_SURFACES) {
     const abs = join(BUNDLE_ROOT, dir);
+    // Surface-dir precondition: the directory MUST exist and be a
+    // directory. walkFiles() swallows ENOENT silently (yields nothing),
+    // which would let a missing required surface slip through as "no
+    // orphans found" — exactly the structural regression the tests
+    // already treat as fatal. Mirror the test's stat() check here so
+    // validate + test agree on what counts as a broken bundle.
     try {
-      for await (const fp of walkFiles(abs)) {
-        const rel = relative(BUNDLE_ROOT, fp).split(/[\\/]+/).join("/");
-        if (!nameFilter(rel)) continue;
-        if (!referenced.has(rel)) {
-          err(`orphan: ${rel} is not linked from bundle-index.md`);
-        }
+      const s = await stat(abs);
+      if (!s.isDirectory()) {
+        err(`missing-surface: required bundle surface ${dir}/ is not a directory`);
+        continue;
       }
     } catch (e) {
-      if (e && e.code !== "ENOENT") throw e;
+      if (e && e.code === "ENOENT") {
+        err(`missing-surface: required bundle surface ${dir}/ does not exist`);
+        continue;
+      }
+      throw e;
+    }
+    for await (const fp of walkFiles(abs)) {
+      const rel = relative(BUNDLE_ROOT, fp).split(/[\\/]+/).join("/");
+      if (!nameFilter(rel)) continue;
+      if (!referenced.has(rel)) {
+        err(`orphan: ${rel} is not linked from bundle-index.md`);
+      }
     }
   }
 }

--- a/scripts/validate_bundle.mjs
+++ b/scripts/validate_bundle.mjs
@@ -25,6 +25,14 @@
 //      .development/{shared,local,cache}/ must also reference
 //      rules/llm-wiki.md, so the write-through-wiki contract from
 //      AGENT.md is enforced at the skill level.
+//  12. bundle-index.md is complete and link-valid:
+//      - every markdown link inside bundle-index.md points at a
+//        file that exists on disk;
+//      - every file under skills/*/SKILL.md, rules/*.md,
+//        templates/*.md, memory-seeds/*.md appears at least once
+//        in bundle-index.md (no orphans);
+//      - when a new bundle doc is added, bundle-index must learn
+//        about it in the same PR.
 //
 
 import { readFile } from "node:fs/promises";
@@ -33,6 +41,7 @@ import { fileURLToPath } from "node:url";
 import { preflight } from "./preflight.mjs";
 import { walkFiles, readTextOrNull } from "./lib/fsx.mjs";
 import { validate } from "./lib/schema.mjs";
+import { extractIndexLinks, REQUIRED_INDEX_SURFACES } from "./lib/bundleIndex.mjs";
 
 await preflight();
 
@@ -318,6 +327,52 @@ async function checkWikiRuleReferences() {
   }
 }
 
+// ---- 12. bundle-index.md completeness + link integrity ----------------
+// The agent reads bundle-index.md first to route a task to the minimal
+// doc slice. That's only useful if the index is complete (every skill /
+// rule / template / memory seed is routable from it) and link-valid
+// (every path it names exists). Orphans silently reduce token economy;
+// dead links silently mislead the agent.
+//
+// Link-extraction logic is shared with tests/bundle-index.test.mjs via
+// scripts/lib/bundleIndex.mjs so prod and test can't drift.
+//
+// Failure messages use class prefixes (`missing-index:`, `dead-link:`,
+// `orphan:`) so a contributor scanning a validate run can tell cause
+// from effect at a glance (e.g. a renamed file produces one `dead-link`
+// plus one `orphan` unless both sides are updated).
+async function checkBundleIndex() {
+  const indexPath = join(BUNDLE_ROOT, "bundle-index.md");
+  const indexText = await readFile(indexPath, "utf8").catch(() => null);
+  if (indexText === null) {
+    err("missing-index: bundle-index.md is missing at the bundle root");
+    return;
+  }
+  const referenced = extractIndexLinks(indexText);
+  for (const rel of referenced) {
+    const abs = resolve(BUNDLE_ROOT, rel);
+    try {
+      await readFile(abs, "utf8");
+    } catch {
+      err(`dead-link: bundle-index.md -> ${rel} (file not found)`);
+    }
+  }
+  for (const { dir, nameFilter } of REQUIRED_INDEX_SURFACES) {
+    const abs = join(BUNDLE_ROOT, dir);
+    try {
+      for await (const fp of walkFiles(abs)) {
+        const rel = relative(BUNDLE_ROOT, fp).split(/[\\/]+/).join("/");
+        if (!nameFilter(rel)) continue;
+        if (!referenced.has(rel)) {
+          err(`orphan: ${rel} is not linked from bundle-index.md`);
+        }
+      }
+    } catch (e) {
+      if (e && e.code !== "ENOENT") throw e;
+    }
+  }
+}
+
 await checkLiterals();
 await checkDashes();
 await checkSkillStructure();
@@ -328,6 +383,7 @@ await checkRuleFrontmatter();
 await checkSeedFrontmatter();
 await checkNoRawHomePaths();
 await checkWikiRuleReferences();
+await checkBundleIndex();
 
 const summary = `validate_bundle: ${errors.length} error(s), ${warnings.length} warning(s)`;
 if (errors.length === 0 && warnings.length === 0) {

--- a/skills/adapt-system/SKILL.md
+++ b/skills/adapt-system/SKILL.md
@@ -9,8 +9,8 @@ do_not_trigger_on:
   - First install; use bootstrap-ops-config.
   - User is asking a question; intent has to be a project-shape change.
   - Intent is ambiguous; ask a clarifying question first.
-  - The proposed cascading diff would touch a path the adapt-system skill never owns: `bundle-index.md`, `.gitignore`, any file in `.github/`, or any region of `CLAUDE.md` outside the managed block delimited by the `<!-- agent:block -->` markers. Follow `rules/ambiguity-halt.md`: halt, surface the observation, ask; do not apply the diff while the question is open.
-  - Two different user intents in the same session cascade to contradictory labels or contradictory `ops.config.json` values. Follow `rules/ambiguity-halt.md`: halt, name the collision, ask which intent wins.
+  - The proposed cascading diff would touch a path the adapt-system skill never owns (`bundle-index.md`, `.gitignore`, any file in `.github/`, or any region of `CLAUDE.md` outside the managed block delimited by the `<!-- agent:block -->` markers). Follow `rules/ambiguity-halt.md` (halt, surface the observation, ask); do not apply the diff while the question is open.
+  - Two different user intents in the same session cascade to contradictory labels or contradictory `ops.config.json` values. Follow `rules/ambiguity-halt.md` (halt, name the collision, ask which intent wins).
 writes_to_github: yes, but only via github-sync (label taxonomy changes, relabelling existing issues on user approval)
 writes_to_filesystem: yes, with diff preview and explicit user approval
 ---

--- a/skills/adapt-system/SKILL.md
+++ b/skills/adapt-system/SKILL.md
@@ -9,6 +9,8 @@ do_not_trigger_on:
   - First install; use bootstrap-ops-config.
   - User is asking a question; intent has to be a project-shape change.
   - Intent is ambiguous; ask a clarifying question first.
+  - The proposed cascading diff would touch a path the adapt-system skill never owns: `bundle-index.md`, `.gitignore`, any file in `.github/`, or any region of `CLAUDE.md` outside the managed block delimited by the `<!-- agent:block -->` markers. Follow `rules/ambiguity-halt.md`: halt, surface the observation, ask; do not apply the diff while the question is open.
+  - Two different user intents in the same session cascade to contradictory labels or contradictory `ops.config.json` values. Follow `rules/ambiguity-halt.md`: halt, name the collision, ask which intent wins.
 writes_to_github: yes, but only via github-sync (label taxonomy changes, relabelling existing issues on user approval)
 writes_to_filesystem: yes, with diff preview and explicit user approval
 ---

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -8,6 +8,7 @@ do_not_trigger_on:
   - Issues in `Done` or closed without merge.
   - Targets where the dev_project has `depth: read-only`.
   - Without a valid ops.config.json (halt and point at bootstrap-ops-config).
+  - The dev issue already has an open PR whose branch is unknown locally, or two open PRs reference the same issue, or `github-sync` reports a status that contradicts local git state. Follow `rules/ambiguity-halt.md`: halt, surface the observation, ask; do not push, open, edit, close, or relabel anything while the question is open.
 writes_to_github: yes, via github-sync only (branch push, PR open, reviewer requests, status updates to In review, comments)
 writes_to_filesystem: yes, code edits plus a self-review report under paths.reports
 ---

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -6,9 +6,9 @@ trigger_on:
   - User explicitly runs /dev-loop <issue-number>.
 do_not_trigger_on:
   - Issues in `Done` or closed without merge.
-  - Targets where the dev_project has `depth: read-only`.
+  - Targets where the dev_project has `depth` set to `read-only`.
   - Without a valid ops.config.json (halt and point at bootstrap-ops-config).
-  - The dev issue already has an open PR whose branch is unknown locally, or two open PRs reference the same issue, or `github-sync` reports a status that contradicts local git state. Follow `rules/ambiguity-halt.md`: halt, surface the observation, ask; do not push, open, edit, close, or relabel anything while the question is open.
+  - The dev issue already has an open PR whose branch is unknown locally, or two open PRs reference the same issue, or `github-sync` reports a status that contradicts local git state. Follow `rules/ambiguity-halt.md` (halt, surface the observation, ask); do not push, open, edit, close, or relabel anything while the question is open.
 writes_to_github: yes, via github-sync only (branch push, PR open, reviewer requests, status updates to In review, comments)
 writes_to_filesystem: yes, code edits plus a self-review report under paths.reports
 ---

--- a/skills/github-sync/SKILL.md
+++ b/skills/github-sync/SKILL.md
@@ -7,7 +7,7 @@ trigger_on:
 do_not_trigger_on:
   - Read-only questions Claude can answer from local context alone.
   - Targets configured as read-only in ops.config.json, for any write path.
-  - The requested mutation would run against an item whose current server-side state differs from the caller's precondition (stale ETag, status-field value no longer in the configured `status_values`, item deleted between fetch and write). Follow `rules/ambiguity-halt.md`: halt, surface the divergence, ask the caller to re-read and re-decide; do not silently retry.
+  - The requested mutation would run against an item whose current server-side state differs from the caller's precondition (stale ETag, status-field value no longer in the configured `status_values`, item deleted between fetch and write). Follow `rules/ambiguity-halt.md` (halt, surface the divergence, ask the caller to re-read and re-decide); do not silently retry.
 writes_to_github: yes, on approval or when called programmatically by another skill under that skill's own approval flow
 writes_to_filesystem: no
 ---

--- a/skills/github-sync/SKILL.md
+++ b/skills/github-sync/SKILL.md
@@ -7,6 +7,7 @@ trigger_on:
 do_not_trigger_on:
   - Read-only questions Claude can answer from local context alone.
   - Targets configured as read-only in ops.config.json, for any write path.
+  - The requested mutation would run against an item whose current server-side state differs from the caller's precondition (stale ETag, status-field value no longer in the configured `status_values`, item deleted between fetch and write). Follow `rules/ambiguity-halt.md`: halt, surface the divergence, ask the caller to re-read and re-decide; do not silently retry.
 writes_to_github: yes, on approval or when called programmatically by another skill under that skill's own approval flow
 writes_to_filesystem: no
 ---

--- a/skills/plan-keeper/SKILL.md
+++ b/skills/plan-keeper/SKILL.md
@@ -10,6 +10,7 @@ do_not_trigger_on:
   - The project's daily report folder. Not touched, ever.
   - The project's knowledge base. Not touched, ever.
   - Plans outside the configured plans_root.
+  - A plan one-liner flip would contradict the linked PR's current status as reported by `github-sync` (plan says `[x]` but PR says "In progress"), OR a plan claims a `related_github_issues` that no longer exists / has been reopened unexpectedly. Follow `rules/ambiguity-halt.md`: halt, surface the observation, ask; do not flip the checkbox or move the plan state while the question is open.
 writes_to_github: no
 writes_to_filesystem: plan files within paths.plans_root only
 ---

--- a/skills/plan-keeper/SKILL.md
+++ b/skills/plan-keeper/SKILL.md
@@ -10,7 +10,7 @@ do_not_trigger_on:
   - The project's daily report folder. Not touched, ever.
   - The project's knowledge base. Not touched, ever.
   - Plans outside the configured plans_root.
-  - A plan one-liner flip would contradict the linked PR's current status as reported by `github-sync` (plan says `[x]` but PR says "In progress"), OR a plan claims a `related_github_issues` that no longer exists / has been reopened unexpectedly. Follow `rules/ambiguity-halt.md`: halt, surface the observation, ask; do not flip the checkbox or move the plan state while the question is open.
+  - A plan one-liner flip would contradict the linked PR's current status as reported by `github-sync` (plan says `[x]` but PR says "In progress"), OR a plan claims a `related_github_issues` that no longer exists / has been reopened unexpectedly. Follow `rules/ambiguity-halt.md` (halt, surface the observation, ask); do not flip the checkbox or move the plan state while the question is open.
 writes_to_github: no
 writes_to_filesystem: plan files within paths.plans_root only
 ---

--- a/skills/pr-iteration/SKILL.md
+++ b/skills/pr-iteration/SKILL.md
@@ -9,6 +9,7 @@ do_not_trigger_on:
   - workflow.external_review.provider is "none", i.e. the dispatcher resolves kind to "none" as an explicit opt-out. Same effect as enabled:false; halt cleanly at In review, do NOT surface a NotSupportedError (which is reserved for unsupported tracker kinds).
   - PRs on trackers where the ReviewProvider dispatcher returns the stub for a tracker kind that isn't "none" (Jira/Linear/GitLab today). Surface the `NotSupportedError` message and halt.
   - Without a valid ops.config.json (halt and point at bootstrap-ops-config).
+  - The PR HEAD advanced between rounds by a commit this loop did not author, OR an unresolved review thread's author is neither a configured bot (`workflow.external_review.bots`) nor the project owner AND the comment contradicts a commit of the loop. Follow `rules/ambiguity-halt.md`: halt, surface the observation, ask; do not push, resolve threads, or re-request reviewers while the question is open.
 writes_to_github: yes, via github-sync for status updates and via tracker-specific providers (GraphQL requestReviews / resolveReviewThread for GitHub) for review mutations
 writes_to_filesystem: yes, code edits per round plus a per-round pr-iteration report under paths.reports (written via @ctxr/skill-llm-wiki, per rules/llm-wiki.md)
 ---

--- a/skills/pr-iteration/SKILL.md
+++ b/skills/pr-iteration/SKILL.md
@@ -9,7 +9,7 @@ do_not_trigger_on:
   - workflow.external_review.provider is "none", i.e. the dispatcher resolves kind to "none" as an explicit opt-out. Same effect as enabled:false; halt cleanly at In review, do NOT surface a NotSupportedError (which is reserved for unsupported tracker kinds).
   - PRs on trackers where the ReviewProvider dispatcher returns the stub for a tracker kind that isn't "none" (Jira/Linear/GitLab today). Surface the `NotSupportedError` message and halt.
   - Without a valid ops.config.json (halt and point at bootstrap-ops-config).
-  - The PR HEAD advanced between rounds by a commit this loop did not author, OR an unresolved review thread's author is neither a configured bot (`workflow.external_review.bots`) nor the project owner AND the comment contradicts a commit of the loop. Follow `rules/ambiguity-halt.md`: halt, surface the observation, ask; do not push, resolve threads, or re-request reviewers while the question is open.
+  - The PR HEAD advanced between rounds by a commit this loop did not author, OR an unresolved review thread's author is neither a configured bot (`workflow.external_review.bots`) nor the project owner AND the comment contradicts a commit of the loop. Follow `rules/ambiguity-halt.md` (halt, surface the observation, ask); do not push, resolve threads, or re-request reviewers while the question is open.
 writes_to_github: yes, via github-sync for status updates and via tracker-specific providers (GraphQL requestReviews / resolveReviewThread for GitHub) for review mutations
 writes_to_filesystem: yes, code edits per round plus a per-round pr-iteration report under paths.reports (written via @ctxr/skill-llm-wiki, per rules/llm-wiki.md)
 ---

--- a/skills/regression-handler/SKILL.md
+++ b/skills/regression-handler/SKILL.md
@@ -2,13 +2,13 @@
 name: regression-handler
 description: When the user reports a bug, runs a deterministic lookup (referenced commit or file, area label on recent closed issues, title keyword match) across every GitHub target the config permits. Attaches a filled regression-report.md and proposes reopen, relink, or new-issue actions. User approves before any write.
 trigger_on:
-  - User reports a regression: a bug in previously-shipped or previously-closed functionality.
+  - User reports a regression (a bug in previously-shipped or previously-closed functionality).
   - User pastes a stack trace, file path, or commit reference and asks what broke this.
   - /regression-handler invoked directly.
 do_not_trigger_on:
   - New features that never worked (that is a bug but not a regression; use issue-bug template directly).
   - Questions that do not name specific behaviour ("something feels slow").
-  - The bug issue the user referenced is already closed with a resolution comment, OR a candidate "best match" has near-equal scores across multiple recently-closed issues. Follow `rules/ambiguity-halt.md`: halt, surface the observation, ask; do not reopen, relabel, or file a new issue while the question is open.
+  - The bug issue the user referenced is already closed with a resolution comment, OR a candidate "best match" has near-equal scores across multiple recently-closed issues. Follow `rules/ambiguity-halt.md` (halt, surface the observation, ask); do not reopen, relabel, or file a new issue while the question is open.
 writes_to_github: yes, via github-sync (reopen, comment with report, or create new linked issue), always behind user approval
 writes_to_filesystem: writes the regression report to paths.reports
 ---

--- a/skills/regression-handler/SKILL.md
+++ b/skills/regression-handler/SKILL.md
@@ -8,6 +8,7 @@ trigger_on:
 do_not_trigger_on:
   - New features that never worked (that is a bug but not a regression; use issue-bug template directly).
   - Questions that do not name specific behaviour ("something feels slow").
+  - The bug issue the user referenced is already closed with a resolution comment, OR a candidate "best match" has near-equal scores across multiple recently-closed issues. Follow `rules/ambiguity-halt.md`: halt, surface the observation, ask; do not reopen, relabel, or file a new issue while the question is open.
 writes_to_github: yes, via github-sync (reopen, comment with report, or create new linked issue), always behind user approval
 writes_to_filesystem: writes the regression report to paths.reports
 ---

--- a/skills/release-tracker/SKILL.md
+++ b/skills/release-tracker/SKILL.md
@@ -9,6 +9,7 @@ trigger_on:
 do_not_trigger_on:
   - Release projects with `depth: read-only`.
   - Projects with zero release_projects configured.
+  - The recompute would flip an umbrella to Done while one or more linked dev issues are reopened OR their relation to the umbrella was broken between fetch and write. Follow `rules/ambiguity-halt.md`: halt, surface the mismatch and the specific issue numbers, ask whether to exclude, re-link, or wait; do not flip the umbrella status or mutate the body while the question is open.
 writes_to_github: yes, via github-sync, only on release umbrellas
 writes_to_filesystem: no
 ---

--- a/skills/release-tracker/SKILL.md
+++ b/skills/release-tracker/SKILL.md
@@ -2,14 +2,14 @@
 name: release-tracker
 description: Computes Release umbrella status from linked dev issues. Auto-moves each umbrella through Backlog -> In progress -> Done and maintains the "Linked Dev Issues" counter and blocker list on the umbrella body. Never auto-promotes a dev issue to Done.
 trigger_on:
-  - Any dev-issue status change on a dev project with `depth: full` that is linked to a release umbrella.
+  - Any dev-issue status change on a dev project whose `depth` is `full` and that is linked to a release umbrella.
   - Issue linked to or unlinked from a release umbrella.
   - User explicitly asks for a release status recompute.
   - After adapt-system changes the intent label taxonomy (new or removed intent values).
 do_not_trigger_on:
-  - Release projects with `depth: read-only`.
+  - Release projects whose `depth` is `read-only`.
   - Projects with zero release_projects configured.
-  - The recompute would flip an umbrella to Done while one or more linked dev issues are reopened OR their relation to the umbrella was broken between fetch and write. Follow `rules/ambiguity-halt.md`: halt, surface the mismatch and the specific issue numbers, ask whether to exclude, re-link, or wait; do not flip the umbrella status or mutate the body while the question is open.
+  - The recompute would flip an umbrella to Done while one or more linked dev issues are reopened OR their relation to the umbrella was broken between fetch and write. Follow `rules/ambiguity-halt.md` (halt, surface the mismatch and the specific issue numbers, ask whether to exclude, re-link, or wait); do not flip the umbrella status or mutate the body while the question is open.
 writes_to_github: yes, via github-sync, only on release umbrellas
 writes_to_filesystem: no
 ---

--- a/tests/bundle-index.test.mjs
+++ b/tests/bundle-index.test.mjs
@@ -115,6 +115,21 @@ describe("extractIndexLinks: regex behaviour (pinned fixtures)", () => {
     assert.ok(out.has("sub/dir/file.md"));
     assert.ok(out.has("still-here.md"), "repeated './' prefixes all stripped");
   });
+  it("canonicalises INTERNAL './' segments (so 'skills/./foo.md' and 'skills/foo.md' match)", () => {
+    // Without this, stat() succeeds on the raw form (the OS resolves
+    // '.' internally) but the orphan check's Set.has() misses because
+    // walkFiles() emits only the normalised relpath. Result: a false
+    // orphan error on a perfectly valid link.
+    const out = extractIndexLinks("[x](skills/./dev-loop/SKILL.md) [y](a/./b/./c.md)");
+    assert.ok(out.has("skills/dev-loop/SKILL.md"), "internal '.' segment must be collapsed");
+    assert.ok(out.has("a/b/c.md"), "multiple internal '.' segments all collapsed");
+    assert.ok(!out.has("skills/./dev-loop/SKILL.md"), "non-canonical form must NOT be present");
+  });
+  it("collapses repeated '/' separators", () => {
+    const out = extractIndexLinks("[x](skills//dev-loop///SKILL.md)");
+    assert.ok(out.has("skills/dev-loop/SKILL.md"), "duplicate slashes must collapse to single");
+    assert.ok(!out.has("skills//dev-loop///SKILL.md"));
+  });
   it("unifies backslash separators to forward slashes (canonical POSIX form)", () => {
     const out = extractIndexLinks("[x](sub\\dir\\file.md)");
     assert.ok(out.has("sub/dir/file.md"), "backslashes must canonicalise to POSIX form for Set lookup");
@@ -128,14 +143,24 @@ describe("extractIndexLinks: regex behaviour (pinned fixtures)", () => {
 });
 
 describe("bundle-index.md: link integrity", () => {
-  it("every internal link points at a file that exists on disk", async () => {
+  it("every internal link points at a regular file that exists on disk", async () => {
+    // Match the validator's stat()+isFile() contract so the test and
+    // the validator agree on what counts as a valid link target.
+    // readFile() would mislabel EISDIR / EACCES / etc. as "missing"
+    // and wouldn't catch a link that resolves to a directory.
     const refs = await loadIndexLinks();
     for (const rel of refs) {
       const abs = resolve(BUNDLE_ROOT, rel);
-      await assert.doesNotReject(
-        readFile(abs, "utf8"),
-        `bundle-index.md references missing file: ${rel}`,
-      );
+      try {
+        const s = await stat(abs);
+        assert.ok(
+          s.isFile(),
+          `bundle-index.md references non-file path: ${rel}`,
+        );
+      } catch (e) {
+        const code = e && e.code ? e.code : (e && e.name ? e.name : "unknown");
+        assert.fail(`bundle-index.md references invalid path: ${rel} (${code})`);
+      }
     }
   });
 });

--- a/tests/bundle-index.test.mjs
+++ b/tests/bundle-index.test.mjs
@@ -76,25 +76,49 @@ describe("extractIndexLinks: regex behaviour (pinned fixtures)", () => {
     const out = extractIndexLinks("[x](#only-anchor)");
     assert.equal(out.size, 0);
   });
-  it("rejects absolute paths (would escape bundle root)", () => {
+  it("rejects POSIX-absolute paths (would escape bundle root)", () => {
     const out = extractIndexLinks("[x](/etc/passwd) [y](/absolute/in/repo.md)");
     assert.equal(out.size, 0, "leading '/' must not produce a reference; avoids host-dependent reads in CI");
   });
-  it("rejects parent-traversal paths (would escape bundle root)", () => {
+  it("rejects Windows drive-letter paths", () => {
+    const out = extractIndexLinks("[x](C:\\Windows\\win.ini) [y](D:/foo/bar.md)");
+    assert.equal(out.size, 0, "drive-letter prefixes must not produce references");
+  });
+  it("rejects parent-traversal regardless of separator style", () => {
+    // Includes POSIX '/', Windows '\\', and mixed forms. On the
+    // target's eventual filesystem (CI is Linux), backslashes may not
+    // literally escape the root, but normalising here makes the
+    // invariant hold cross-platform and defends against copy-pasted
+    // Windows paths in a contributor's editor.
     const cases = [
       "[x](../outside.md)",
       "[y](a/../../escape.md)",
       "[z](a/..)",
+      "[w](..\\outside.md)",
+      "[v](a\\..\\..\\escape.md)",
+      "[u](a\\..)",
+      "[s](sub/..\\outside.md)",
     ];
     for (const text of cases) {
       const out = extractIndexLinks(text);
-      assert.equal(out.size, 0, `'..' segment in ${text} must not produce a reference`);
+      assert.equal(
+        out.size,
+        0,
+        `parent traversal in ${text} must not produce a reference`,
+      );
     }
   });
-  it("accepts legitimate relative paths with `.` or subdirs (no '..')", () => {
-    const out = extractIndexLinks("[x](./same-dir.md) [y](sub/dir/file.md)");
-    assert.ok(out.has("./same-dir.md"));
+  it("canonicalises leading './' (so './foo' and 'foo' are interchangeable)", () => {
+    const out = extractIndexLinks("[x](./same-dir.md) [y](sub/dir/file.md) [z](././still-here.md)");
+    assert.ok(out.has("same-dir.md"), "leading './' must be stripped");
+    assert.ok(!out.has("./same-dir.md"), "non-canonical form must NOT be present");
     assert.ok(out.has("sub/dir/file.md"));
+    assert.ok(out.has("still-here.md"), "repeated './' prefixes all stripped");
+  });
+  it("unifies backslash separators to forward slashes (canonical POSIX form)", () => {
+    const out = extractIndexLinks("[x](sub\\dir\\file.md)");
+    assert.ok(out.has("sub/dir/file.md"), "backslashes must canonicalise to POSIX form for Set lookup");
+    assert.ok(!out.has("sub\\dir\\file.md"), "non-canonical form must NOT be present");
   });
   it("extracts multiple links from mixed prose", () => {
     const text = "See [a](one.md) and [b](two.md#x); not [this](https://y) and not ![img](p.png).";

--- a/tests/bundle-index.test.mjs
+++ b/tests/bundle-index.test.mjs
@@ -7,7 +7,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { walkFiles } from "../scripts/lib/fsx.mjs";
@@ -24,11 +24,27 @@ async function loadIndexLinks() {
 }
 
 // Walks `dir` (required to exist) and returns bundle-relative paths
-// filtered by `nameFilter`. Throws on ENOENT: the caller is asking
-// about a surface the bundle-index MUST cover, so a missing dir is a
-// structural regression, not a skip.
+// filtered by `nameFilter`. Throws an explicit error when `dir` is
+// missing: the caller is asking about a surface the bundle-index MUST
+// cover, so a missing dir is a structural regression. `walkFiles()`
+// itself swallows ENOENT (yields nothing), so we stat() up front to
+// surface a clear message rather than let it fall through to a
+// confusing "expected at least one doc" assertion failure downstream.
 async function collectRequiredDocs(dir, nameFilter) {
   const abs = join(BUNDLE_ROOT, dir);
+  try {
+    const s = await stat(abs);
+    if (!s.isDirectory()) {
+      throw new Error(`collectRequiredDocs: ${dir} is not a directory`);
+    }
+  } catch (e) {
+    if (e && e.code === "ENOENT") {
+      throw new Error(
+        `collectRequiredDocs: required bundle surface ${dir}/ does not exist`,
+      );
+    }
+    throw e;
+  }
   const rels = [];
   for await (const fp of walkFiles(abs)) {
     const rel = relative(BUNDLE_ROOT, fp).split(/[\\/]+/).join("/");
@@ -59,6 +75,26 @@ describe("extractIndexLinks: regex behaviour (pinned fixtures)", () => {
   it("rejects fragment-only anchors", () => {
     const out = extractIndexLinks("[x](#only-anchor)");
     assert.equal(out.size, 0);
+  });
+  it("rejects absolute paths (would escape bundle root)", () => {
+    const out = extractIndexLinks("[x](/etc/passwd) [y](/absolute/in/repo.md)");
+    assert.equal(out.size, 0, "leading '/' must not produce a reference; avoids host-dependent reads in CI");
+  });
+  it("rejects parent-traversal paths (would escape bundle root)", () => {
+    const cases = [
+      "[x](../outside.md)",
+      "[y](a/../../escape.md)",
+      "[z](a/..)",
+    ];
+    for (const text of cases) {
+      const out = extractIndexLinks(text);
+      assert.equal(out.size, 0, `'..' segment in ${text} must not produce a reference`);
+    }
+  });
+  it("accepts legitimate relative paths with `.` or subdirs (no '..')", () => {
+    const out = extractIndexLinks("[x](./same-dir.md) [y](sub/dir/file.md)");
+    assert.ok(out.has("./same-dir.md"));
+    assert.ok(out.has("sub/dir/file.md"));
   });
   it("extracts multiple links from mixed prose", () => {
     const text = "See [a](one.md) and [b](two.md#x); not [this](https://y) and not ![img](p.png).";

--- a/tests/bundle-index.test.mjs
+++ b/tests/bundle-index.test.mjs
@@ -1,0 +1,109 @@
+// bundle-index.test.mjs
+// Asserts the invariants validate_bundle.mjs check #12 enforces at the
+// bundle level. Imports the link-extraction helper DIRECTLY from the
+// same module the validator uses (`scripts/lib/bundleIndex.mjs`) so the
+// two cannot drift: a future tweak to the regex updates prod + test
+// together.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { walkFiles } from "../scripts/lib/fsx.mjs";
+import {
+  extractIndexLinks,
+  REQUIRED_INDEX_SURFACES,
+} from "../scripts/lib/bundleIndex.mjs";
+
+const BUNDLE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+async function loadIndexLinks() {
+  const text = await readFile(join(BUNDLE_ROOT, "bundle-index.md"), "utf8");
+  return extractIndexLinks(text);
+}
+
+// Walks `dir` (required to exist) and returns bundle-relative paths
+// filtered by `nameFilter`. Throws on ENOENT: the caller is asking
+// about a surface the bundle-index MUST cover, so a missing dir is a
+// structural regression, not a skip.
+async function collectRequiredDocs(dir, nameFilter) {
+  const abs = join(BUNDLE_ROOT, dir);
+  const rels = [];
+  for await (const fp of walkFiles(abs)) {
+    const rel = relative(BUNDLE_ROOT, fp).split(/[\\/]+/).join("/");
+    if (!nameFilter(rel)) continue;
+    rels.push(rel);
+  }
+  return rels;
+}
+
+describe("extractIndexLinks: regex behaviour (pinned fixtures)", () => {
+  it("accepts a plain relative link", () => {
+    const out = extractIndexLinks("[x](rel/path.md)");
+    assert.ok(out.has("rel/path.md"));
+  });
+  it("strips #anchor suffixes", () => {
+    const out = extractIndexLinks("[x](path.md#section)");
+    assert.ok(out.has("path.md"));
+    assert.ok(!out.has("path.md#section"));
+  });
+  it("rejects image references `![alt](path)`", () => {
+    const out = extractIndexLinks("![img](assets/icon.png)");
+    assert.equal(out.size, 0, "image references must not be treated as routing links");
+  });
+  it("rejects external URLs and mailto", () => {
+    const out = extractIndexLinks("[a](https://example.com) [b](http://x) [c](mailto:a@b)");
+    assert.equal(out.size, 0);
+  });
+  it("rejects fragment-only anchors", () => {
+    const out = extractIndexLinks("[x](#only-anchor)");
+    assert.equal(out.size, 0);
+  });
+  it("extracts multiple links from mixed prose", () => {
+    const text = "See [a](one.md) and [b](two.md#x); not [this](https://y) and not ![img](p.png).";
+    const out = extractIndexLinks(text);
+    assert.deepEqual([...out].sort(), ["one.md", "two.md"]);
+  });
+});
+
+describe("bundle-index.md: link integrity", () => {
+  it("every internal link points at a file that exists on disk", async () => {
+    const refs = await loadIndexLinks();
+    for (const rel of refs) {
+      const abs = resolve(BUNDLE_ROOT, rel);
+      await assert.doesNotReject(
+        readFile(abs, "utf8"),
+        `bundle-index.md references missing file: ${rel}`,
+      );
+    }
+  });
+});
+
+describe("bundle-index.md: orphan detection", () => {
+  // Iterate the SAME surfaces the validator walks, so a future
+  // REQUIRED_INDEX_SURFACES extension automatically gets covered.
+  for (const { dir, nameFilter } of REQUIRED_INDEX_SURFACES) {
+    it(`every required doc under ${dir}/ appears in the index`, async () => {
+      const refs = await loadIndexLinks();
+      const docs = await collectRequiredDocs(dir, nameFilter);
+      assert.ok(docs.length > 0, `expected at least one required doc under ${dir}/`);
+      for (const rel of docs) {
+        assert.ok(
+          refs.has(rel),
+          `bundle-index.md must reference ${rel} (add a routing entry)`,
+        );
+      }
+    });
+  }
+});
+
+describe("bundle-index.md: editorial pins (lock specific routing decisions)", () => {
+  it("routes to the pr-iteration runbook from the 'iterate on review comments' intent", async () => {
+    const refs = await loadIndexLinks();
+    assert.ok(
+      refs.has("skills/pr-iteration/runbook.md"),
+      "runbook is the deep-dive for iteration; index must route to it",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two small, orthogonal improvements. Neither persists state or tracks work across sessions; the broader agent-memory concern is explicitly deferred to a later PR built on `@ctxr/skill-llm-wiki`.

### Part A: `bundle-index.md`

Hand-authored routing doc at the bundle root that tells the agent which docs answer which concrete intent ("opening a PR" → X + Y, "iterating on review comments" → P + Q + runbook). Backed by validator check #12 that fails CI on dead links or orphaned files. Source of truth is a shared lib (`scripts/lib/bundleIndex.mjs`) consumed by both validator and tests so the link-extraction rules cannot drift.

Benefits:

- Agent reads the minimal doc slice instead of re-loading full SKILLs.
- Explicit "don't-read" list for heavy / one-shot files.
- Deterministic: no generated artifacts, no CI freshness gate flakiness.

### Part B: `rules/ambiguity-halt.md`

One shared contract every writer skill invokes when it notices state it cannot classify deterministically (branch gone remotely, PR closed without merge, plan status contradicts PR status, stale ETag, concurrent diff collision). The skill halts, emits one short sentence per observation, asks the user, and takes no mutating action while the question is open.

Hard never-do list covers every mutation surface currently in play: git push (incl. tags), Release publish, PR open/edit/merge, review thread mutations, issue mutations, branch delete/rename, wiki extend/rebuild/fix, adapt-system cascade apply.

Cross-linked from 7 writer SKILLs (`dev-loop`, `pr-iteration`, `regression-handler`, `adapt-system`, `plan-keeper`, `github-sync`, `release-tracker`), each naming a skill-specific ambiguity trigger.

## Files

New:

- `bundle-index.md`
- `rules/ambiguity-halt.md`
- `scripts/lib/bundleIndex.mjs`
- `tests/bundle-index.test.mjs`

Modified:

- `scripts/validate_bundle.mjs` (+ check #12)
- `AGENT.md`, `CONTRIBUTING.md` (one pointer + one contributor note)
- 7 SKILLs: `dev-loop`, `pr-iteration`, `regression-handler`, `adapt-system`, `plan-keeper`, `github-sync`, `release-tracker` (one ambiguity bullet each)

## Review cycle

Local `skill-code-review` was run against a pre-push draft and flagged:

- 2 Critical: missing ambiguity bullets on `github-sync` + `release-tracker`; test regex duplicated instead of imported.
- 3 Important: validator regex accepting images; failure-message class prefixes; `adapt-system` bullet citing a non-existent "hand-authored flag".
- Several Minor.

All Critical + Important items addressed in this single commit (no separate review-round commits since the loop hadn't started). Local gate: validate PASS, lint 0, 306/306 tests pass.

## Test plan

- [ ] Merge. `tag-on-main` no-ops (no version bump).
- [ ] On a scratch repo, confirm a contributor who adds a new skill but forgets to update `bundle-index.md` sees a clear `orphan: skills/foo/SKILL.md is not linked from bundle-index.md` message.
- [ ] On a scratch repo, confirm a typo'd link in `bundle-index.md` produces a `dead-link: bundle-index.md -> foo/bar.md (file not found)` message.
- [ ] Spot-check a skill's ambiguity-halt bullet: simulate a precondition mismatch in `github-sync`; confirm the skill surfaces the templated message and makes no mutating call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)