### PR TITLE
feat(bootstrap): release umbrellas optional + branch-naming interview question

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,28 +58,19 @@ The agent targets four tracker kinds; today only GitHub is backed by real implem
 
 Real Jira / Linear / GitLab backends ship in follow-up releases. Today, the only **observed** (read-only) target kind the interview and runtime actually wire up is GitHub repos (for cross-repo lookups). The schema accepts observed Jira / Linear / GitLab entries, but every operation against them throws `NotSupportedError` because those backends are full stubs end-to-end: there's no path that reads from them either. Treat those kinds as "not implemented yet" full stop until the real backends land.
 
+## Release models the interview supports
+
+The interview's cadence question picks which umbrella rhythm fits your project:
+
+- **Per-wave / per-sprint** (the default; one umbrella per `intent` label value like `wave-1`, `wave-2`).
+- **Per-version** (`initial`, `v1`, `v2`, ...). Pick `per-version` in the cadence question.
+- **Continuous** (minimal: just `initial` and `post-launch`). Pick `continuous` in the cadence question.
+
+Teams that don't coordinate releases with umbrella issues (solo dev on tag-based continuous deploy, milestone-only workflows) answer `no` to the release-umbrella question in the interview. The agent omits `trackers.release` from the generated config; `release-tracker` halts silently and `dev-loop` skips the link-umbrella step.
+
 ## Things the interview does not ask (yet)
 
-A couple of things the bootstrap interview does NOT prompt for today, so you should know where the defaults come from and how to change them:
-
-- **Branch naming.** The agent uses these defaults for every project:
-
-  ```text
-  feat/{issue}-{slug}        refactor/{issue}-{slug}
-  fix/{issue}-{slug}         docs/{issue}-{slug}
-  chore/{issue}-{slug}
-  ```
-
-  `{issue}` is resolved per tracker kind (`123` on GitHub, `PROJ-123` on Jira, `TEAM-123` on Linear, `123` on GitLab). If you want a different convention (e.g. `meshin-dev/feat/widgets` or `release/2026-04`), ask the agent to run `adapt-system` with your intent, or edit `workflow.branch_patterns` in `ops.config.json` by hand.
-
-- **Release umbrellas are required in the schema today.** The interview asks you for `trackers.release`. If your team doesn't use umbrella issues for releases (e.g. you're a solo dev on a tag-based continuous deploy, or you use GitHub Milestones only), the closest workaround today is:
-  - Set `depth: "read-only"` on `trackers.release` so the release-tracker skill refuses to write anything there.
-  - Set `workflow.pr.link_release_umbrella: false` so dev-loop doesn't try to update umbrellas on PR open / close.
-
-  A cleaner "we don't use release umbrellas" toggle is planned for a follow-up release. The release models the interview-with-defaults is built for:
-  - **Per-wave / per-sprint** (the default; one umbrella per `intent` label value like `wave-1`, `wave-2`).
-  - **Per-version** (`initial`, `v1`, `v2`, ...). Pick `per-version` in the cadence question.
-  - **Continuous** (minimal: just `initial` and `post-launch`). Pick `continuous` in the cadence question.
+- **Workspace multi-repo dispatch.** The schema reserves `workspace.members[]` for projects where siblings dirs have their own git repos with different trackers, but the bootstrap interview does not yet prompt for members, and the dispatcher routes everything through the top-level `trackers.*`. A follow-up release wires the per-member lookup. If you need multi-repo support today, add the `workspace.members[]` block by hand after bootstrap.
 
 ## Quick start
 
@@ -95,7 +86,7 @@ Then in Claude Code, ask Claude to run the agent, for example:
 Run the agent-staff-engineer and help me set it up for this project.
 ```
 
-On first run, the agent detects that `.claude/ops.config.json` is missing and self-bootstraps: it runs its own installer, launches the interactive interview (eight topics covering release cadence, team size and push principals, e2e setup, which tracker hosts dev issues and release umbrellas (GitHub / Jira / Linear / GitLab) plus the target coordinates, additional repos to observe, observation depth, compliance context, optional project-specific rules to seed), writes `ops.config.json`, generates thin wrapper files at the canonical Claude Code locations, and hands control back.
+On first run, the agent detects that `.claude/ops.config.json` is missing and self-bootstraps: it runs its own installer, launches the interactive interview (nine topics covering release cadence, team size and push principals, e2e setup, which tracker hosts dev issues (GitHub / Jira / Linear / GitLab) plus the target coordinates, whether you coordinate releases with umbrella issues (and if so, which tracker hosts them), whether to customise branch naming, additional repos to observe, observation depth, compliance context, optional project-specific rules to seed), writes `ops.config.json`, generates thin wrapper files at the canonical Claude Code locations, and hands control back.
 
 On every later invocation the agent acts on your request directly, guided by the configured rules.
 

--- a/design/ARCHITECTURE.md
+++ b/design/ARCHITECTURE.md
@@ -75,8 +75,9 @@ Every layer only reads down. Skills read templates and rules. Scripts read the s
 Key groups:
 
 - `project`: name, org, repo, default_branch, principals.
-- `github.dev_projects[]`: owner, number, status_values, fields.
-- `github.release_projects[]`: same shape as dev_projects[].
+- `trackers.dev`: kind (github / jira / linear / gitlab) + kind-specific coordinates; when `kind` is github, includes `projects[]` with owner, number, status_values, fields.
+- `trackers.release` (optional; absent when the project opted out of release umbrellas): same shape as `trackers.dev` per kind.
+- `trackers.observed[]`: read-only targets for cross-repo lookups; each entry is its own per-kind target.
 - `labels`: type, area, priority, intent, size, automation, state_modifiers.
 - `workflow`: phase_term, branch_patterns, commits, pr, release.
 - `paths`: plans_root, plan_states, done_pattern, dev_working_dir (default `.development`) with three subtrees set by `dev_working_{shared,local,cache}_subdir` (defaults `shared`/`local`/`cache`; `local/` and `cache/` are gitignored by default, `shared/` commits), templates, reports (default `.development/shared/reports`), runbooks (default `.development/shared/runbooks`). No keys touch `daily/` or `knowledge/`.
@@ -567,17 +568,17 @@ Update never overwrites `ops.config.json`, project rules, below-marker wrapper c
 
 Content updates that do not change the set of canonical files (the common case) need no `install.mjs --update` run at all: `git pull` inside the bundle is sufficient, because wrappers reference in-bundle paths and pick up the new content on the next Claude session. Re-running `--update` becomes necessary only when (a) the bundle's canonical file set changes, (b) the schema grows required keys, or (c) the user wants the wrapper headers refreshed.
 
-## Multi-target GitHub observation
+## Multi-target tracker observation
 
-The agent reads and writes GitHub according to a list of observed targets declared in `ops.config.json`. Each entry carries a depth setting that controls what the agent is allowed to do there.
+The agent reads and writes trackers according to the targets declared in `ops.config.json` under `trackers.*`. Each target carries a `depth` setting that controls what the agent is allowed to do there; observed entries default to `read-only`.
 
 ```text
 +-------------------------+
 |   ops.config.json       |
-|   github:               |
-|     dev_projects: [...] |
-|     release_projects:   |
-|     observed_repos:     |
+|   trackers:             |
+|     dev: {kind, ...}    |
+|     release: {...} opt. |
+|     observed: [...]     |
 +------------+------------+
              |
              v

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -221,13 +221,13 @@
           "type": "object",
           "required": ["feature", "fix", "chore", "refactor", "docs"],
           "additionalProperties": false,
-          "description": "Branch name templates per type. Placeholders: {issue}, {slug}.",
+          "description": "Branch name templates per type. Placeholders: {issue}, {slug}. Both must appear; either order is accepted (e.g. 'feat/{issue}-{slug}' and 'feat/{slug}-{issue}' both validate).",
           "properties": {
-            "feature":  { "type": "string", "pattern": ".*\\{issue\\}.*\\{slug\\}.*" },
-            "fix":      { "type": "string", "pattern": ".*\\{issue\\}.*\\{slug\\}.*" },
-            "chore":    { "type": "string", "pattern": ".*\\{issue\\}.*\\{slug\\}.*" },
-            "refactor": { "type": "string", "pattern": ".*\\{issue\\}.*\\{slug\\}.*" },
-            "docs":     { "type": "string", "pattern": ".*\\{issue\\}.*\\{slug\\}.*" }
+            "feature":  { "type": "string", "pattern": "^(?=.*\\{issue\\})(?=.*\\{slug\\}).*$" },
+            "fix":      { "type": "string", "pattern": "^(?=.*\\{issue\\})(?=.*\\{slug\\}).*$" },
+            "chore":    { "type": "string", "pattern": "^(?=.*\\{issue\\})(?=.*\\{slug\\}).*$" },
+            "refactor": { "type": "string", "pattern": "^(?=.*\\{issue\\})(?=.*\\{slug\\}).*$" },
+            "docs":     { "type": "string", "pattern": "^(?=.*\\{issue\\})(?=.*\\{slug\\}).*$" }
           }
         },
         "commits": {

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -61,9 +61,9 @@
 
     "trackers": {
       "type": "object",
-      "required": ["dev", "release"],
+      "required": ["dev"],
       "additionalProperties": false,
-      "description": "Issue / PR / project trackers the agent operates against. `dev` hosts day-to-day issues and code review; `release` hosts release umbrellas; `observed` is a read-only array for cross-tracker lookups (e.g. during a migration or for shared libs on a different tracker). Each entry is a tracker target discriminated by the required `kind` field (github, jira, linear, gitlab).",
+      "description": "Issue / PR / project trackers the agent operates against. `dev` hosts day-to-day issues and code review; `release` hosts release umbrellas (optional; when absent, release-tracker is effectively disabled and `workflow.pr.link_release_umbrella` behaves as if false regardless of its setting); `observed` is a read-only array for cross-tracker lookups (e.g. during a migration or for shared libs on a different tracker). Each entry is a tracker target discriminated by the required `kind` field (github, jira, linear, gitlab). Teams who don't use umbrella issues for coordinating releases (solo / continuous deploy / milestone-based workflows) should omit `release` entirely.",
       "properties": {
         "dev": { "$ref": "#/definitions/trackerTarget" },
         "release": { "$ref": "#/definitions/trackerTarget" },
@@ -299,7 +299,7 @@
             },
             "link_release_umbrella": {
               "type": "boolean",
-              "description": "If true, the agent updates the linked release umbrella when a PR opens or closes.",
+              "description": "If true, the agent updates the linked release umbrella when a PR opens or closes. Effectively ignored (treated as false) when `trackers.release` is absent — the consumers (dev-loop, release-tracker) short-circuit on the missing tracker first.",
               "default": true
             },
             "update_plan_oneliner": {

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -638,8 +638,13 @@ export async function askNonEmpty(ask, question, defaultValue, humanLabel, optio
  * `{slug}` placeholders are present (the schema's pattern check enforces
  * this downstream; catching it at prompt time gives a better error).
  * Up to 3 attempts, then fall back to the default. The schema's
- * workflow.branch_patterns.<type> pattern is `.*\\{issue\\}.*\\{slug\\}.*`
- * so the two tokens can appear in any order with prefix / suffix text.
+ * workflow.branch_patterns.<type> pattern is
+ * `^(?=.*\\{issue\\})(?=.*\\{slug\\}).*$` so the two tokens can appear
+ * in EITHER order (`{issue}-{slug}` and `{slug}-{issue}` are both
+ * valid) with prefix / suffix text. This prompt check (using
+ * `includes` for each token separately) intentionally matches the
+ * schema's order-independent contract, so any pattern accepted here
+ * validates against the schema at compose time.
  */
 export async function askBranchPattern(ask, label, defaultValue) {
   const MAX_ATTEMPTS = 3;

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1152,11 +1152,13 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
     // trackers.release is omitted entirely when the user said "no" to
     // the release-umbrella question (a.releaseTracker is undefined).
     // The schema treats `release` as optional; consumers short-circuit
-    // on absence. Conditionally spread so the key is literally missing
-    // rather than set to undefined (which would fail strict schema).
+    // on absence. Gate on `=== undefined` (not truthiness) so bad
+    // inputs like null / 0 / "" still propagate through and fail
+    // schema validation downstream — silently dropping them would hide
+    // bugs in callers that construct an answers object programmatically.
     trackers: {
       dev: a.devTracker,
-      ...(a.releaseTracker ? { release: a.releaseTracker } : {}),
+      ...(a.releaseTracker === undefined ? {} : { release: a.releaseTracker }),
       observed: a.observed ?? [],
     },
     labels: {
@@ -1190,8 +1192,22 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
       //       remaining keys filled in from the canonical defaults,
       //       rather than a schema-invalid config missing required
       //       keys. The full key set is `required` on the schema, so
-      //       never letting partials through preserves that contract.
-      branch_patterns: { ...DEFAULT_BRANCH_PATTERNS, ...(a.branchPatterns ?? {}) },
+      //       never letting partials through preserves that contract;
+      //   (c) only schema-known keys survive. The schema declares
+      //       `additionalProperties: false` on workflow.branch_patterns,
+      //       so a caller with a typo ("fixes" instead of "fix") would
+      //       otherwise produce a schema-invalid config. Whitelist
+      //       against `DEFAULT_BRANCH_PATTERNS` (the single source of
+      //       truth for valid keys) so typos are silently dropped in
+      //       favour of the default rather than poisoning the output.
+      branch_patterns: {
+        ...DEFAULT_BRANCH_PATTERNS,
+        ...Object.fromEntries(
+          Object.entries(a.branchPatterns ?? {}).filter(
+            ([key]) => Object.prototype.hasOwnProperty.call(DEFAULT_BRANCH_PATTERNS, key),
+          ),
+        ),
+      },
       commits: {
         style: "conventional",
         signed: false,

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -633,6 +633,24 @@ export async function askNonEmpty(ask, question, defaultValue, humanLabel, optio
  * future tracker prompts (e.g. workspace-member trackers) get the same
  * normalisation + validation without copy-paste.
  */
+export async function askTrackerKind(ask, question, defaultValue) {
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const rawAnswer = await ask(question, defaultValue);
+    const normalised = String(rawAnswer ?? "").trim().toLowerCase();
+    if (SUPPORTED_TRACKER_KINDS.includes(normalised)) {
+      return normalised;
+    }
+    process.stderr.write(
+      `bootstrap: '${rawAnswer}' is not a supported tracker kind (got attempt ${attempt}/${MAX_ATTEMPTS}). ` +
+      `Expected one of: ${SUPPORTED_TRACKER_KINDS.join(", ")}.\n`,
+    );
+  }
+  throw new Error(
+    `bootstrap: could not obtain a valid tracker kind after ${MAX_ATTEMPTS} attempts; re-run and enter one of ${SUPPORTED_TRACKER_KINDS.join(", ")}`,
+  );
+}
+
 /**
  * Ask for a branch-pattern template, validate that both `{issue}` and
  * `{slug}` placeholders are present (the schema's pattern check enforces
@@ -668,24 +686,6 @@ export async function askBranchPattern(ask, label, defaultValue) {
     `bootstrap: could not obtain a valid ${label} after ${MAX_ATTEMPTS} attempts; keeping the default '${defaultValue}'.\n`,
   );
   return defaultValue;
-}
-
-export async function askTrackerKind(ask, question, defaultValue) {
-  const MAX_ATTEMPTS = 3;
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
-    const rawAnswer = await ask(question, defaultValue);
-    const normalised = String(rawAnswer ?? "").trim().toLowerCase();
-    if (SUPPORTED_TRACKER_KINDS.includes(normalised)) {
-      return normalised;
-    }
-    process.stderr.write(
-      `bootstrap: '${rawAnswer}' is not a supported tracker kind (got attempt ${attempt}/${MAX_ATTEMPTS}). ` +
-      `Expected one of: ${SUPPORTED_TRACKER_KINDS.join(", ")}.\n`,
-    );
-  }
-  throw new Error(
-    `bootstrap: could not obtain a valid tracker kind after ${MAX_ATTEMPTS} attempts; re-run and enter one of ${SUPPORTED_TRACKER_KINDS.join(", ")}`,
-  );
 }
 
 /**

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -456,7 +456,7 @@ async function interview(rl, d, _bundleRef) {
     return s.split(",").map((x) => x.trim()).filter(Boolean);
   };
 
-  process.stdout.write("interview (8 topics). Enter accepts the default shown in brackets.\n");
+  process.stdout.write("interview (9 topics). Enter accepts the default shown in brackets.\n");
   process.stdout.write("Note: on GitHub, only the review namespace is implemented today (used by skills/pr-iteration); issues / projects / labels namespaces are stubbed. Jira / Linear / GitLab backends accept the config but EVERY op (read or write) throws NotSupportedError until their real impls land.\n\n");
 
   const cadence = await ask(
@@ -486,15 +486,53 @@ async function interview(rl, d, _bundleRef) {
   );
   const devTracker = await askTrackerTarget(ask, devKind, "dev", d);
 
-  const releaseKind = await askTrackerKind(
-    ask,
-    "5. Tracker hosting release umbrellas: github / jira / linear / gitlab (default: same as dev)",
-    devKind,
+  // Release umbrellas are optional. Teams that don't use one coordinating
+  // issue per release (solo, continuous deploy, milestone-based workflows)
+  // skip this block entirely. The schema treats `trackers.release` as
+  // optional; consumer skills (release-tracker, dev-loop's link-umbrella
+  // step) short-circuit when it's absent.
+  const usesReleaseUmbrellas = await askYesNo(
+    "5. Do you use release-umbrella issues (one coordinating issue per release)? If unsure, say no; you can add this later via adapt-system",
+    "no"
   );
-  const releaseTracker = await askTrackerTarget(ask, releaseKind, "release", d, devTracker);
+  let releaseTracker;
+  if (usesReleaseUmbrellas) {
+    const releaseKind = await askTrackerKind(
+      ask,
+      "   Tracker hosting release umbrellas: github / jira / linear / gitlab (default: same as dev)",
+      devKind,
+    );
+    releaseTracker = await askTrackerTarget(ask, releaseKind, "release", d, devTracker);
+  }
+
+  // Branch naming. Defaults work for most projects and match conventional
+  // commit prefixes. A user who wants something different can customise
+  // per-type here, or later via adapt-system.
+  const DEFAULT_BRANCH_PATTERNS = {
+    feature: "feat/{issue}-{slug}",
+    fix: "fix/{issue}-{slug}",
+    chore: "chore/{issue}-{slug}",
+    refactor: "refactor/{issue}-{slug}",
+    docs: "docs/{issue}-{slug}",
+  };
+  const customiseBranchNaming = await askYesNo(
+    `6. Customise branch naming? Defaults: feat/{issue}-{slug}, fix/{issue}-{slug}, chore/{issue}-{slug}, refactor/{issue}-{slug}, docs/{issue}-{slug}. Placeholders {issue} and {slug} are required`,
+    "no"
+  );
+  let branchPatterns = DEFAULT_BRANCH_PATTERNS;
+  if (customiseBranchNaming) {
+    branchPatterns = {};
+    for (const type of ["feature", "fix", "chore", "refactor", "docs"]) {
+      branchPatterns[type] = await askBranchPattern(
+        ask,
+        `   ${type} branches`,
+        DEFAULT_BRANCH_PATTERNS[type],
+      );
+    }
+  }
 
   const observedReposStr = await ask(
-    "6. Additional observed GitHub repos (owner/name), comma-separated, blank for none",
+    "7. Additional observed GitHub repos (owner/name), comma-separated, blank for none",
     ""
   );
   const defaultDepth = await ask(
@@ -504,7 +542,7 @@ async function interview(rl, d, _bundleRef) {
   const observed = parseObservedGithubRepos(observedReposStr, defaultDepth);
 
   const regimes = await askCsv(
-    "7. Compliance regimes: gdpr,ccpa,soc2,pci,hipaa,mhmda,appi,pipa,lgpd or 'none'",
+    "8. Compliance regimes: gdpr,ccpa,soc2,pci,hipaa,mhmda,appi,pipa,lgpd or 'none'",
     "none"
   );
   const dataClasses = await askCsv(
@@ -512,7 +550,7 @@ async function interview(rl, d, _bundleRef) {
     "none"
   );
   const seedProductRules = await askYesNo(
-    "8. Seed any project-specific rules now? (you can add later via adapt-system)",
+    "9. Seed any project-specific rules now? (you can add later via adapt-system)",
     "no"
   );
 
@@ -525,6 +563,7 @@ async function interview(rl, d, _bundleRef) {
     e2ePath,
     devTracker,
     releaseTracker,
+    branchPatterns,
     observed,
     // defaultDepth lives as a local variable only: its single use is
     // parseObservedGithubRepos() above, which consumes it inline to
@@ -594,6 +633,38 @@ export async function askNonEmpty(ask, question, defaultValue, humanLabel, optio
  * future tracker prompts (e.g. workspace-member trackers) get the same
  * normalisation + validation without copy-paste.
  */
+/**
+ * Ask for a branch-pattern template, validate that both `{issue}` and
+ * `{slug}` placeholders are present (the schema's pattern check enforces
+ * this downstream; catching it at prompt time gives a better error).
+ * Up to 3 attempts, then fall back to the default. The schema's
+ * workflow.branch_patterns.<type> pattern is `.*\\{issue\\}.*\\{slug\\}.*`
+ * so the two tokens can appear in any order with prefix / suffix text.
+ */
+export async function askBranchPattern(ask, label, defaultValue) {
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    const raw = await ask(label, defaultValue);
+    const trimmed = String(raw ?? "").trim();
+    if (!trimmed) {
+      // Empty → accept the default silently; users who Enter through
+      // mean "keep the default".
+      return defaultValue;
+    }
+    if (trimmed.includes("{issue}") && trimmed.includes("{slug}")) {
+      return trimmed;
+    }
+    process.stderr.write(
+      `bootstrap: branch pattern '${trimmed}' is missing one of {issue} / {slug} (attempt ${attempt}/${MAX_ATTEMPTS}). ` +
+      `Example: 'feat/{issue}-{slug}'.\n`,
+    );
+  }
+  process.stderr.write(
+    `bootstrap: could not obtain a valid ${label} after ${MAX_ATTEMPTS} attempts; keeping the default '${defaultValue}'.\n`,
+  );
+  return defaultValue;
+}
+
 export async function askTrackerKind(ask, question, defaultValue) {
   const MAX_ATTEMPTS = 3;
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
@@ -880,6 +951,11 @@ export function pickDefaults(d) {
   const pushAllowed = [d.gh.login, "claude"].filter(Boolean);
   const reviewers = [d.gh.login, "copilot"].filter(Boolean);
   const devTracker = defaultTrackerTarget(kind, "dev", d);
+  // --yes installs keep the legacy "always emit a release tracker" shape
+  // so existing non-interactive pipelines don't break. Interactive
+  // users decide via the bootstrap interview question. Teams that want
+  // --yes to skip umbrellas can follow up with adapt-system or delete
+  // `trackers.release` by hand.
   const releaseTracker = defaultTrackerTarget(kind, "release", d);
   return {
     cadence: "per-wave",
@@ -890,6 +966,16 @@ export function pickDefaults(d) {
     e2ePath: "",
     devTracker,
     releaseTracker,
+    // Match the schema default so downstream compose() emits the same
+    // patterns it did before the interactive branch-naming question
+    // existed.
+    branchPatterns: {
+      feature: "feat/{issue}-{slug}",
+      fix: "fix/{issue}-{slug}",
+      chore: "chore/{issue}-{slug}",
+      refactor: "refactor/{issue}-{slug}",
+      docs: "docs/{issue}-{slug}",
+    },
     observed: [],
     regimes: ["none"],
     dataClasses: ["none"],
@@ -1040,9 +1126,14 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
         reviewers_default: a.reviewers,
       },
     },
+    // trackers.release is omitted entirely when the user said "no" to
+    // the release-umbrella question (a.releaseTracker is undefined).
+    // The schema treats `release` as optional; consumers short-circuit
+    // on absence. Conditionally spread so the key is literally missing
+    // rather than set to undefined (which would fail strict schema).
     trackers: {
       dev: a.devTracker,
-      release: a.releaseTracker,
+      ...(a.releaseTracker ? { release: a.releaseTracker } : {}),
       observed: a.observed ?? [],
     },
     labels: {
@@ -1067,7 +1158,11 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
     },
     workflow: {
       phase_term: a.cadence === "per-wave" ? "wave" : a.cadence === "per-version" ? "version" : "track",
-      branch_patterns: {
+      // Prefer the answers' branchPatterns (from the customise-yes path
+      // in the interview or from pickDefaults' default block); fall
+      // back to the conventional defaults if an older caller doesn't
+      // supply them.
+      branch_patterns: a.branchPatterns ?? {
         feature: "feat/{issue}-{slug}",
         fix: "fix/{issue}-{slug}",
         chore: "chore/{issue}-{slug}",
@@ -1087,7 +1182,12 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
         tests_required: ["unit", "integration"],
         e2e_required_on: a.e2eSetup === "none" ? [] : ["ux"],
         self_review_required: true,
-        link_release_umbrella: true,
+        // link_release_umbrella is set to true ONLY when the user
+        // configured a release tracker. When `a.releaseTracker` is
+        // undefined we emit false so downstream dev-loop's
+        // "update the linked umbrella" step never fires even if a
+        // future release-tracker appears in the config mid-session.
+        link_release_umbrella: Boolean(a.releaseTracker),
         update_plan_oneliner: true,
       },
       release: {

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -506,23 +506,17 @@ async function interview(rl, d, _bundleRef) {
   }
 
   // Branch naming. Defaults work for most projects and match conventional
-  // commit prefixes. A user who wants something different can customise
-  // per-type here, or later via adapt-system.
-  const DEFAULT_BRANCH_PATTERNS = {
-    feature: "feat/{issue}-{slug}",
-    fix: "fix/{issue}-{slug}",
-    chore: "chore/{issue}-{slug}",
-    refactor: "refactor/{issue}-{slug}",
-    docs: "docs/{issue}-{slug}",
-  };
+  // commit prefixes (see module-level DEFAULT_BRANCH_PATTERNS). A user
+  // who wants something different can customise per-type here, or
+  // later via adapt-system.
   const customiseBranchNaming = await askYesNo(
-    `6. Customise branch naming? Defaults: feat/{issue}-{slug}, fix/{issue}-{slug}, chore/{issue}-{slug}, refactor/{issue}-{slug}, docs/{issue}-{slug}. Placeholders {issue} and {slug} are required`,
+    `6. Customise branch naming? Defaults: ${Object.values(DEFAULT_BRANCH_PATTERNS).join(", ")}. Placeholders {issue} and {slug} are required`,
     "no"
   );
-  let branchPatterns = DEFAULT_BRANCH_PATTERNS;
+  let branchPatterns = { ...DEFAULT_BRANCH_PATTERNS };
   if (customiseBranchNaming) {
     branchPatterns = {};
-    for (const type of ["feature", "fix", "chore", "refactor", "docs"]) {
+    for (const type of Object.keys(DEFAULT_BRANCH_PATTERNS)) {
       branchPatterns[type] = await askBranchPattern(
         ask,
         `   ${type} branches`,
@@ -578,6 +572,34 @@ async function interview(rl, d, _bundleRef) {
 
 /** The tracker kinds askTrackerTarget() knows how to ask questions for. */
 export const SUPPORTED_TRACKER_KINDS = Object.freeze(["github", "jira", "linear", "gitlab"]);
+
+/**
+ * Canonical branch-pattern defaults for every workflow.branch_patterns.<type>.
+ * Single source of truth consumed in three places:
+ *   1. interview() shows these as the default in the "customise branch
+ *      naming?" question and as the per-type fallback when the user
+ *      chose yes but Enters through a row.
+ *   2. pickDefaults() emits this block in the non-interactive (--yes)
+ *      path so composed configs match what the interactive path would
+ *      produce when the user declines to customise.
+ *   3. compose() uses it as the `a.branchPatterns ?? ...` fallback for
+ *      older callers that don't populate `answers.branchPatterns`.
+ *
+ * Object.freeze + spreads at each consumer keep the constant
+ * immutable; consumers must `{ ...DEFAULT_BRANCH_PATTERNS }` if they
+ * need a mutable copy (e.g. interview's customise path builds the
+ * answers object incrementally).
+ *
+ * Exported so tests can assert on it directly rather than duplicating
+ * the literal in test fixtures.
+ */
+export const DEFAULT_BRANCH_PATTERNS = Object.freeze({
+  feature: "feat/{issue}-{slug}",
+  fix: "fix/{issue}-{slug}",
+  chore: "chore/{issue}-{slug}",
+  refactor: "refactor/{issue}-{slug}",
+  docs: "docs/{issue}-{slug}",
+});
 
 /**
  * Ask a prompt, normalise the answer (trim), optionally validate it
@@ -971,16 +993,12 @@ export function pickDefaults(d) {
     e2ePath: "",
     devTracker,
     releaseTracker,
-    // Match the schema default so downstream compose() emits the same
-    // patterns it did before the interactive branch-naming question
-    // existed.
-    branchPatterns: {
-      feature: "feat/{issue}-{slug}",
-      fix: "fix/{issue}-{slug}",
-      chore: "chore/{issue}-{slug}",
-      refactor: "refactor/{issue}-{slug}",
-      docs: "docs/{issue}-{slug}",
-    },
+    // Copy the canonical defaults so downstream compose() emits the
+    // same patterns it did before the interactive branch-naming
+    // question existed. Spread (vs referencing DEFAULT_BRANCH_PATTERNS
+    // directly) hands callers a mutable plain object, matching what
+    // the interactive path produces.
+    branchPatterns: { ...DEFAULT_BRANCH_PATTERNS },
     observed: [],
     regimes: ["none"],
     dataClasses: ["none"],
@@ -1165,15 +1183,10 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
       phase_term: a.cadence === "per-wave" ? "wave" : a.cadence === "per-version" ? "version" : "track",
       // Prefer the answers' branchPatterns (from the customise-yes path
       // in the interview or from pickDefaults' default block); fall
-      // back to the conventional defaults if an older caller doesn't
-      // supply them.
-      branch_patterns: a.branchPatterns ?? {
-        feature: "feat/{issue}-{slug}",
-        fix: "fix/{issue}-{slug}",
-        chore: "chore/{issue}-{slug}",
-        refactor: "refactor/{issue}-{slug}",
-        docs: "docs/{issue}-{slug}",
-      },
+      // back to the canonical DEFAULT_BRANCH_PATTERNS if an older
+      // caller doesn't supply them. Spread to hand compose's consumers
+      // a mutable plain object (matches the interactive path's shape).
+      branch_patterns: a.branchPatterns ?? { ...DEFAULT_BRANCH_PATTERNS },
       commits: {
         style: "conventional",
         signed: false,

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1181,12 +1181,17 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
     },
     workflow: {
       phase_term: a.cadence === "per-wave" ? "wave" : a.cadence === "per-version" ? "version" : "track",
-      // Prefer the answers' branchPatterns (from the customise-yes path
-      // in the interview or from pickDefaults' default block); fall
-      // back to the canonical DEFAULT_BRANCH_PATTERNS if an older
-      // caller doesn't supply them. Spread to hand compose's consumers
-      // a mutable plain object (matches the interactive path's shape).
-      branch_patterns: a.branchPatterns ?? { ...DEFAULT_BRANCH_PATTERNS },
+      // Merge DEFAULT_BRANCH_PATTERNS under a.branchPatterns so:
+      //   (a) the composed object is always a fresh mutable copy,
+      //       never a direct reference to answers or the frozen
+      //       module-level constant;
+      //   (b) callers that supply a PARTIAL branchPatterns (e.g. a
+      //       migration script that only overrides `feature`) get the
+      //       remaining keys filled in from the canonical defaults,
+      //       rather than a schema-invalid config missing required
+      //       keys. The full key set is `required` on the schema, so
+      //       never letting partials through preserves that contract.
+      branch_patterns: { ...DEFAULT_BRANCH_PATTERNS, ...(a.branchPatterns ?? {}) },
       commits: {
         style: "conventional",
         signed: false,

--- a/scripts/lib/trackers/dispatcher.mjs
+++ b/scripts/lib/trackers/dispatcher.mjs
@@ -81,6 +81,28 @@ export function pickReviewProvider(cfg) {
 }
 
 /**
+ * Cheap probe: does the config declare a release tracker? The `release`
+ * key is optional on `trackers:` — teams that don't use release
+ * umbrellas (solo / continuous deploy / milestone-based workflows)
+ * omit it and the release-tracker + dev-loop consumers short-circuit
+ * on absence. This helper lets callers check the presence without
+ * having to catch pickTracker's "missing trackers.release" throw.
+ *
+ * @param {object} cfg parsed ops.config.json
+ * @returns {boolean} true if `trackers.release` is a non-null object with a `kind`.
+ */
+export function hasReleaseTracker(cfg) {
+  const target = cfg?.trackers?.release;
+  return (
+    Boolean(target) &&
+    typeof target === "object" &&
+    !Array.isArray(target) &&
+    typeof target.kind === "string" &&
+    target.kind.length > 0
+  );
+}
+
+/**
  * Return the tracker kind for the named role without constructing a
  * Tracker. Used by callers that only need the kind string (logging,
  * branch naming, skill routing decisions). Performs the same config

--- a/skills/bootstrap-ops-config/SKILL.md
+++ b/skills/bootstrap-ops-config/SKILL.md
@@ -57,7 +57,7 @@ Turns a fresh clone into a configured target. Two-phase: silent detection, then 
 
 - **gh not authed**: print `gh auth login` guidance with the required scopes (`repo, project, read:org, workflow`) and halt.
 - **No git remote**: halt with a clear message; ask the user to configure the remote first.
-- **Zero GitHub Projects discovered**: the interview still runs; the skill records an empty `dev_projects` and `release_projects` and warns that skills needing those lists will halt until the user points at real projects.
+- **Zero GitHub Projects discovered**: the interview still runs; the skill records empty `trackers.dev.projects[]` and (when the user opted into release umbrellas) `trackers.release.projects[]`, and warns that skills needing those lists will halt until the user points at real projects.
 - **Schema validation fails after user confirmation**: halt and surface the failing path. Do not write a malformed config.
 - **User declines to answer a required topic**: halt; the skill refuses to write a config with unresolved required keys.
 
@@ -76,12 +76,12 @@ Running `bootstrap-ops-config` on a project that already has a valid `ops.config
 Reads (via the schema):
 
 - `schemas/ops.config.schema.json` to validate its own output.
-- Writes every top-level key of `ops.config.json`: `project`, `github`, `labels`, `workflow`, `paths`, `stack`, `area_keywords`, `compliance`.
+- Writes every top-level key of `ops.config.json`: `project`, `trackers`, `labels`, `workflow`, `paths`, `stack`, `area_keywords`, `compliance`.
 
 Specific keys the interview asks the user about:
 
 - `project.name`, `project.org`, `project.repo`, `project.default_branch`, `project.principals.push_allowed`, `project.principals.reviewers_default`
-- `github.auth_login`, `github.dev_projects[]`, `github.release_projects[]`, `github.observed_repos[]`
+- `trackers.dev` (kind + kind-specific coordinates + projects/fields when GitHub), `trackers.release` (optional; omitted entirely when the user declines the release-umbrella question), `trackers.observed[]`
 - `labels.type`, `labels.area`, `labels.priority`, `labels.intent`, `labels.size`, `labels.automation`, `labels.state_modifiers`
 - `workflow.phase_term`, `workflow.pr.e2e_required_on`, `workflow.release.umbrella_title`, `workflow.code_review.provider`
 - `paths.plans_root`, `paths.dev_working_dir`, `paths.reports`, `paths.runbooks`, `paths.templates`

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -138,7 +138,7 @@ The ctxr-skill-code-review default is the recommended path. Projects opt out via
 ## Project contract
 
 - `project.default_branch`, `project.principals.push_allowed`, `project.principals.reviewers_default`.
-- `github.dev_projects[]` (needs depth that allows writes for the chosen target).
+- `trackers.dev` (needs `depth` that allows writes for the chosen target; project bindings live under `trackers.dev.projects[]` when `kind` is GitHub).
 - `labels.type`, `labels.area`, `labels.priority`, `labels.size`, `labels.state_modifiers`.
 - `workflow.branch_patterns.*`.
 - `workflow.commits.style`, `workflow.commits.signed`, `workflow.commits.scope_source`.

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -31,7 +31,7 @@ Hard rule baked in: **the dev-loop never merges a PR and never sets a dev issue 
 - A self-review artefact under `workflow.code_review.report_dir` (default `.development/shared/reports/`).
 - An open PR rendered from `templates/pr.md` with `workflow.pr.link_issue_with` referencing the issue.
 - The dev issue updated to `In review` (via `tracker-sync`).
-- Linked Release umbrella updated (via `release-tracker` triggered by `tracker-sync`). This step is skipped entirely when the project opted out of release umbrellas (`trackers.release` absent from `ops.config.json`): the `release-tracker` skill halts silently per its own `do_not_trigger_on` contract, and `workflow.pr.link_release_umbrella` is treated as false regardless of its configured value.
+- Linked Release umbrella updated (via `release-tracker` triggered by `tracker-sync`). This step is skipped entirely when the project opted out of release umbrellas (`trackers.release` absent from `.claude/ops.config.json`): the `release-tracker` skill halts silently per its own `do_not_trigger_on` contract, and `workflow.pr.link_release_umbrella` is treated as false regardless of its configured value.
 - Plan one-liner updated (via `plan-keeper`) when `workflow.pr.update_plan_oneliner` is true.
 
 ## State machine

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -31,7 +31,7 @@ Hard rule baked in: **the dev-loop never merges a PR and never sets a dev issue 
 - A self-review artefact under `workflow.code_review.report_dir` (default `.development/shared/reports/`).
 - An open PR rendered from `templates/pr.md` with `workflow.pr.link_issue_with` referencing the issue.
 - The dev issue updated to `In review` (via `tracker-sync`).
-- Linked Release umbrella updated (via `release-tracker` triggered by `tracker-sync`).
+- Linked Release umbrella updated (via `release-tracker` triggered by `tracker-sync`). This step is skipped entirely when the project opted out of release umbrellas (`trackers.release` absent from `ops.config.json`): the `release-tracker` skill halts silently per its own `do_not_trigger_on` contract, and `workflow.pr.link_release_umbrella` is treated as false regardless of its configured value.
 - Plan one-liner updated (via `plan-keeper`) when `workflow.pr.update_plan_oneliner` is true.
 
 ## State machine
@@ -67,7 +67,9 @@ Hard rule baked in: **the dev-loop never merges a PR and never sets a dev issue 
 [tracker-sync: review.requestReview per project.principals.reviewers_default]
 [tracker-sync: issues.updateIssueStatus -> In review]
 [plan-keeper: flip plan one-liner to [x]]
-[release-tracker: recompute linked umbrella status]
+[release-tracker: recompute linked umbrella status]   (skipped when
+                                                       trackers.release
+                                                       is absent)
       |
       v
 [hand off to skills/pr-iteration]

--- a/skills/regression-handler/SKILL.md
+++ b/skills/regression-handler/SKILL.md
@@ -80,7 +80,7 @@ Running `regression-handler` twice on the same input produces the same report an
 ## Project contract
 
 - `project.name`, `project.repo`.
-- `github.dev_projects[]`, `github.release_projects[]`, `github.observed_repos[]` (to scope the lookup).
+- `trackers.dev.projects[]` (when `kind` is GitHub), `trackers.release.projects[]` (optional; absent when the project opted out of release umbrellas), `trackers.observed[]` (each with its own kind + coordinates): all scope the lookup.
 - `labels.type` (picks `bug`), `labels.priority`, `labels.area`, `labels.automation` (applies `auto-regression` when present).
 - `labels.state_modifiers` (to mark the report with blocked/deferred where relevant).
 - `area_keywords` (primary lookup input).

--- a/skills/release-tracker/SKILL.md
+++ b/skills/release-tracker/SKILL.md
@@ -9,6 +9,7 @@ trigger_on:
 do_not_trigger_on:
   - Release projects whose `depth` is `read-only`.
   - Projects with zero release_projects configured.
+  - The project opted out of release umbrellas entirely (`trackers.release` absent from ops.config.json). The skill halts silently, neither reporting nor writing; any caller that invoked it explicitly receives a no-op result.
   - The recompute would flip an umbrella to Done while one or more linked dev issues are reopened OR their relation to the umbrella was broken between fetch and write. Follow `rules/ambiguity-halt.md` (halt, surface the mismatch and the specific issue numbers, ask whether to exclude, re-link, or wait); do not flip the umbrella status or mutate the body while the question is open.
 writes_to_github: yes, via tracker-sync, only on release umbrellas
 writes_to_filesystem: no

--- a/skills/release-tracker/SKILL.md
+++ b/skills/release-tracker/SKILL.md
@@ -8,7 +8,7 @@ trigger_on:
   - After adapt-system changes the intent label taxonomy (new or removed intent values).
 do_not_trigger_on:
   - Release projects whose `depth` is `read-only`.
-  - Projects with zero release_projects configured.
+  - Projects with zero entries in `trackers.release.projects[]`.
   - The project opted out of release umbrellas entirely (`trackers.release` absent from `.claude/ops.config.json`). The skill halts silently, neither reporting nor writing; any caller that invoked it explicitly receives a no-op result.
   - The recompute would flip an umbrella to Done while one or more linked dev issues are reopened OR their relation to the umbrella was broken between fetch and write. Follow `rules/ambiguity-halt.md` (halt, surface the mismatch and the specific issue numbers, ask whether to exclude, re-link, or wait); do not flip the umbrella status or mutate the body while the question is open.
 writes_to_github: yes, via tracker-sync, only on release umbrellas
@@ -42,7 +42,7 @@ Owns release umbrella state. Never touches dev issues. Never moves a dev issue t
 For each umbrella:
 
 ```text
-linked = issues linked to the umbrella via the release project's "Linked Dev Issues" relation
+linked = issues linked to the umbrella via the release tracker's "Linked Dev Issues" relation
          or carrying the umbrella's intent label
 
 statuses = { backlog, ready, in_progress, in_review, done } counts across linked
@@ -66,8 +66,8 @@ A recompute against the same underlying state is a no-op write (the skill compar
 ## Guardrails
 
 - Refuses to move any dev issue. The skill's surface has no "update dev status" entry point.
-- Refuses to touch umbrellas in a `depth: read-only` release_project.
-- `depth: umbrella-only` is the natural fit for release projects; the skill works correctly under `full` or `umbrella-only`.
+- Refuses to touch umbrellas when `trackers.release.depth` is `read-only`.
+- `depth: umbrella-only` is the natural fit for release trackers; the skill works correctly under `full` or `umbrella-only`.
 
 ## Failure modes
 
@@ -83,13 +83,13 @@ A recompute against the same underlying state is a no-op write (the skill compar
 
 ## Release umbrella creation
 
-Umbrellas are created by `tracker-sync.create_release_umbrella` when a new `labels.intent` value exists without a corresponding umbrella on any configured `release_project`. Title template from `workflow.release.umbrella_title`. `release-tracker` verifies one umbrella exists per intent value and asks `tracker-sync` to create missing ones on approval.
+Umbrellas are created by `tracker-sync.create_release_umbrella` when a new `labels.intent` value exists without a corresponding umbrella on any configured `trackers.release.projects[]` entry. Title template from `workflow.release.umbrella_title`. `release-tracker` verifies one umbrella exists per intent value and asks `tracker-sync` to create missing ones on approval.
 
 ## Project contract
 
 - `project.name` (for summary printing).
-- `github.release_projects[]` (owner, number, role, depth, status_field, status_values, fields).
-- `github.dev_projects[]` (only to read linked-issue statuses).
+- `trackers.release` (optional; per-kind target with its own `projects[]` when `kind` is GitHub: `{owner, number, role, depth, status_field, status_values, fields}`). Skill halts silently when absent.
+- `trackers.dev.projects[]` (only to read linked-issue statuses).
 - `labels.intent` (one umbrella per value).
 - `labels.state_modifiers` (to compute blocker count).
 - `workflow.release.umbrella_title`.

--- a/skills/release-tracker/SKILL.md
+++ b/skills/release-tracker/SKILL.md
@@ -9,7 +9,7 @@ trigger_on:
 do_not_trigger_on:
   - Release projects whose `depth` is `read-only`.
   - Projects with zero release_projects configured.
-  - The project opted out of release umbrellas entirely (`trackers.release` absent from ops.config.json). The skill halts silently, neither reporting nor writing; any caller that invoked it explicitly receives a no-op result.
+  - The project opted out of release umbrellas entirely (`trackers.release` absent from `.claude/ops.config.json`). The skill halts silently, neither reporting nor writing; any caller that invoked it explicitly receives a no-op result.
   - The recompute would flip an umbrella to Done while one or more linked dev issues are reopened OR their relation to the umbrella was broken between fetch and write. Follow `rules/ambiguity-halt.md` (halt, surface the mismatch and the specific issue numbers, ask whether to exclude, re-link, or wait); do not flip the umbrella status or mutate the body while the question is open.
 writes_to_github: yes, via tracker-sync, only on release umbrellas
 writes_to_filesystem: no

--- a/templates/issue-release.md
+++ b/templates/issue-release.md
@@ -7,7 +7,7 @@ ops.config keys read:
   - labels.intent                  (this umbrella represents one intent value)
   - workflow.phase_term
   - workflow.release.umbrella_title
-  - github.release_projects[].fields   (e.g. "Target Date", "Scope Tag", "Linked Dev Issues")
+  - trackers.release.projects[].fields   (e.g. "Target Date", "Scope Tag", "Linked Dev Issues")
 scalar placeholders:
   {{ project.name }}
   {{ intent_label_pretty }}        e.g. "Wave 1" derived from intent label "wave-1"

--- a/templates/iteration-summary.md
+++ b/templates/iteration-summary.md
@@ -6,7 +6,7 @@ stored at: {{ paths.reports }}/{{ iteration_end_date }}-iteration-{{ iteration_s
 ops.config keys read:
   - project.name
   - workflow.phase_term
-  - github.dev_projects
+  - trackers.dev.projects
   - paths.reports
   - labels.intent
   - labels.area

--- a/templates/regression-report.md
+++ b/templates/regression-report.md
@@ -9,8 +9,8 @@ ops.config keys read:
   - labels.priority
   - labels.automation           (applies auto-regression label)
   - area_keywords
-  - github.dev_projects
-  - github.observed_repos
+  - trackers.dev.projects
+  - trackers.observed
 scalar placeholders:
   {{ date }}
   {{ bug_issue_number }}

--- a/templates/release-readiness-checklist.md
+++ b/templates/release-readiness-checklist.md
@@ -9,7 +9,7 @@ ops.config keys read:
   - workflow.pr.e2e_required_on
   - workflow.pr.tests_required
   - labels.intent
-  - github.release_projects
+  - trackers.release.projects
   - paths.reports
 scalar placeholders:
   {{ date }}

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -9,6 +9,7 @@ import {
   defaultTrackerTarget,
   canAutoPopulate,
   isOnPath,
+  askBranchPattern,
   askTrackerKind,
   askTrackerTarget,
   SUPPORTED_TRACKER_KINDS,
@@ -701,6 +702,58 @@ describe("bootstrap.pickDefaults", () => {
   });
 });
 
+describe("bootstrap.askBranchPattern", () => {
+  // Minimal ask stub: drains a queue, returns each answer once.
+  const makeAsk = (answers) => {
+    const queue = [...answers];
+    return async () => {
+      if (queue.length === 0) throw new Error("ask stub exhausted");
+      return queue.shift();
+    };
+  };
+
+  it("returns the default when the user presses Enter", async () => {
+    const out = await askBranchPattern(makeAsk([""]), "feature", "feat/{issue}-{slug}");
+    assert.equal(out, "feat/{issue}-{slug}");
+  });
+
+  it("returns the user's custom pattern when both {issue} and {slug} are present", async () => {
+    const out = await askBranchPattern(
+      makeAsk(["{issue}/feature-{slug}"]),
+      "feature",
+      "feat/{issue}-{slug}",
+    );
+    assert.equal(out, "{issue}/feature-{slug}");
+  });
+
+  it("re-prompts on missing {issue} placeholder", async () => {
+    const out = await askBranchPattern(
+      makeAsk(["feat/{slug}", "feat/{issue}-{slug}"]),
+      "feature",
+      "feat/{issue}-{slug}",
+    );
+    assert.equal(out, "feat/{issue}-{slug}");
+  });
+
+  it("re-prompts on missing {slug} placeholder", async () => {
+    const out = await askBranchPattern(
+      makeAsk(["feat/{issue}", "release/{issue}-{slug}"]),
+      "feature",
+      "feat/{issue}-{slug}",
+    );
+    assert.equal(out, "release/{issue}-{slug}");
+  });
+
+  it("falls back to the default after 3 invalid attempts (does not throw)", async () => {
+    const out = await askBranchPattern(
+      makeAsk(["bad1", "bad2", "bad3"]),
+      "feature",
+      "feat/{issue}-{slug}",
+    );
+    assert.equal(out, "feat/{issue}-{slug}");
+  });
+});
+
 describe("bootstrap.compose", () => {
   const detection = {
     git: { remote: "git@github.com:acme/foo.git", defaultBranch: "main", ownerRepo: "acme/foo" },
@@ -821,5 +874,74 @@ describe("bootstrap.compose", () => {
       const msg = JSON.stringify(v.errors ?? []);
       assert.match(msg, /depth/, `error should mention 'depth' for role=${role}; got: ${msg}`);
     }
+  });
+
+  // PR 7: release umbrellas are now opt-in. When the user says "no" in
+  // the interview (the default), compose() must omit `trackers.release`
+  // entirely rather than emit an undefined value or an empty object.
+  // The consumer contract (release-tracker SKILL.md do_not_trigger_on,
+  // dev-loop's link-umbrella step) keys on the key being absent.
+  it("omits trackers.release when answers.releaseTracker is undefined", () => {
+    const answersNoRelease = { ...answers, releaseTracker: undefined };
+    const cfg = compose(detection, answersNoRelease, ".claude/agents/agent-staff-engineer");
+    assert.equal("release" in cfg.trackers, false, "trackers.release must be absent, not undefined");
+    assert.equal(cfg.trackers.dev.kind, "github", "dev tracker still composed");
+    assert.deepEqual(cfg.trackers.observed, [], "observed still composed as empty array");
+  });
+
+  // PR 7: when the release tracker is opted out, the PR-creation step
+  // must not try to link an umbrella either, even if a stale
+  // link_release_umbrella=true survived. Lock the contract that compose
+  // sets this to Boolean(a.releaseTracker), not the prior hard-coded
+  // true.
+  it("sets link_release_umbrella=false when answers.releaseTracker is undefined", () => {
+    const answersNoRelease = { ...answers, releaseTracker: undefined };
+    const cfg = compose(detection, answersNoRelease, ".claude/agents/agent-staff-engineer");
+    assert.equal(cfg.workflow.pr.link_release_umbrella, false);
+  });
+
+  it("keeps link_release_umbrella=true when answers.releaseTracker is present", () => {
+    const cfg = compose(detection, answers, ".claude/agents/agent-staff-engineer");
+    assert.equal(cfg.workflow.pr.link_release_umbrella, true);
+  });
+
+  // PR 7: schema now marks trackers.release as optional. A composed
+  // config without it must still validate end-to-end. Catches any
+  // future schema re-tightening that forgets to flip the `required`
+  // array back.
+  it("schema accepts a composed config without trackers.release", async () => {
+    const schema = await loadSchemaOnce();
+    const { validate } = await import("../scripts/lib/schema.mjs");
+    const answersNoRelease = { ...answers, releaseTracker: undefined };
+    const cfg = compose(detection, answersNoRelease, ".claude/agents/agent-staff-engineer");
+    const v = validate(schema, cfg);
+    assert.ok(v.ok, `composed config without release failed schema: ${JSON.stringify(v.errors ?? null)}`);
+  });
+
+  // PR 7: branch naming is interview-customisable. compose() must
+  // carry the answers' branchPatterns through when supplied, and fall
+  // back to the conventional defaults when absent (older callers that
+  // don't populate it).
+  it("uses answers.branchPatterns verbatim when provided", () => {
+    const custom = {
+      feature: "features/{issue}-{slug}",
+      fix: "fixes/{issue}-{slug}",
+      chore: "chores/{issue}-{slug}",
+      refactor: "refactors/{issue}-{slug}",
+      docs: "docs/{issue}-{slug}",
+    };
+    const answersCustom = { ...answers, branchPatterns: custom };
+    const cfg = compose(detection, answersCustom, ".claude/agents/agent-staff-engineer");
+    assert.deepEqual(cfg.workflow.branch_patterns, custom);
+  });
+
+  it("falls back to the conventional branch defaults when answers.branchPatterns is absent", () => {
+    const { branchPatterns: _omit, ...answersMinusBranch } = answers;
+    const cfg = compose(detection, answersMinusBranch, ".claude/agents/agent-staff-engineer");
+    assert.equal(cfg.workflow.branch_patterns.feature, "feat/{issue}-{slug}");
+    assert.equal(cfg.workflow.branch_patterns.fix, "fix/{issue}-{slug}");
+    assert.equal(cfg.workflow.branch_patterns.chore, "chore/{issue}-{slug}");
+    assert.equal(cfg.workflow.branch_patterns.refactor, "refactor/{issue}-{slug}");
+    assert.equal(cfg.workflow.branch_patterns.docs, "docs/{issue}-{slug}");
   });
 });

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -944,4 +944,37 @@ describe("bootstrap.compose", () => {
     assert.equal(cfg.workflow.branch_patterns.refactor, "refactor/{issue}-{slug}");
     assert.equal(cfg.workflow.branch_patterns.docs, "docs/{issue}-{slug}");
   });
+
+  // PR 7 R1 (Copilot): askBranchPattern used `includes` for each token
+  // separately, accepting {slug}-{issue} order; but the schema's old
+  // pattern `.*\{issue\}.*\{slug\}.*` required {issue} first, so the
+  // prompt could pass inputs that later failed schema. Schema was
+  // loosened to accept either order. Lock the contract: both orders
+  // validate; missing-either-token still fails.
+  it("schema accepts {slug} before {issue} in branch patterns (either order OK)", async () => {
+    const schema = await loadSchemaOnce();
+    const { validate } = await import("../scripts/lib/schema.mjs");
+    const cfg = composeFresh();
+    cfg.workflow.branch_patterns.feature = "feat/{slug}-{issue}";
+    const v = validate(schema, cfg);
+    assert.ok(v.ok, `{slug}-{issue} order must validate: ${JSON.stringify(v.errors ?? null)}`);
+  });
+
+  it("schema still rejects a branch pattern missing {issue}", async () => {
+    const schema = await loadSchemaOnce();
+    const { validate } = await import("../scripts/lib/schema.mjs");
+    const cfg = composeFresh();
+    cfg.workflow.branch_patterns.feature = "feat/{slug}-only";
+    const v = validate(schema, cfg);
+    assert.equal(v.ok, false, "missing {issue} must fail schema validation");
+  });
+
+  it("schema still rejects a branch pattern missing {slug}", async () => {
+    const schema = await loadSchemaOnce();
+    const { validate } = await import("../scripts/lib/schema.mjs");
+    const cfg = composeFresh();
+    cfg.workflow.branch_patterns.feature = "feat/{issue}-only";
+    const v = validate(schema, cfg);
+    assert.equal(v.ok, false, "missing {slug} must fail schema validation");
+  });
 });

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -1003,4 +1003,43 @@ describe("bootstrap.compose", () => {
     const v = validate(schema, cfg);
     assert.equal(v.ok, false, "missing {slug} must fail schema validation");
   });
+
+  // PR 7 R5 (Copilot): compose whitelists branchPatterns keys against
+  // DEFAULT_BRANCH_PATTERNS because the schema declares
+  // `additionalProperties: false` on workflow.branch_patterns. A typo
+  // like "fixes" instead of "fix" would otherwise propagate and
+  // produce a schema-invalid config. Lock the drop-unknown-keys
+  // behaviour so a future rewrite doesn't silently undo it.
+  it("compose drops unknown branchPatterns keys (schema has additionalProperties: false)", async () => {
+    const schema = await loadSchemaOnce();
+    const { validate } = await import("../scripts/lib/schema.mjs");
+    const polluted = {
+      feature: "feat/{issue}-{slug}",
+      fix: "fix/{issue}-{slug}",
+      chore: "chore/{issue}-{slug}",
+      refactor: "refactor/{issue}-{slug}",
+      docs: "docs/{issue}-{slug}",
+      fixes: "fixes/{issue}-{slug}",           // typo; must be dropped
+      releaseBranch: "release/{slug}",          // extra key; must be dropped
+    };
+    const cfg = compose(detection, { ...answers, branchPatterns: polluted }, ".claude/agents/agent-staff-engineer");
+    assert.equal("fixes" in cfg.workflow.branch_patterns, false, "unknown 'fixes' key must be dropped");
+    assert.equal("releaseBranch" in cfg.workflow.branch_patterns, false, "unknown 'releaseBranch' key must be dropped");
+    assert.equal(cfg.workflow.branch_patterns.fix, "fix/{issue}-{slug}", "valid keys survive");
+    assert.ok(validate(schema, cfg).ok, "composed config with dropped unknown keys must validate");
+  });
+
+  // PR 7 R5 (Copilot): trackers.release is gated on `=== undefined`,
+  // not truthiness. Bad inputs (null / 0 / "") must propagate so
+  // downstream schema validation surfaces them instead of silently
+  // omitting the key (which would produce a "valid" config despite
+  // the bad caller input).
+  it("compose propagates null releaseTracker to fail schema (not silently omit)", async () => {
+    const schema = await loadSchemaOnce();
+    const { validate } = await import("../scripts/lib/schema.mjs");
+    const cfg = compose(detection, { ...answers, releaseTracker: null }, ".claude/agents/agent-staff-engineer");
+    assert.equal("release" in cfg.trackers, true, "null releaseTracker must still produce a release key");
+    assert.equal(cfg.trackers.release, null, "null passes through verbatim");
+    assert.equal(validate(schema, cfg).ok, false, "null release must fail schema validation");
+  });
 });

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -945,6 +945,32 @@ describe("bootstrap.compose", () => {
     assert.equal(cfg.workflow.branch_patterns.docs, "docs/{issue}-{slug}");
   });
 
+  // PR 7 R4 (Copilot): compose now merges partial answers.branchPatterns
+  // UNDER DEFAULT_BRANCH_PATTERNS so callers (e.g. migration scripts
+  // that only override a subset) always produce a schema-valid config
+  // with every required key populated. Lock the merge semantics:
+  // user-supplied keys win, unset keys come from defaults.
+  it("merges partial answers.branchPatterns over defaults", () => {
+    const partial = { feature: "features/{issue}-{slug}" };
+    const cfg = compose(detection, { ...answers, branchPatterns: partial }, ".claude/agents/agent-staff-engineer");
+    assert.equal(cfg.workflow.branch_patterns.feature, "features/{issue}-{slug}", "user override wins");
+    assert.equal(cfg.workflow.branch_patterns.fix, "fix/{issue}-{slug}", "unset key filled from defaults");
+    assert.equal(cfg.workflow.branch_patterns.chore, "chore/{issue}-{slug}");
+    assert.equal(cfg.workflow.branch_patterns.refactor, "refactor/{issue}-{slug}");
+    assert.equal(cfg.workflow.branch_patterns.docs, "docs/{issue}-{slug}");
+  });
+
+  // Composed branch_patterns must ALWAYS be a fresh object — never a
+  // direct reference to the frozen DEFAULT_BRANCH_PATTERNS or to
+  // answers.branchPatterns. Mutating the composed result must not
+  // back-propagate into the source.
+  it("composed branch_patterns is a fresh object (mutation does not leak to answers)", () => {
+    const custom = { feature: "features/{issue}-{slug}", fix: "fix/{issue}-{slug}", chore: "chore/{issue}-{slug}", refactor: "refactor/{issue}-{slug}", docs: "docs/{issue}-{slug}" };
+    const cfg = compose(detection, { ...answers, branchPatterns: custom }, ".claude/agents/agent-staff-engineer");
+    cfg.workflow.branch_patterns.feature = "MUTATED";
+    assert.equal(custom.feature, "features/{issue}-{slug}", "answers.branchPatterns must not be mutated");
+  });
+
   // PR 7 R1 (Copilot): askBranchPattern used `includes` for each token
   // separately, accepting {slug}-{issue} order; but the schema's old
   // pattern `.*\{issue\}.*\{slug\}.*` required {issue} first, so the

--- a/tests/trackers_dispatcher.test.mjs
+++ b/tests/trackers_dispatcher.test.mjs
@@ -9,6 +9,7 @@ import {
   pickTracker,
   pickReviewProvider,
   resolveTrackerKind,
+  hasReleaseTracker,
 } from "../scripts/lib/trackers/dispatcher.mjs";
 import {
   NotSupportedError,
@@ -147,5 +148,48 @@ describe("resolveTrackerKind", () => {
 
   it("propagates pickTracker's errors on malformed config", () => {
     assert.throws(() => resolveTrackerKind({}, "dev"), /trackers\.dev/);
+  });
+});
+
+// PR 7 R3 (Copilot): hasReleaseTracker is the new cheap probe consumers
+// use to short-circuit on the "team opted out of release umbrellas"
+// path without having to catch pickTracker's "missing trackers.release"
+// throw. Lock the probe semantics: true only for a non-null object with
+// a non-empty string `kind`; everything else (missing, null, array,
+// primitive, empty kind) is false. This prevents regressions where a
+// future change loosens the check and consumers unintentionally try to
+// construct a tracker from a garbage value.
+describe("hasReleaseTracker", () => {
+  it("returns true when trackers.release is a valid kind-discriminator object", () => {
+    assert.equal(hasReleaseTracker(GITHUB_DEV), true);
+    assert.equal(hasReleaseTracker(JIRA_DEV), true);
+  });
+
+  it("returns false when trackers.release is absent", () => {
+    assert.equal(hasReleaseTracker({ trackers: { dev: { kind: "github" } } }), false);
+  });
+
+  it("returns false when trackers block itself is missing", () => {
+    assert.equal(hasReleaseTracker({}), false);
+    assert.equal(hasReleaseTracker({ project: {} }), false);
+  });
+
+  it("returns false when cfg is null or undefined", () => {
+    assert.equal(hasReleaseTracker(null), false);
+    assert.equal(hasReleaseTracker(undefined), false);
+  });
+
+  it("returns false when trackers.release is null", () => {
+    assert.equal(hasReleaseTracker({ trackers: { release: null } }), false);
+  });
+
+  it("returns false when trackers.release is an array (not a plain object)", () => {
+    assert.equal(hasReleaseTracker({ trackers: { release: [{ kind: "github" }] } }), false);
+  });
+
+  it("returns false when trackers.release has no `kind` string", () => {
+    assert.equal(hasReleaseTracker({ trackers: { release: {} } }), false);
+    assert.equal(hasReleaseTracker({ trackers: { release: { kind: "" } } }), false);
+    assert.equal(hasReleaseTracker({ trackers: { release: { kind: 42 } } }), false);
   });
 });


### PR DESCRIPTION
## Summary

- **Release umbrellas opt-out.** `trackers.release` is now optional in the schema. Teams that don't coordinate releases with umbrella issues (solo dev on tag-based continuous deploy, milestone-only workflows) answer `no` in the interview and the agent omits the whole block from the composed config. `release-tracker` halts silently when invoked; `dev-loop` skips the link-umbrella step.
- **Branch-naming interview question.** New yes/no prompt in the bootstrap interview. If the user says yes, they supply per-type patterns (feature / fix / chore / refactor / docs); a new `askBranchPattern` helper validates that both `{issue}` and `{slug}` placeholders are present, retries up to 3 times on invalid input, and falls back to the default without throwing.
- Interview grows from 8 to 9 topics.
- `compose()` uses conditional spread for `trackers.release` so the key is literally absent when omitted (not set to undefined). `link_release_umbrella` derives from `Boolean(a.releaseTracker)`.
- New `hasReleaseTracker(cfg)` dispatcher probe for callers that want to check presence without catching the pickTracker throw.

## Files changed

- `schemas/ops.config.schema.json` — `trackers.release` moved from `required` to optional; description extended.
- `scripts/bootstrap.mjs` — new Q5 (release umbrellas yes/no) + Q6 (branch naming yes/no) + `askBranchPattern` helper; `compose()` uses conditional spread and `Boolean(a.releaseTracker)`; `pickDefaults()` emits branchPatterns.
- `scripts/lib/trackers/dispatcher.mjs` — new `hasReleaseTracker(cfg)` probe.
- `skills/release-tracker/SKILL.md` — new `do_not_trigger_on` entry describing the silent-halt behaviour.
- `skills/dev-loop/SKILL.md` — state-machine diagram annotated with the skip.
- `tests/bootstrap.test.mjs` — 6 new compose() tests + 5 new `askBranchPattern` tests.
- `README.md` — removed now-closed "Branch naming" and "Release umbrellas" items from "Things the interview does not ask (yet)"; moved release-model docs up; interview topic count updated.

## Test plan

- [x] `npm test` — 401 tests pass (6 new compose + 5 new askBranchPattern)
- [x] `npm run validate` — PASS
- [x] `npm run lint` — 0 errors
- [ ] Copilot review on this PR; iterate to clean terminal state

## Plan reference

`/Users/developer/.claude/plans/can-we-make-the-binary-emerson.md` PR 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)