### PR TITLE
feat(trackers,bootstrap): workspace multi-repo dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Then in Claude Code, ask Claude to run the agent, for example:
 Run the agent-staff-engineer and help me set it up for this project.
 ```
 
-On first run, the agent detects that `.claude/ops.config.json` is missing and self-bootstraps: it runs its own installer, launches the interactive interview (nine topics covering release cadence, team size and push principals, e2e setup, which tracker hosts dev issues (GitHub / Jira / Linear / GitLab) plus the target coordinates, whether you coordinate releases with umbrella issues (and if so, which tracker hosts them), whether to customise branch naming, additional repos to observe, observation depth, compliance context, optional project-specific rules to seed), writes `ops.config.json`, generates thin wrapper files at the canonical Claude Code locations, and hands control back.
+On first run, the agent detects that `.claude/ops.config.json` is missing and self-bootstraps: it runs its own installer, launches the interactive interview (ten topics covering release cadence, team size and push principals, e2e setup, which tracker hosts dev issues (GitHub / Jira / Linear / GitLab) plus the target coordinates, whether you coordinate releases with umbrella issues (and if so, which tracker hosts them), whether to customise branch naming, whether this is a multi-repo workspace (and if so, each member's path + tracker binding), additional repos to observe, observation depth, compliance context, optional project-specific rules to seed), writes `ops.config.json`, generates thin wrapper files at the canonical Claude Code locations, and hands control back.
 
 On every later invocation the agent acts on your request directly, guided by the configured rules.
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ The interview's cadence question picks which umbrella rhythm fits your project:
 
 Teams that don't coordinate releases with umbrella issues (solo dev on tag-based continuous deploy, milestone-only workflows) answer `no` to the release-umbrella question in the interview. The agent omits `trackers.release` from the generated config; `release-tracker` halts silently and `dev-loop` skips the link-umbrella step.
 
-## Things the interview does not ask (yet)
+## Multi-repo workspaces
 
-- **Workspace multi-repo dispatch.** The schema reserves `workspace.members[]` for projects where siblings dirs have their own git repos with different trackers, but the bootstrap interview does not yet prompt for members, and the dispatcher routes everything through the top-level `trackers.*`. A follow-up release wires the per-member lookup. If you need multi-repo support today, add the `workspace.members[]` block by hand after bootstrap.
+For projects where sibling directories have their own git repos and possibly different trackers (e.g., a Jira-tracked library next to a GitHub-tracked app), the interview asks you to declare each member: project-relative path, short name, and its own dev tracker (plus optional release tracker). The runtime dispatcher (`pickTrackerForMember` / `resolveMemberFromPath`) routes each operation through the owning member deepest-first: a file under `libs/shared/x.ts` resolves to the `libs/shared` member; files outside any nested member fall back to the root. Single-repo projects answer `no` and keep the single-tracker path with zero config overhead.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Teams that don't coordinate releases with umbrella issues (solo dev on tag-based
 
 ## Multi-repo workspaces
 
-For projects where sibling directories have their own git repos and possibly different trackers (e.g., a Jira-tracked library next to a GitHub-tracked app), the interview asks you to declare each member: project-relative path, short name, and its own dev tracker (plus optional release tracker). The runtime dispatcher (`pickTrackerForMember` / `resolveMemberFromPath`) routes each operation through the owning member deepest-first: a file under `libs/shared/x.ts` resolves to the `libs/shared` member; files outside any nested member fall back to the root. Single-repo projects answer `no` and keep the single-tracker path with zero config overhead.
+For projects where sibling directories have their own git repos and possibly different trackers (e.g., a Jira-tracked library next to a GitHub-tracked app), the interview asks you to declare each member: project-relative path, short name, and its own dev tracker (plus optional release tracker). The runtime dispatcher (`pickTrackerForMember` / `resolveMemberFromPath`) routes each operation through the owning member deepest-first: a file under `libs/shared/x.ts` resolves to the `libs/shared` member. For files that don't match any nested member, include an explicit member with path `.` in `workspace.members[]` to catch them as the root; without one, unmatched files fall back to the top-level `trackers.dev` instead. Single-repo projects answer `no` and keep the single-tracker path with zero config overhead.
 
 ## Quick start
 

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -3,7 +3,7 @@
 // Interactive interview backing the bootstrap-ops-config skill.
 // Two phases:
 //   1) Detection (silent reads): git, gh, codebase heuristics.
-//   2) Interview (8 topics): user input wins over heuristics when they conflict.
+//   2) Interview (10 topics): user input wins over heuristics when they conflict.
 // Produces:
 //   <target>/.claude/ops.config.json
 //   <target>/.claude/.bootstrap-answers.json

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -456,7 +456,7 @@ async function interview(rl, d, _bundleRef) {
     return s.split(",").map((x) => x.trim()).filter(Boolean);
   };
 
-  process.stdout.write("interview (9 topics). Enter accepts the default shown in brackets.\n");
+  process.stdout.write("interview (10 topics). Enter accepts the default shown in brackets.\n");
   process.stdout.write("Note: on GitHub, only the review namespace is implemented today (used by skills/pr-iteration); issues / projects / labels namespaces are stubbed. Jira / Linear / GitLab backends accept the config but EVERY op (read or write) throws NotSupportedError until their real impls land.\n\n");
 
   const cadence = await ask(
@@ -525,8 +525,24 @@ async function interview(rl, d, _bundleRef) {
     }
   }
 
+  // Multi-repo workspace. Most projects live in a single repo and
+  // answer "no"; teams with sibling directories that each have their
+  // own git origin + tracker (mid-migration monorepos, toolchain
+  // workspaces, Jira-tracked lib next to a GitHub-tracked app) say
+  // yes and bind per-member trackers. Runtime dispatch for these
+  // members is in `scripts/lib/trackers/dispatcher.mjs` via
+  // `pickTrackerForMember` and `resolveMemberFromPath`.
+  const hasWorkspace = await askYesNo(
+    "7. Multi-repo workspace? Say yes if sibling directories in this project have their OWN git origins with possibly-different trackers (e.g. a Jira-tracked library next to a GitHub-tracked app). Most projects are single-repo and say no",
+    "no"
+  );
+  let workspace;
+  if (hasWorkspace) {
+    workspace = await interviewWorkspaceMembers(ask, askYesNo, d);
+  }
+
   const observedReposStr = await ask(
-    "7. Additional observed GitHub repos (owner/name), comma-separated, blank for none",
+    "8. Additional observed GitHub repos (owner/name), comma-separated, blank for none",
     ""
   );
   const defaultDepth = await ask(
@@ -536,7 +552,7 @@ async function interview(rl, d, _bundleRef) {
   const observed = parseObservedGithubRepos(observedReposStr, defaultDepth);
 
   const regimes = await askCsv(
-    "8. Compliance regimes: gdpr,ccpa,soc2,pci,hipaa,mhmda,appi,pipa,lgpd or 'none'",
+    "9. Compliance regimes: gdpr,ccpa,soc2,pci,hipaa,mhmda,appi,pipa,lgpd or 'none'",
     "none"
   );
   const dataClasses = await askCsv(
@@ -544,7 +560,7 @@ async function interview(rl, d, _bundleRef) {
     "none"
   );
   const seedProductRules = await askYesNo(
-    "9. Seed any project-specific rules now? (you can add later via adapt-system)",
+    "10. Seed any project-specific rules now? (you can add later via adapt-system)",
     "no"
   );
 
@@ -558,6 +574,7 @@ async function interview(rl, d, _bundleRef) {
     devTracker,
     releaseTracker,
     branchPatterns,
+    workspace,
     observed,
     // defaultDepth lives as a local variable only: its single use is
     // parseObservedGithubRepos() above, which consumes it inline to
@@ -708,6 +725,61 @@ export async function askBranchPattern(ask, label, defaultValue) {
     `bootstrap: could not obtain a valid ${label} after ${MAX_ATTEMPTS} attempts; keeping the default '${defaultValue}'.\n`,
   );
   return defaultValue;
+}
+
+/**
+ * Interview loop for `workspace.members[]`. Called only when the user
+ * answered "yes" to the multi-repo workspace question. Collects one
+ * member per iteration until the user enters an empty path. Each
+ * member gets a `path`, `name`, and its own tracker binding(s).
+ *
+ * The returned object matches the schema's `workspace` block shape
+ * exactly: `{ members: [{ path, name, trackers: { dev, release? } }] }`.
+ * Returns `undefined` when the user bailed before providing a single
+ * valid member (treat as "actually no workspace" and drop the block).
+ *
+ * Exported so tests can exercise the loop in isolation without
+ * driving the full `interview()` run.
+ */
+export async function interviewWorkspaceMembers(ask, askYesNo, d) {
+  const members = [];
+  process.stdout.write(
+    "   Enter workspace members one at a time. Blank path ends the loop.\n"
+    + "   Each member needs a path (project-relative, use '.' for the primary repo),\n"
+    + "   a short name, and its own dev tracker.\n"
+  );
+  for (let idx = 1; idx <= 16; idx += 1) {
+    const path = (await ask(`   member ${idx} path (blank to finish)`, "")).trim();
+    if (!path) break;
+    const name = await askNonEmpty(
+      ask,
+      `   member ${idx} name`,
+      path === "." ? "primary" : path.split("/").pop(),
+      "member name",
+    );
+    const devKind = await askTrackerKind(
+      ask,
+      `   member ${idx} dev tracker kind: github / jira / linear / gitlab`,
+      "github",
+    );
+    const devTracker = await askTrackerTarget(ask, devKind, "dev", d);
+    const memberTrackers = { dev: devTracker };
+    const hasRelease = await askYesNo(
+      `   member ${idx} also binds its own release tracker? (most members say no)`,
+      "no",
+    );
+    if (hasRelease) {
+      const releaseKind = await askTrackerKind(
+        ask,
+        `   member ${idx} release tracker kind (default: same as dev)`,
+        devKind,
+      );
+      memberTrackers.release = await askTrackerTarget(ask, releaseKind, "release", d, devTracker);
+    }
+    members.push({ path, name, trackers: memberTrackers });
+  }
+  if (members.length === 0) return undefined;
+  return { members };
 }
 
 /**
@@ -999,6 +1071,11 @@ export function pickDefaults(d) {
     // directly) hands callers a mutable plain object, matching what
     // the interactive path produces.
     branchPatterns: { ...DEFAULT_BRANCH_PATTERNS },
+    // --yes installs default to single-repo (no workspace block).
+    // Interactive users answer the multi-repo question and populate
+    // members explicitly; teams that need this on --yes can follow up
+    // with adapt-system or hand-edit `workspace.members[]`.
+    workspace: undefined,
     observed: [],
     regimes: ["none"],
     dataClasses: ["none"],
@@ -1161,6 +1238,13 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
       ...(a.releaseTracker === undefined ? {} : { release: a.releaseTracker }),
       observed: a.observed ?? [],
     },
+    // workspace is optional. Emitted only when the user said "yes" to
+    // the multi-repo question AND provided at least one member
+    // (interviewWorkspaceMembers returns undefined when the user
+    // bailed without adding any). Gate on `=== undefined` (not
+    // truthiness) so bad inputs surface via schema validation instead
+    // of silently dropping the block.
+    ...(a.workspace === undefined ? {} : { workspace: a.workspace }),
     labels: {
       type: ["feature", "bug", "task", "refactor", "docs", "chore"],
       area: [

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -775,9 +775,12 @@ export async function interviewWorkspaceMembers(ask, askYesNo, d) {
       }
     }
     if (path === null) break;
-    // Members must have distinct names too, since `pickTrackerForMember`
-    // does a first-match lookup on the name. Reject duplicates with up
-    // to 3 retries; fall back to the loop-exit on exhausting retries.
+    // Members must have distinct names too. Runtime dispatch is keyed
+    // by member name and `pickTrackerForMember` hard-refuses on
+    // duplicate matches (after PR 8 R5), so catching duplicates here
+    // at prompt time gives users a clean error rather than a
+    // dispatch-time throw on some later invocation. Up to 3 retries;
+    // fall back to the loop-exit on exhausting retries.
     let name = null;
     for (let attempt = 1; attempt <= 3; attempt += 1) {
       const candidate = await askNonEmpty(

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -754,26 +754,46 @@ export async function interviewWorkspaceMembers(ask, askYesNo, d) {
     // Validate the member path at prompt time so users catch typos
     // (absolute paths, parent-traversal, Windows backslashes that
     // would never match POSIX diff input) before the config is
-    // written. Up to 3 attempts; if the user can't produce a
-    // valid path, break the loop rather than hang the interview.
+    // written. Also reject duplicate member paths (post-normalisation):
+    // two members with the same canonical path make resolveMemberFromPath
+    // ambiguous (first-match semantics). Up to 3 attempts; if the user
+    // can't produce a valid path, break the loop rather than hang the
+    // interview.
     for (let attempt = 1; attempt <= 3; attempt += 1) {
       const raw = (await ask(`   member ${idx} path (blank to finish)`, "")).trim();
       if (!raw) { path = null; break; }
       try {
         // allowRoot so members can bind to the project root via "."
-        path = normaliseMemberPath(raw, `member ${idx} path`, { allowRoot: true });
+        const candidate = normaliseMemberPath(raw, `member ${idx} path`, { allowRoot: true });
+        if (members.some((m) => m.path === candidate)) {
+          throw new Error(`member ${idx} path '${candidate}' duplicates an earlier member`);
+        }
+        path = candidate;
         break;
       } catch (e) {
-        process.stderr.write(`${e.message} (attempt ${attempt}/3). Use project-relative POSIX paths like 'libs/shared' or '.' for the root repo.\n`);
+        process.stderr.write(`${e.message} (attempt ${attempt}/3). Use project-relative POSIX paths like 'libs/shared' or '.' for the root repo; each path must be unique.\n`);
       }
     }
     if (path === null) break;
-    const name = await askNonEmpty(
-      ask,
-      `   member ${idx} name`,
-      path === "." ? "primary" : path.split("/").pop(),
-      "member name",
-    );
+    // Members must have distinct names too, since `pickTrackerForMember`
+    // does a first-match lookup on the name. Reject duplicates with up
+    // to 3 retries; fall back to the loop-exit on exhausting retries.
+    let name = null;
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const candidate = await askNonEmpty(
+        ask,
+        `   member ${idx} name`,
+        path === "." ? "primary" : path.split("/").pop(),
+        "member name",
+      );
+      if (members.some((m) => m.name === candidate)) {
+        process.stderr.write(`member ${idx} name '${candidate}' duplicates an earlier member (attempt ${attempt}/3). Pick a different name.\n`);
+        continue;
+      }
+      name = candidate;
+      break;
+    }
+    if (name === null) break;
     const devKind = await askTrackerKind(
       ask,
       `   member ${idx} dev tracker kind: github / jira / linear / gitlab`,

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -29,6 +29,7 @@ import {
   safeRealpathOrExit,
 } from "./lib/fsx.mjs";
 import { ghExec, ghAuthReady } from "./lib/ghExec.mjs";
+import { normaliseMemberPath } from "./lib/trackers/dispatcher.mjs";
 import { validate } from "./lib/schema.mjs";
 import { diffLines } from "./lib/diff.mjs";
 
@@ -749,8 +750,24 @@ export async function interviewWorkspaceMembers(ask, askYesNo, d) {
     + "   a short name, and its own dev tracker.\n"
   );
   for (let idx = 1; idx <= 16; idx += 1) {
-    const path = (await ask(`   member ${idx} path (blank to finish)`, "")).trim();
-    if (!path) break;
+    let path = null;
+    // Validate the member path at prompt time so users catch typos
+    // (absolute paths, parent-traversal, Windows backslashes that
+    // would never match POSIX diff input) before the config is
+    // written. Up to 3 attempts; if the user can't produce a
+    // valid path, break the loop rather than hang the interview.
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const raw = (await ask(`   member ${idx} path (blank to finish)`, "")).trim();
+      if (!raw) { path = null; break; }
+      try {
+        // allowRoot so members can bind to the project root via "."
+        path = normaliseMemberPath(raw, `member ${idx} path`, { allowRoot: true });
+        break;
+      } catch (e) {
+        process.stderr.write(`${e.message} (attempt ${attempt}/3). Use project-relative POSIX paths like 'libs/shared' or '.' for the root repo.\n`);
+      }
+    }
+    if (path === null) break;
     const name = await askNonEmpty(
       ask,
       `   member ${idx} name`,

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -783,12 +783,23 @@ export async function interviewWorkspaceMembers(ask, askYesNo, d) {
     // fall back to the loop-exit on exhausting retries.
     let name = null;
     for (let attempt = 1; attempt <= 3; attempt += 1) {
-      const candidate = await askNonEmpty(
-        ask,
-        `   member ${idx} name`,
-        path === "." ? "primary" : path.split("/").pop(),
-        "member name",
-      );
+      let candidate;
+      try {
+        candidate = await askNonEmpty(
+          ask,
+          `   member ${idx} name`,
+          path === "." ? "primary" : path.split("/").pop(),
+          "member name",
+        );
+      } catch (e) {
+        // askNonEmpty throws after its own internal 3-attempt cap
+        // on empty/whitespace answers. Don't let that abort the
+        // entire bootstrap run; surface the cause and fall through
+        // to the loop-exit the same way a duplicate-exhausted
+        // retry does (name stays null, outer break fires below).
+        process.stderr.write(`${e.message} Ending workspace-member collection.\n`);
+        break;
+      }
       if (members.some((m) => m.name === candidate)) {
         process.stderr.write(`member ${idx} name '${candidate}' duplicates an earlier member (attempt ${attempt}/3). Pick a different name.\n`);
         continue;

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -362,7 +362,15 @@ if (opsConfig.wiki?.required) {
 if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.length > 0) {
   const missing = [];
   const invalid = [];
-  for (const member of opsConfig.workspace.members) {
+  // Duplicate-detection maps: a hand-edited config can bypass
+  // bootstrap's prompt-time rejection and reintroduce duplicates
+  // that make runtime dispatch ambiguous. Track both names and
+  // canonicalised paths so a second occurrence can flag both
+  // originals without having to re-scan the array.
+  const seenNames = new Map();
+  const seenPaths = new Map();
+  for (let memberIdx = 0; memberIdx < opsConfig.workspace.members.length; memberIdx += 1) {
+    const member = opsConfig.workspace.members[memberIdx];
     if (!member || typeof member.path !== "string") continue;
     // Run member.path through the canonical normaliser so absolute
     // paths, Windows drive prefixes, and `..` traversal are rejected
@@ -375,6 +383,35 @@ if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.l
     } catch (e) {
       invalid.push({ name: member.name ?? "<unnamed>", path: member.path, reason: e.message });
       continue;
+    }
+    // Duplicate-path check (post-normalisation so `libs/shared`
+    // and `./libs/shared/` are caught as duplicates of each other).
+    // Hand-edited configs can reintroduce duplicates that bootstrap
+    // rejects at prompt time; runtime dispatch would first-match
+    // and silently route through the wrong member.
+    if (seenPaths.has(normalisedRel)) {
+      const firstIdx = seenPaths.get(normalisedRel);
+      invalid.push({
+        name: member.name ?? "<unnamed>",
+        path: member.path,
+        reason: `path normalises to '${normalisedRel}' which duplicates members[${firstIdx}]; every workspace member must have a unique canonical path`,
+      });
+      continue;
+    }
+    seenPaths.set(normalisedRel, memberIdx);
+    // Duplicate-name check. Same rationale as path: first-match
+    // dispatch would silently pick whichever entry came first.
+    if (typeof member.name === "string" && member.name.length > 0) {
+      if (seenNames.has(member.name)) {
+        const firstIdx = seenNames.get(member.name);
+        invalid.push({
+          name: member.name,
+          path: member.path,
+          reason: `name '${member.name}' duplicates members[${firstIdx}]; every workspace member must have a unique name`,
+        });
+        continue;
+      }
+      seenNames.set(member.name, memberIdx);
     }
     // After normalisation, resolve under TARGET. Defence-in-depth:
     // recompute the absolute path with `resolve` and assert it

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -437,20 +437,34 @@ if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.l
       continue;
     }
     seenPaths.set(normalisedRel, memberIdx);
+    // Validate member.name BEFORE the duplicate check. A
+    // missing/empty/non-string name is a schema violation the
+    // schema would catch, but install.mjs does not re-validate an
+    // existing ops.config.json, so a hand-edit that strips a name
+    // would otherwise be silently skipped by both
+    // resolveMemberFromPath (guards on `typeof m.name === "string"`)
+    // and pickTrackerForMember (looks up by name equality). Fail
+    // preflight with a pointed error instead.
+    if (typeof member.name !== "string" || member.name.length === 0) {
+      invalid.push({
+        name: member.name ?? "<unnamed>",
+        path: member.path,
+        reason: `workspace.members[${memberIdx}].name must be a non-empty string`,
+      });
+      continue;
+    }
     // Duplicate-name check. Same rationale as path: first-match
     // dispatch would silently pick whichever entry came first.
-    if (typeof member.name === "string" && member.name.length > 0) {
-      if (seenNames.has(member.name)) {
-        const firstIdx = seenNames.get(member.name);
-        invalid.push({
-          name: member.name,
-          path: member.path,
-          reason: `name '${member.name}' duplicates members[${firstIdx}]; every workspace member must have a unique name`,
-        });
-        continue;
-      }
-      seenNames.set(member.name, memberIdx);
+    if (seenNames.has(member.name)) {
+      const firstIdx = seenNames.get(member.name);
+      invalid.push({
+        name: member.name,
+        path: member.path,
+        reason: `name '${member.name}' duplicates members[${firstIdx}]; every workspace member must have a unique name`,
+      });
+      continue;
     }
+    seenNames.set(member.name, memberIdx);
     // After normalisation, resolve under TARGET. Defence-in-depth:
     // recompute the absolute path with `resolve` and assert it
     // stays under TARGET. Use `path.relative` for the containment

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -437,7 +437,7 @@ if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.l
       continue;
     }
     seenPaths.set(normalisedRel, memberIdx);
-    // Validate member.name BEFORE the duplicate check. A
+    // Validate member.name BEFORE the duplicate-name check. A
     // missing/empty/non-string name is a schema violation the
     // schema would catch, but install.mjs does not re-validate an
     // existing ops.config.json, so a hand-edit that strips a name

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -369,9 +369,47 @@ if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.l
   // originals without having to re-scan the array.
   const seenNames = new Map();
   const seenPaths = new Map();
+  // Compute TARGET's realpath once up front rather than per member.
+  // Besides saving syscalls, this also means any error reporting
+  // the user sees about TARGET (e.g. "TARGET realpath failed") is
+  // identical across members. A realpath failure on TARGET aborts
+  // the preflight entirely since every subsequent containment check
+  // would have no safe baseline to compare against.
+  const resolvedTargetOnce = resolve(TARGET);
+  let realTargetOnce;
+  try {
+    realTargetOnce = realpathSync(resolvedTargetOnce);
+  } catch (e) {
+    process.stderr.write(
+      `\nERROR: cannot realpath install TARGET '${resolvedTargetOnce}': ${e?.message ?? e}. Fix the target path or re-run with --target pointing at an accessible directory.\n`,
+    );
+    process.exit(1);
+  }
   for (let memberIdx = 0; memberIdx < opsConfig.workspace.members.length; memberIdx += 1) {
     const member = opsConfig.workspace.members[memberIdx];
-    if (!member || typeof member.path !== "string") continue;
+    // Malformed entries (null, non-object, or missing/non-string
+    // path) would otherwise silently skip the validation phase and
+    // land at dispatch time as a vague "not a tracker" throw. Treat
+    // them as invalid up-front with a pointed message so the user
+    // sees exactly which index is broken. install.mjs does not
+    // schema-validate an existing ops.config.json, so this is the
+    // only guard against a bad hand-edit slipping through.
+    if (!member || typeof member !== "object" || Array.isArray(member)) {
+      invalid.push({
+        name: "<missing>",
+        path: "<missing>",
+        reason: `workspace.members[${memberIdx}] is not an object (got ${member === null ? "null" : Array.isArray(member) ? "array" : typeof member})`,
+      });
+      continue;
+    }
+    if (typeof member.path !== "string" || member.path.length === 0) {
+      invalid.push({
+        name: member.name ?? "<unnamed>",
+        path: typeof member.path === "string" ? member.path : `<${typeof member.path}>`,
+        reason: `workspace.members[${memberIdx}].path must be a non-empty string`,
+      });
+      continue;
+    }
     // Run member.path through the canonical normaliser so absolute
     // paths, Windows drive prefixes, and `..` traversal are rejected
     // up front. `join(TARGET, absPath)` would let an absolute path
@@ -423,16 +461,18 @@ if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.l
     // valid multi-repo install. Cross-platform rule: the relative
     // path from resolvedTarget to absolute must be either empty
     // (same dir) OR not absolute AND not start with a ".." segment.
+    // Reuse the hoisted `resolvedTargetOnce` instead of re-computing
+    // `resolve(TARGET)` per member; the value is constant over the
+    // loop so the redundant syscalls were pure overhead.
     const absolute = resolve(TARGET, normalisedRel);
-    const resolvedTarget = resolve(TARGET);
-    const rel = relative(resolvedTarget, absolute);
+    const rel = relative(resolvedTargetOnce, absolute);
     const escapes =
       isAbsolute(rel) || rel === ".." || rel.startsWith(`..${sep}`) || rel.startsWith("../");
     if (escapes) {
       invalid.push({
         name: member.name ?? "<unnamed>",
         path: member.path,
-        reason: `resolved path '${absolute}' escapes target '${resolvedTarget}'`,
+        reason: `resolved path '${absolute}' escapes target '${resolvedTargetOnce}'`,
       });
       continue;
     }
@@ -468,17 +508,16 @@ if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.l
     // catches 'libs/../..' and absolute paths, but a symlink at the
     // resolved location can still point outside TARGET. Resolve the
     // actual filesystem location via realpath and re-check
-    // containment on the real paths. The resolvedTarget side is
-    // realpath'd up front so a TARGET that itself sits behind a
-    // symlink (common on macOS: /var is a symlink to /private/var)
-    // is compared apples-to-apples. realpath failures are treated
+    // containment on the real paths. `realTargetOnce` was computed
+    // before the loop (TARGET itself may sit behind a symlink, as
+    // on macOS where /var -> /private/var, so the comparison has to
+    // happen apples-to-apples) so only the member's realpath is
+    // computed per iteration. Member realpath failures are treated
     // as "cannot verify safety" and surface as invalid rather than
     // silently trusting the lexical check.
     let realAbs;
-    let realTarget;
     try {
       realAbs = realpathSync(absolute);
-      realTarget = realpathSync(resolvedTarget);
     } catch (e) {
       invalid.push({
         name: member.name ?? "<unnamed>",
@@ -487,14 +526,14 @@ if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.l
       });
       continue;
     }
-    const realRel = relative(realTarget, realAbs);
+    const realRel = relative(realTargetOnce, realAbs);
     const realEscapes =
       isAbsolute(realRel) || realRel === ".." || realRel.startsWith(`..${sep}`) || realRel.startsWith("../");
     if (realEscapes) {
       invalid.push({
         name: member.name ?? "<unnamed>",
         path: member.path,
-        reason: `member path resolves to '${realAbs}' which is outside '${realTarget}' (symlink escape)`,
+        reason: `member path resolves to '${realAbs}' which is outside '${realTargetOnce}' (symlink escape)`,
       });
     }
   }

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -32,7 +32,7 @@
 import { readFile, readdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
 import { stdin as processStdin, stdout as processStdout } from "node:process";
@@ -369,20 +369,29 @@ if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.l
     // up front. `join(TARGET, absPath)` would let an absolute path
     // silently escape TARGET and check a location outside the
     // project; the normaliser catches that before it can happen.
-    let relative;
+    let normalisedRel;
     try {
-      relative = normaliseMemberPath(member.path, `workspace member '${member.name ?? "<unnamed>"}' path`, { allowRoot: true });
+      normalisedRel = normaliseMemberPath(member.path, `workspace member '${member.name ?? "<unnamed>"}' path`, { allowRoot: true });
     } catch (e) {
       invalid.push({ name: member.name ?? "<unnamed>", path: member.path, reason: e.message });
       continue;
     }
     // After normalisation, resolve under TARGET. Defence-in-depth:
     // recompute the absolute path with `resolve` and assert it
-    // stays under TARGET. A mid-normaliser bug or a clever
-    // symlink would otherwise get through the first check.
-    const absolute = resolve(TARGET, relative);
+    // stays under TARGET. Use `path.relative` for the containment
+    // check rather than string-prefix-with-"/" because the latter
+    // is POSIX-specific; on Windows `resolve` returns
+    // backslash-separated paths, so a "/" prefix check would
+    // always report escape for non-root members and block every
+    // valid multi-repo install. Cross-platform rule: the relative
+    // path from resolvedTarget to absolute must be either empty
+    // (same dir) OR not absolute AND not start with a ".." segment.
+    const absolute = resolve(TARGET, normalisedRel);
     const resolvedTarget = resolve(TARGET);
-    if (absolute !== resolvedTarget && !absolute.startsWith(resolvedTarget + "/")) {
+    const rel = relative(resolvedTarget, absolute);
+    const escapes =
+      isAbsolute(rel) || rel === ".." || rel.startsWith(`..${sep}`) || rel.startsWith("../");
+    if (escapes) {
       invalid.push({
         name: member.name ?? "<unnamed>",
         path: member.path,

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -30,7 +30,7 @@
 //
 
 import { readFile, readdir, rm } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -401,6 +401,30 @@ if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.l
     }
     if (!existsSync(absolute)) {
       missing.push({ name: member.name ?? "<unnamed>", path: member.path, absolute });
+      continue;
+    }
+    // The workspace contract treats members as directory subtrees
+    // (resolveMemberFromPath walks file-path prefixes against
+    // member.path). A plain file at the member path would pass the
+    // exists check but produce garbage at runtime when the agent
+    // tries to resolve files "under" it. Assert directory-shape
+    // here; treat a non-directory as invalid rather than missing so
+    // the error message is unambiguous.
+    let isDir = false;
+    try {
+      isDir = statSync(absolute).isDirectory();
+    } catch {
+      // Race between existsSync and statSync (deleted during
+      // install). Treat as missing rather than invalid.
+      missing.push({ name: member.name ?? "<unnamed>", path: member.path, absolute });
+      continue;
+    }
+    if (!isDir) {
+      invalid.push({
+        name: member.name ?? "<unnamed>",
+        path: member.path,
+        reason: `resolved path '${absolute}' exists but is not a directory (workspace members must be directory subtrees)`,
+      });
     }
   }
   if (invalid.length > 0) {

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -30,7 +30,7 @@
 //
 
 import { readFile, readdir, rm } from "node:fs/promises";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -424,6 +424,40 @@ if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.l
         name: member.name ?? "<unnamed>",
         path: member.path,
         reason: `resolved path '${absolute}' exists but is not a directory (workspace members must be directory subtrees)`,
+      });
+      continue;
+    }
+    // Symlink escape check: the earlier lexical containment check
+    // catches 'libs/../..' and absolute paths, but a symlink at the
+    // resolved location can still point outside TARGET. Resolve the
+    // actual filesystem location via realpath and re-check
+    // containment on the real paths. The resolvedTarget side is
+    // realpath'd up front so a TARGET that itself sits behind a
+    // symlink (common on macOS: /var is a symlink to /private/var)
+    // is compared apples-to-apples. realpath failures are treated
+    // as "cannot verify safety" and surface as invalid rather than
+    // silently trusting the lexical check.
+    let realAbs;
+    let realTarget;
+    try {
+      realAbs = realpathSync(absolute);
+      realTarget = realpathSync(resolvedTarget);
+    } catch (e) {
+      invalid.push({
+        name: member.name ?? "<unnamed>",
+        path: member.path,
+        reason: `cannot resolve real path (${e?.message ?? e}); aborting rather than trusting lexical containment`,
+      });
+      continue;
+    }
+    const realRel = relative(realTarget, realAbs);
+    const realEscapes =
+      isAbsolute(realRel) || realRel === ".." || realRel.startsWith(`..${sep}`) || realRel.startsWith("../");
+    if (realEscapes) {
+      invalid.push({
+        name: member.name ?? "<unnamed>",
+        path: member.path,
+        reason: `member path resolves to '${realAbs}' which is outside '${realTarget}' (symlink escape)`,
       });
     }
   }

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -348,6 +348,39 @@ if (opsConfig.wiki?.required) {
   process.stdout.write(`wiki provider: ${provider} found at ${portableRef(found, TARGET)}\n`);
 }
 
+// Workspace member preflight: when the config declares multi-repo
+// workspace members, every declared path MUST exist on disk before
+// install proceeds. A missing member path almost always means the
+// user committed a config from a teammate's checkout or renamed a
+// directory after bootstrap; either way the runtime dispatch
+// (pickTrackerForMember, resolveMemberFromPath) has nothing to match
+// against and every call that targets the missing member throws at
+// use time. Fail here with a pointed list so the user fixes the
+// typo / clones the sibling before anything else runs. Non-fatal
+// when `workspace` is absent (single-repo projects).
+if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.length > 0) {
+  const missing = [];
+  for (const member of opsConfig.workspace.members) {
+    if (!member || typeof member.path !== "string") continue;
+    const absolute = join(TARGET, member.path);
+    if (!existsSync(absolute)) {
+      missing.push({ name: member.name ?? "<unnamed>", path: member.path, absolute });
+    }
+  }
+  if (missing.length > 0) {
+    process.stderr.write(
+      `\nERROR: ops.config.json declares workspace members whose paths do not exist on disk:\n`,
+    );
+    for (const m of missing) {
+      process.stderr.write(`  - '${m.name}' at '${m.path}' (expected ${portableRef(m.absolute, TARGET)})\n`);
+    }
+    process.stderr.write(
+      `\nEither (a) clone / create those directories at the listed paths, or (b) remove the affected entries from \`workspace.members\` in ops.config.json. The runtime dispatcher refuses to route through a member whose working tree is absent.\n`,
+    );
+    process.exit(1);
+  }
+}
+
 /**
  * Decide interactive vs fail-fast based on TTY state and --yes, then
  * dispatch to the extracted wait helper OR print the non-interactive

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -55,6 +55,7 @@ import { ensureGitignore } from "./lib/gitignore.mjs";
 import { injectManagedBlock, removeManagedBlock } from "./lib/inject.mjs";
 import { getAgentPrefix, prefixed } from "./lib/agentName.mjs";
 import { portableRef, resolvePortable } from "./lib/bundleRef.mjs";
+import { normaliseMemberPath } from "./lib/trackers/dispatcher.mjs";
 
 // Managed-block markers used to own a region inside a project-authored
 // CLAUDE.md. Any content outside these two lines belongs to the user and the
@@ -360,12 +361,50 @@ if (opsConfig.wiki?.required) {
 // when `workspace` is absent (single-repo projects).
 if (Array.isArray(opsConfig.workspace?.members) && opsConfig.workspace.members.length > 0) {
   const missing = [];
+  const invalid = [];
   for (const member of opsConfig.workspace.members) {
     if (!member || typeof member.path !== "string") continue;
-    const absolute = join(TARGET, member.path);
+    // Run member.path through the canonical normaliser so absolute
+    // paths, Windows drive prefixes, and `..` traversal are rejected
+    // up front. `join(TARGET, absPath)` would let an absolute path
+    // silently escape TARGET and check a location outside the
+    // project; the normaliser catches that before it can happen.
+    let relative;
+    try {
+      relative = normaliseMemberPath(member.path, `workspace member '${member.name ?? "<unnamed>"}' path`, { allowRoot: true });
+    } catch (e) {
+      invalid.push({ name: member.name ?? "<unnamed>", path: member.path, reason: e.message });
+      continue;
+    }
+    // After normalisation, resolve under TARGET. Defence-in-depth:
+    // recompute the absolute path with `resolve` and assert it
+    // stays under TARGET. A mid-normaliser bug or a clever
+    // symlink would otherwise get through the first check.
+    const absolute = resolve(TARGET, relative);
+    const resolvedTarget = resolve(TARGET);
+    if (absolute !== resolvedTarget && !absolute.startsWith(resolvedTarget + "/")) {
+      invalid.push({
+        name: member.name ?? "<unnamed>",
+        path: member.path,
+        reason: `resolved path '${absolute}' escapes target '${resolvedTarget}'`,
+      });
+      continue;
+    }
     if (!existsSync(absolute)) {
       missing.push({ name: member.name ?? "<unnamed>", path: member.path, absolute });
     }
+  }
+  if (invalid.length > 0) {
+    process.stderr.write(
+      `\nERROR: ops.config.json declares workspace members with invalid paths:\n`,
+    );
+    for (const m of invalid) {
+      process.stderr.write(`  - '${m.name}' at '${m.path}': ${m.reason}\n`);
+    }
+    process.stderr.write(
+      `\nMember paths must be project-relative POSIX strings (e.g. '.', 'libs/shared'). Absolute paths, Windows drive prefixes, and '..' traversal are all refused because the runtime dispatcher cannot route through them safely. Fix \`workspace.members\` in ops.config.json.\n`,
+    );
+    process.exit(1);
   }
   if (missing.length > 0) {
     process.stderr.write(

--- a/scripts/lib/trackers/dispatcher.mjs
+++ b/scripts/lib/trackers/dispatcher.mjs
@@ -323,18 +323,21 @@ export function normaliseMemberPath(input, label, opts = {}) {
   if (typeof input !== "string" || input.length === 0) {
     throw new Error(`normaliseMemberPath: ${label} must be a non-empty string`);
   }
-  // Reject Windows drive-qualified prefixes up front so the later
-  // "no leading /" check doesn't accidentally let any of
-  //   `C:\foo`   (backslash -> forward slash; still drive-qualified),
-  //   `C:/foo`   (already absolute on Windows),
-  //   `C:foo`    (drive-relative: uses the current directory on
-  //               drive C, which is not project-relative)
-  // through. All three escape "project-relative" on Windows even
-  // though only the first two have an explicit separator after
-  // the colon; broaden the guard to any `^[A-Za-z]:` prefix.
-  if (/^[A-Za-z]:/.test(input)) {
-    throw new Error(`normaliseMemberPath: ${label} must be project-relative (got drive path '${input}')`);
-  }
+  // Reject Windows drive-qualified prefixes. The guard has to run in
+  // two places:
+  //   1. On the raw input, to catch `C:\foo` / `C:/foo` / `C:foo`
+  //      directly.
+  //   2. On the post-"./"-strip form, to catch bypasses like
+  //      `./C:foo` or `.\C:foo` that would otherwise normalise to
+  //      `C:foo` after the strip and slip past a one-off check at
+  //      the top.
+  // `C:` with no separator is drive-relative on Windows (uses the
+  // current directory on drive C), so a bare `^[A-Za-z]:` prefix
+  // is sufficient to cover every variant.
+  const failDrive = (raw) => {
+    throw new Error(`normaliseMemberPath: ${label} must be project-relative (got drive path '${raw}')`);
+  };
+  if (/^[A-Za-z]:/.test(input)) failDrive(input);
   // Normalise separators first so the rest of the checks are
   // POSIX-only. An input of `libs\\shared` becomes `libs/shared`.
   const withForward = input.replace(/\\/g, "/");
@@ -343,6 +346,12 @@ export function normaliseMemberPath(input, label, opts = {}) {
   if (withForward.startsWith("/")) {
     throw new Error(`normaliseMemberPath: ${label} must be project-relative (got absolute path '${input}')`);
   }
+  // Second drive-prefix check. After "./" is stripped below, the
+  // remaining string could start with a drive prefix again (e.g.
+  // user typed `./C:foo`). The first check above only caught the
+  // raw-input form; re-run the test on the stripped candidate.
+  const afterStrip = withForward.replace(/^\.\/+/, "");
+  if (/^[A-Za-z]:/.test(afterStrip)) failDrive(input);
   // Root-member shorthand. "." and "./" (or any ".//" variant) are
   // the canonical ways to bind a member to the project root. They
   // need special handling because the strip-leading-"./" regex below

--- a/scripts/lib/trackers/dispatcher.mjs
+++ b/scripts/lib/trackers/dispatcher.mjs
@@ -140,3 +140,120 @@ function makeTracker(kind, target) {
     default: throw new Error(`makeTracker: unreachable kind '${kind}'`);
   }
 }
+
+/**
+ * Build a Tracker for a specific workspace member + role. Callers pass
+ * a member `name` (as recorded in `cfg.workspace.members[].name`); when
+ * `memberName === null` or `cfg.workspace` is absent, the call falls
+ * through to the project-level `pickTracker(cfg, role)` so single-repo
+ * projects do not need to change their call sites.
+ *
+ * A member whose `trackers.<role>` is missing is an error, not a
+ * silent fallback to the project-level tracker: the member declared
+ * itself in the workspace but did not bind a tracker for this role,
+ * which is almost always a bootstrap bug the user should see. If you
+ * truly want a member to inherit the top-level tracker, omit it from
+ * `workspace.members[]` entirely.
+ *
+ * @param {object} cfg          parsed ops.config.json
+ * @param {string|null} memberName  workspace member name, or null for root
+ * @param {"dev"|"release"} [role="dev"]
+ * @returns {{ tracker: object, kind: string, memberName: string|null }}
+ */
+export function pickTrackerForMember(cfg, memberName, role = "dev") {
+  if (role !== "dev" && role !== "release") {
+    throw new Error(`pickTrackerForMember: role must be "dev" or "release"; got ${JSON.stringify(role)}`);
+  }
+  if (memberName === null || memberName === undefined) {
+    const { tracker, kind } = pickTracker(cfg, role);
+    return { tracker, kind, memberName: null };
+  }
+  const members = cfg?.workspace?.members;
+  if (!Array.isArray(members) || members.length === 0) {
+    // A memberName was supplied but the config has no workspace block.
+    // This is a caller bug: surface it rather than silently routing
+    // through the root tracker, which would mask the missing workspace.
+    throw new Error(
+      `pickTrackerForMember: memberName='${memberName}' was requested but cfg.workspace.members is absent or empty`,
+    );
+  }
+  const member = members.find((m) => m && m.name === memberName);
+  if (!member) {
+    const known = members.map((m) => m?.name).filter(Boolean).join(", ");
+    throw new Error(
+      `pickTrackerForMember: unknown workspace member '${memberName}' (known: ${known || "<none>"})`,
+    );
+  }
+  const target = member.trackers?.[role];
+  if (!target || typeof target !== "object" || Array.isArray(target)) {
+    throw new Error(
+      `pickTrackerForMember: workspace member '${memberName}' is missing trackers.${role}`,
+    );
+  }
+  const kind = target.kind;
+  if (!SUPPORTED_KINDS.includes(kind)) {
+    throw new Error(
+      `pickTrackerForMember: member '${memberName}' declares unsupported tracker kind '${kind}' for role '${role}' (supported: ${SUPPORTED_KINDS.join(", ")})`,
+    );
+  }
+  return { tracker: makeTracker(kind, target), kind, memberName };
+}
+
+/**
+ * Resolve the workspace member that owns a given project-relative file
+ * path. Returns the member `name`, or `null` if no member declares a
+ * path that contains the file (single-repo projects always return
+ * null). Matching is deepest-first, so a file under `libs/shared/x.ts`
+ * resolves to the `libs/shared` member even when `.` also declares
+ * itself as a member. Path comparison is normalised (POSIX-style; trailing
+ * slashes stripped) so `.` and `./` both match as the project root.
+ *
+ * This helper is consumed by dev-loop / pr-iteration before they pick a
+ * tracker: given the set of files changed on the current branch, the
+ * agent picks the deepest containing member and dispatches through it.
+ * Callers pass project-relative paths (no leading `/`, no `..` escape).
+ *
+ * @param {object} cfg       parsed ops.config.json
+ * @param {string} filePath  project-relative POSIX path (no leading slash)
+ * @returns {string|null}    matched member's name, or null
+ */
+export function resolveMemberFromPath(cfg, filePath) {
+  if (typeof filePath !== "string" || filePath.length === 0) {
+    throw new Error("resolveMemberFromPath: filePath must be a non-empty string");
+  }
+  const members = cfg?.workspace?.members;
+  if (!Array.isArray(members) || members.length === 0) return null;
+
+  // Normalise the file path: strip leading ./ and trailing slashes;
+  // reject absolute paths and parent-traversal since those never
+  // describe a project-relative position.
+  const norm = filePath.replace(/^\.\/+/, "").replace(/\/+$/, "");
+  if (norm.startsWith("/") || norm.split("/").includes("..")) {
+    throw new Error(`resolveMemberFromPath: filePath must be project-relative, got '${filePath}'`);
+  }
+
+  // Rank each member's path by how many leading path segments match
+  // the file's segments. Ties and zero-match misses are discarded.
+  // "." matches everything with length 0 (the weakest signal).
+  const fileParts = norm.split("/");
+  let best = { name: null, depth: -1 };
+  for (const m of members) {
+    if (!m || typeof m.path !== "string" || typeof m.name !== "string") continue;
+    const memberPath = m.path.replace(/^\.\/+/, "").replace(/\/+$/, "");
+    if (memberPath === "" || memberPath === ".") {
+      // Root member: weakest match, length 0.
+      if (best.depth < 0) best = { name: m.name, depth: 0 };
+      continue;
+    }
+    const memberParts = memberPath.split("/");
+    if (memberParts.length > fileParts.length) continue;
+    let matches = true;
+    for (let i = 0; i < memberParts.length; i += 1) {
+      if (memberParts[i] !== fileParts[i]) { matches = false; break; }
+    }
+    if (matches && memberParts.length > best.depth) {
+      best = { name: m.name, depth: memberParts.length };
+    }
+  }
+  return best.name;
+}

--- a/scripts/lib/trackers/dispatcher.mjs
+++ b/scripts/lib/trackers/dispatcher.mjs
@@ -143,17 +143,20 @@ function makeTracker(kind, target) {
 
 /**
  * Build a Tracker for a specific workspace member + role. Callers pass
- * a member `name` (as recorded in `cfg.workspace.members[].name`); when
- * `memberName === null` or `cfg.workspace` is absent, the call falls
- * through to the project-level `pickTracker(cfg, role)` so single-repo
- * projects do not need to change their call sites.
+ * a member `name` (as recorded in `cfg.workspace.members[].name`); the
+ * call falls through to the project-level `pickTracker(cfg, role)` ONLY
+ * when `memberName === null` or `memberName === undefined`, so
+ * single-repo call sites pass `null` and keep working unchanged.
+ * Passing a non-null `memberName` on a config with no workspace is an
+ * error, not a silent fallback: the caller asked for a specific member
+ * that the config does not declare, and returning the root tracker
+ * would mask a real bug.
  *
- * A member whose `trackers.<role>` is missing is an error, not a
- * silent fallback to the project-level tracker: the member declared
- * itself in the workspace but did not bind a tracker for this role,
- * which is almost always a bootstrap bug the user should see. If you
- * truly want a member to inherit the top-level tracker, omit it from
- * `workspace.members[]` entirely.
+ * A member whose `trackers.<role>` is missing is likewise an error:
+ * the member declared itself in the workspace but did not bind a
+ * tracker for this role, which is almost always a bootstrap bug the
+ * user should see. If you truly want a member to inherit the top-level
+ * tracker, omit it from `workspace.members[]` entirely.
  *
  * @param {object} cfg          parsed ops.config.json
  * @param {string|null} memberName  workspace member name, or null for root
@@ -320,11 +323,16 @@ export function normaliseMemberPath(input, label, opts = {}) {
   if (typeof input !== "string" || input.length === 0) {
     throw new Error(`normaliseMemberPath: ${label} must be a non-empty string`);
   }
-  // Reject Windows drive prefixes up front so the later "no leading /"
-  // check doesn't accidentally let `C:\foo` through (the backslash
-  // conversion would turn it into `C:/foo`, which has no leading
-  // slash but still resolves to an absolute drive path on Windows).
-  if (/^[A-Za-z]:[\\/]/.test(input)) {
+  // Reject Windows drive-qualified prefixes up front so the later
+  // "no leading /" check doesn't accidentally let any of
+  //   `C:\foo`   (backslash -> forward slash; still drive-qualified),
+  //   `C:/foo`   (already absolute on Windows),
+  //   `C:foo`    (drive-relative: uses the current directory on
+  //               drive C, which is not project-relative)
+  // through. All three escape "project-relative" on Windows even
+  // though only the first two have an explicit separator after
+  // the colon; broaden the guard to any `^[A-Za-z]:` prefix.
+  if (/^[A-Za-z]:/.test(input)) {
     throw new Error(`normaliseMemberPath: ${label} must be project-relative (got drive path '${input}')`);
   }
   // Normalise separators first so the rest of the checks are

--- a/scripts/lib/trackers/dispatcher.mjs
+++ b/scripts/lib/trackers/dispatcher.mjs
@@ -224,13 +224,10 @@ export function resolveMemberFromPath(cfg, filePath) {
   const members = cfg?.workspace?.members;
   if (!Array.isArray(members) || members.length === 0) return null;
 
-  // Normalise the file path: strip leading ./ and trailing slashes;
-  // reject absolute paths and parent-traversal since those never
-  // describe a project-relative position.
-  const norm = filePath.replace(/^\.\/+/, "").replace(/\/+$/, "");
-  if (norm.startsWith("/") || norm.split("/").includes("..")) {
-    throw new Error(`resolveMemberFromPath: filePath must be project-relative, got '${filePath}'`);
-  }
+  // Normalise the caller-supplied file path. Member paths get the
+  // same normalisation below so "libs\\shared" in ops.config.json
+  // matches "libs/shared/x.ts" from a git diff.
+  const norm = normaliseMemberPath(filePath, "filePath");
 
   // Rank each member's path by how many leading path segments match
   // the file's segments. Ties and zero-match misses are discarded.
@@ -239,8 +236,20 @@ export function resolveMemberFromPath(cfg, filePath) {
   let best = { name: null, depth: -1 };
   for (const m of members) {
     if (!m || typeof m.path !== "string" || typeof m.name !== "string") continue;
-    const memberPath = m.path.replace(/^\.\/+/, "").replace(/\/+$/, "");
-    if (memberPath === "" || memberPath === ".") {
+    // Member paths are normalised the same way as file paths so a
+    // Windows user who typed "libs\\shared" in the interview still
+    // resolves to POSIX-diff input "libs/shared/x.ts". Bad member
+    // paths (absolute, parent-traversal, empty-after-normalise) are
+    // caught at install-time preflight and bootstrap prompt-time, so
+    // a throw here is a config-loaded-mid-session edge case: treat
+    // it as "skip this member" rather than abort the whole resolve.
+    let memberPath;
+    try {
+      memberPath = normaliseMemberPath(m.path, `member '${m.name}' path`, { allowRoot: true });
+    } catch {
+      continue;
+    }
+    if (memberPath === ".") {
       // Root member: weakest match, length 0.
       if (best.depth < 0) best = { name: m.name, depth: 0 };
       continue;
@@ -256,4 +265,71 @@ export function resolveMemberFromPath(cfg, filePath) {
     }
   }
   return best.name;
+}
+
+/**
+ * Canonical normalisation for workspace member paths and the file
+ * paths passed to `resolveMemberFromPath`. Exported so bootstrap and
+ * install can reuse the same contract at prompt-time and preflight,
+ * rather than each round-tripping through slightly-different ad-hoc
+ * regex and later disagreeing.
+ *
+ * Contract:
+ *   - Converts backslashes to forward slashes (Windows paths typed
+ *     into the bootstrap interview or checked-in configs).
+ *   - Strips a leading `./` and trailing `/`.
+ *   - Rejects absolute paths (leading `/` after normalisation or a
+ *     Windows drive prefix like `C:/`).
+ *   - Rejects any `..` segment.
+ *   - Rejects collapse-to-empty (e.g. `./`, `////`).
+ *   - When `allowRoot` is true, the inputs `.` and `./` resolve to
+ *     `.` instead of throwing. File paths never set this flag (a
+ *     file "." makes no sense); member paths always do.
+ *
+ * @param {string} input     raw path
+ * @param {string} label     prefix for error messages
+ * @param {{allowRoot?: boolean}} [opts]
+ * @returns {string}         normalised POSIX path, or `.` for root member
+ */
+export function normaliseMemberPath(input, label, opts = {}) {
+  const { allowRoot = false } = opts;
+  if (typeof input !== "string" || input.length === 0) {
+    throw new Error(`normaliseMemberPath: ${label} must be a non-empty string`);
+  }
+  // Reject Windows drive prefixes up front so the later "no leading /"
+  // check doesn't accidentally let `C:\foo` through (the backslash
+  // conversion would turn it into `C:/foo`, which has no leading
+  // slash but still resolves to an absolute drive path on Windows).
+  if (/^[A-Za-z]:[\\/]/.test(input)) {
+    throw new Error(`normaliseMemberPath: ${label} must be project-relative (got drive path '${input}')`);
+  }
+  // Normalise separators first so the rest of the checks are
+  // POSIX-only. An input of `libs\\shared` becomes `libs/shared`.
+  const withForward = input.replace(/\\/g, "/");
+  // Handle absolute paths BEFORE stripping leading "./" so the error
+  // message distinguishes "/absolute" from "./foo".
+  if (withForward.startsWith("/")) {
+    throw new Error(`normaliseMemberPath: ${label} must be project-relative (got absolute path '${input}')`);
+  }
+  // Root-member shorthand. "." and "./" (or any ".//" variant) are
+  // the canonical ways to bind a member to the project root. They
+  // need special handling because the strip-leading-"./" regex below
+  // leaves "." as-is but collapses "./" to "". Canonicalise both to
+  // "." when allowRoot is set; reject otherwise since a non-root
+  // caller (like a file path) never meaningfully maps to the root.
+  const rootOnly = withForward === "." || /^\.\/+$/.test(withForward);
+  if (rootOnly) {
+    if (allowRoot) return ".";
+    throw new Error(`normaliseMemberPath: ${label} collapses to empty after normalisation (got '${input}')`);
+  }
+  const stripped = withForward.replace(/^\.\/+/, "").replace(/\/+$/, "");
+  if (stripped.length === 0) {
+    // e.g. "////" or ".////" that didn't match rootOnly above.
+    throw new Error(`normaliseMemberPath: ${label} collapses to empty after normalisation (got '${input}')`);
+  }
+  const parts = stripped.split("/");
+  if (parts.includes("..")) {
+    throw new Error(`normaliseMemberPath: ${label} must not contain '..' (got '${input}')`);
+  }
+  return stripped;
 }

--- a/scripts/lib/trackers/dispatcher.mjs
+++ b/scripts/lib/trackers/dispatcher.mjs
@@ -177,13 +177,31 @@ export function pickTrackerForMember(cfg, memberName, role = "dev") {
       `pickTrackerForMember: memberName='${memberName}' was requested but cfg.workspace.members is absent or empty`,
     );
   }
-  const member = members.find((m) => m && m.name === memberName);
-  if (!member) {
+  // Collect every member with the requested name rather than calling
+  // Array.find. Bootstrap already rejects duplicate names at prompt
+  // time, but a hand-edited config can reintroduce them; silently
+  // picking the first match would make dispatch ambiguous in a way
+  // that's almost impossible to debug at runtime. Treat duplicates as
+  // a hard error listing both offending entries (by index) so the
+  // user can fix the config.
+  const matches = [];
+  for (let i = 0; i < members.length; i += 1) {
+    const m = members[i];
+    if (m && m.name === memberName) matches.push({ member: m, index: i });
+  }
+  if (matches.length === 0) {
     const known = members.map((m) => m?.name).filter(Boolean).join(", ");
     throw new Error(
       `pickTrackerForMember: unknown workspace member '${memberName}' (known: ${known || "<none>"})`,
     );
   }
+  if (matches.length > 1) {
+    const collisions = matches.map(({ index }) => `members[${index}]`).join(", ");
+    throw new Error(
+      `pickTrackerForMember: duplicate workspace member name '${memberName}' makes dispatch ambiguous (${collisions})`,
+    );
+  }
+  const member = matches[0].member;
   const target = member.trackers?.[role];
   if (!target || typeof target !== "object" || Array.isArray(target)) {
     throw new Error(
@@ -205,16 +223,22 @@ export function pickTrackerForMember(cfg, memberName, role = "dev") {
  * path that contains the file (single-repo projects always return
  * null). Matching is deepest-first, so a file under `libs/shared/x.ts`
  * resolves to the `libs/shared` member even when `.` also declares
- * itself as a member. Path comparison is normalised (POSIX-style; trailing
- * slashes stripped) so `.` and `./` both match as the project root.
+ * itself as a member.
+ *
+ * **Root shorthand (`.` / `./`) applies to member.path normalisation
+ * only**, where a declared member with that path is canonicalised to
+ * `.` and becomes the weakest possible match. The `filePath` argument,
+ * in contrast, must be a real project-relative POSIX **file** path:
+ * inputs like `.` and `./` are rejected by
+ * `normaliseMemberPath(..., allowRoot=false)` because a "file" at the
+ * project root makes no sense for path-based dispatch.
  *
  * This helper is consumed by dev-loop / pr-iteration before they pick a
  * tracker: given the set of files changed on the current branch, the
  * agent picks the deepest containing member and dispatches through it.
- * Callers pass project-relative paths (no leading `/`, no `..` escape).
  *
  * @param {object} cfg       parsed ops.config.json
- * @param {string} filePath  project-relative POSIX path (no leading slash)
+ * @param {string} filePath  project-relative POSIX file path (no leading slash, no `..`, not the root shorthand `.`/`./`)
  * @returns {string|null}    matched member's name, or null
  */
 export function resolveMemberFromPath(cfg, filePath) {

--- a/scripts/lib/trackers/dispatcher.mjs
+++ b/scripts/lib/trackers/dispatcher.mjs
@@ -159,7 +159,7 @@ function makeTracker(kind, target) {
  * tracker, omit it from `workspace.members[]` entirely.
  *
  * @param {object} cfg          parsed ops.config.json
- * @param {string|null} memberName  workspace member name, or null for root
+ * @param {string|null|undefined} memberName  workspace member name, or null/undefined to trigger fallback to project-level `pickTracker`
  * @param {"dev"|"release"} [role="dev"]
  * @returns {{ tracker: object, kind: string, memberName: string|null }}
  */

--- a/scripts/lib/trackers/dispatcher.mjs
+++ b/scripts/lib/trackers/dispatcher.mjs
@@ -327,9 +327,23 @@ export function normaliseMemberPath(input, label, opts = {}) {
     // e.g. "////" or ".////" that didn't match rootOnly above.
     throw new Error(`normaliseMemberPath: ${label} collapses to empty after normalisation (got '${input}')`);
   }
-  const parts = stripped.split("/");
+  // Collapse consecutive separators ("libs//shared" -> "libs/shared")
+  // and drop interior "." segments ("libs/./shared" -> "libs/shared").
+  // Without this the normaliser would accept inputs that look fine
+  // at bootstrap time but never match a real git-diff file path at
+  // runtime (diffs always emit canonical POSIX with single slashes
+  // and no "./" segments), breaking resolveMemberFromPath silently.
+  const parts = stripped.split("/").filter((seg) => seg !== "" && seg !== ".");
+  if (parts.length === 0) {
+    // Input was composed entirely of "." and "/" segments (e.g.
+    // "././", ".//./"). That's semantically the root member; honour
+    // allowRoot here the same way as the early rootOnly shortcut so
+    // a caller can't sneak a "sort-of root" input past the guard.
+    if (allowRoot) return ".";
+    throw new Error(`normaliseMemberPath: ${label} collapses to empty after normalisation (got '${input}')`);
+  }
   if (parts.includes("..")) {
     throw new Error(`normaliseMemberPath: ${label} must not contain '..' (got '${input}')`);
   }
-  return stripped;
+  return parts.join("/");
 }

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -23,6 +23,7 @@ Hard rule baked in: **the dev-loop never merges a PR and never sets a dev issue 
 
 - Issue reference (number or URL) on a `dev_project` with `depth` permitting writes.
 - Optional work plan or acceptance-criteria override the user supplies up front.
+- Optional workspace member. For single-repo projects, omit (the skill routes through `trackers.dev`). For multi-repo projects (`workspace.members[]` present), the skill resolves the owning member by walking the diff's file paths through `resolveMemberFromPath(cfg, filePath)` before picking the tracker via `pickTrackerForMember(cfg, memberName, "dev")`. Deepest-first match wins; files outside any nested member fall back to the root member (path `.`).
 
 ## Outputs
 

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -23,7 +23,7 @@ Hard rule baked in: **the dev-loop never merges a PR and never sets a dev issue 
 
 - Issue reference (number or URL) on a `dev_project` with `depth` permitting writes.
 - Optional work plan or acceptance-criteria override the user supplies up front.
-- Optional workspace member. For single-repo projects, omit (the skill routes through `trackers.dev`). For multi-repo projects (`workspace.members[]` present), the skill resolves the owning member by walking the diff's file paths through `resolveMemberFromPath(cfg, filePath)` before picking the tracker via `pickTrackerForMember(cfg, memberName, "dev")`. Deepest-first match wins; files outside any nested member fall back to the root member (path `.`).
+- Optional workspace member. For single-repo projects, omit (the skill routes through `trackers.dev`). For multi-repo projects (`workspace.members[]` present), the skill resolves the owning member by walking the diff's file paths through `resolveMemberFromPath(cfg, filePath)` before picking the tracker via `pickTrackerForMember(cfg, memberName, "dev")`. Deepest-first match wins; files outside any nested member fall back to a root member ONLY when `workspace.members[]` contains an entry whose normalised path is `.`. Without an explicit root member, `resolveMemberFromPath` returns `null` for unmatched files and the caller routes through the top-level `trackers.dev` instead.
 
 ## Outputs
 

--- a/skills/pr-iteration/SKILL.md
+++ b/skills/pr-iteration/SKILL.md
@@ -23,6 +23,7 @@ Hard rule baked in: **pr-iteration never merges a PR.** Merge is a human gate. E
 ## Inputs
 
 - PR number on the tracker that owns dev issues (`trackers.dev.kind`).
+- Optional workspace member. For multi-repo projects (`workspace.members[]` present), the skill inherits the member name from the originating `dev-loop` invocation, or resolves it via `resolveMemberFromPath(cfg, filePath)` on the PR's changed files. The review provider is then picked via `pickTrackerForMember(cfg, memberName, "dev").tracker.review`. Single-repo projects omit `memberName` and route through `trackers.dev` as before.
 - Optional override of `workflow.external_review.*` fields for this invocation (rare).
 
 ## Outputs

--- a/skills/tracker-sync/SKILL.md
+++ b/skills/tracker-sync/SKILL.md
@@ -24,7 +24,7 @@ Centralises every tracker API call. Other skills describe what they want; `track
 
 ## Inputs
 
-- Role (`dev` or `release`) plus an optional workspace member name when `workspace.members[]` is configured. The skill resolves these to a tracker target via `scripts/lib/trackers/dispatcher.mjs#pickTracker`.
+- Role (`dev` or `release`) plus an optional `memberName` string when `workspace.members[]` is configured. The skill resolves these to a tracker target via `scripts/lib/trackers/dispatcher.mjs#pickTrackerForMember` (falls back to `pickTracker` when `memberName === null` or the config has no workspace). Callers who need to derive `memberName` from a file path use `resolveMemberFromPath(cfg, filePath)` from the same module, which walks `workspace.members[]` deepest-first.
 - Operation name (enum, see "Operations" below).
 - Operation-specific payload (issue title, label list, field-value map, thread ID, etc.).
 - Approval mode (`dry-run` default, `--apply` to write).

--- a/skills/tracker-sync/SKILL.md
+++ b/skills/tracker-sync/SKILL.md
@@ -24,7 +24,7 @@ Centralises every tracker API call. Other skills describe what they want; `track
 
 ## Inputs
 
-- Role (`dev` or `release`) plus an optional `memberName` string when `workspace.members[]` is configured. The skill resolves these to a tracker target via `scripts/lib/trackers/dispatcher.mjs#pickTrackerForMember` (falls back to `pickTracker` when `memberName === null` or the config has no workspace). Callers who need to derive `memberName` from a file path use `resolveMemberFromPath(cfg, filePath)` from the same module, which walks `workspace.members[]` deepest-first.
+- Role (`dev` or `release`) plus an optional `memberName` string when `workspace.members[]` is configured. The skill resolves these to a tracker target via `scripts/lib/trackers/dispatcher.mjs#pickTrackerForMember`. The fallback to `pickTracker(cfg, role)` fires ONLY when `memberName` is `null` or `undefined`; supplying a non-null `memberName` on a single-repo config (`workspace.members[]` absent) is an error, not a silent fallback, and `pickTrackerForMember` throws with a pointed message. Callers who need to derive `memberName` from a file path use `resolveMemberFromPath(cfg, filePath)` from the same module, which walks `workspace.members[]` deepest-first and returns `null` when no member contains the file (safe to pass back into `pickTrackerForMember` as-is).
 - Operation name (enum, see "Operations" below).
 - Operation-specific payload (issue title, label list, field-value map, thread ID, etc.).
 - Approval mode (`dry-run` default, `--apply` to write).

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -757,13 +757,17 @@ describe("bootstrap.askBranchPattern", () => {
 
 describe("bootstrap.interviewWorkspaceMembers", () => {
   // Build a stubbed ask + askYesNo pair that reads from a scripted
-  // answer queue. The interview() pattern is ask(question, def) with
-  // trim+fallback; the stub replicates that so call sites under test
-  // can rely on the same semantics (empty-string -> default).
+  // answer queue. The interview() pattern is ask(question, def) which
+  // does `s.trim() || def`; the stub mirrors that exactly so
+  // whitespace-only inputs collapse to the default the same way they
+  // would during a real interview run. Without the trim, tests would
+  // mask whitespace-handling bugs in call sites that assume the
+  // returned string is already trimmed.
   const makeAsk = (queue) => async (_q, def = "") => {
     if (queue.length === 0) throw new Error("ask stub exhausted");
     const a = queue.shift();
-    return a === "" ? def : a;
+    const trimmed = String(a ?? "").trim();
+    return trimmed === "" ? def : trimmed;
   };
   const makeYesNo = (queue) => async (_q, def = "yes") => {
     if (queue.length === 0) throw new Error("yesno stub exhausted");
@@ -833,6 +837,72 @@ describe("bootstrap.interviewWorkspaceMembers", () => {
     const out = await interviewWorkspaceMembers(ask, yn, detection);
     assert.ok(out);
     assert.equal(out.members.length, 16, "cap enforced at 16");
+  });
+
+  // PR 8 R4 (Copilot): duplicate member paths make resolveMemberFromPath
+  // ambiguous (first-match semantics). Prompt-time rejection retries
+  // up to 3 times; on exhaustion the loop exits with the members
+  // collected so far rather than hanging the interview.
+  it("rejects duplicate member paths with a 3-attempt retry + loop exit", async () => {
+    // First member: path '.' is accepted. Second member: first
+    // attempt repeats '.', then a retry supplies 'libs/shared'.
+    const ask = makeAsk([
+      // --- member 1 ---
+      ".",
+      "primary",
+      "github",
+      "acme",
+      "primary",
+      "1",
+      // --- member 2, attempt 1 (duplicate '.') then attempt 2 ('libs/shared') ---
+      ".",
+      "libs/shared",
+      "shared",
+      "github",
+      "acme",
+      "shared-repo",
+      "1",
+      // --- end loop ---
+      "",
+    ]);
+    const yn = makeYesNo(["no", "no"]);
+    const out = await interviewWorkspaceMembers(ask, yn, detection);
+    assert.ok(out);
+    assert.equal(out.members.length, 2);
+    assert.equal(out.members[0].path, ".");
+    assert.equal(out.members[1].path, "libs/shared");
+  });
+
+  // PR 8 R4 (Copilot): duplicate member names make
+  // pickTrackerForMember ambiguous. Same 3-attempt retry pattern.
+  it("rejects duplicate member names with a 3-attempt retry + loop exit", async () => {
+    // First member uses default name 'primary'. Second member:
+    // attempt 1 tries the same 'primary' (duplicate), attempt 2
+    // supplies 'shared'.
+    const ask = makeAsk([
+      // --- member 1 ---
+      ".",
+      "primary",
+      "github",
+      "acme",
+      "primary",
+      "1",
+      // --- member 2 ---
+      "libs/shared",
+      "primary",   // attempt 1: duplicate name
+      "shared",    // attempt 2: unique
+      "github",
+      "acme",
+      "shared-repo",
+      "1",
+      // --- end loop ---
+      "",
+    ]);
+    const yn = makeYesNo(["no", "no"]);
+    const out = await interviewWorkspaceMembers(ask, yn, detection);
+    assert.ok(out);
+    assert.equal(out.members.length, 2);
+    assert.equal(out.members[1].name, "shared");
   });
 });
 

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -16,6 +16,7 @@ import {
   pickDefaults,
   compose,
   cadenceToIntent,
+  interviewWorkspaceMembers,
 } from "../scripts/bootstrap.mjs";
 
 describe("bootstrap.parseOwnerRepo", () => {
@@ -754,6 +755,87 @@ describe("bootstrap.askBranchPattern", () => {
   });
 });
 
+describe("bootstrap.interviewWorkspaceMembers", () => {
+  // Build a stubbed ask + askYesNo pair that reads from a scripted
+  // answer queue. The interview() pattern is ask(question, def) with
+  // trim+fallback; the stub replicates that so call sites under test
+  // can rely on the same semantics (empty-string -> default).
+  const makeAsk = (queue) => async (_q, def = "") => {
+    if (queue.length === 0) throw new Error("ask stub exhausted");
+    const a = queue.shift();
+    return a === "" ? def : a;
+  };
+  const makeYesNo = (queue) => async (_q, def = "yes") => {
+    if (queue.length === 0) throw new Error("yesno stub exhausted");
+    const a = queue.shift();
+    if (a === "") return def === "yes";
+    return String(a).toLowerCase().startsWith("y");
+  };
+
+  const detection = {
+    git: { ownerRepo: "acme/primary", defaultBranch: "main" },
+    gh: { authed: true, login: "jane" },
+    tracker: { jira: {}, linear: {}, gitlab: {} },
+    stack: { language: ["typescript"], testing: ["vitest"], platform: ["web"] },
+    devHints: {},
+  };
+
+  it("returns undefined when the user immediately enters a blank path", async () => {
+    const ask = makeAsk([""]);
+    const yn = makeYesNo([]);
+    const out = await interviewWorkspaceMembers(ask, yn, detection);
+    assert.equal(out, undefined);
+  });
+
+  it("collects a single member with path='.' and default name", async () => {
+    // Queue order (matching helpers' order):
+    //   ask: path -> name -> devKind -> github owner -> github repo -> projectNum (blank uses default "1") -> next path (blank stops)
+    //   yn: release-tracker?
+    const ask = makeAsk([
+      ".",               // path
+      "primary",         // name
+      "github",          // dev kind (askTrackerKind normalises)
+      "acme",            // github owner (askNonEmpty)
+      "primary",         // github repo (askNonEmpty)
+      "1",               // project v2 number (askTrackerTarget)
+      "",                // next member path (blank stops the loop)
+    ]);
+    const yn = makeYesNo(["no"]); // release tracker? no
+    const out = await interviewWorkspaceMembers(ask, yn, detection);
+    assert.ok(out, "must return a workspace object");
+    assert.equal(out.members.length, 1);
+    assert.equal(out.members[0].path, ".");
+    assert.equal(out.members[0].name, "primary");
+    assert.equal(out.members[0].trackers.dev.kind, "github");
+    assert.equal(out.members[0].trackers.dev.owner, "acme");
+    assert.equal(out.members[0].trackers.dev.repo, "primary");
+    assert.equal("release" in out.members[0].trackers, false, "no release when user said no");
+  });
+
+  it("caps the loop at 16 members so a runaway stub cannot hang tests forever", async () => {
+    // Supply enough answers for 16 iterations of the github member
+    // collection. Each iteration consumes: path, name, kind, owner,
+    // repo, projectNum (= 6 ask calls). After 16 iterations the loop
+    // exits by its own cap, never reaching a 17th "path" prompt.
+    const queue = [];
+    for (let i = 1; i <= 16; i += 1) {
+      queue.push(
+        `path-${i}`,
+        `name-${i}`,
+        "github",
+        "acme",
+        `repo-${i}`,
+        "1",
+      );
+    }
+    const ask = makeAsk(queue);
+    const yn = makeYesNo(Array.from({ length: 16 }, () => "no"));
+    const out = await interviewWorkspaceMembers(ask, yn, detection);
+    assert.ok(out);
+    assert.equal(out.members.length, 16, "cap enforced at 16");
+  });
+});
+
 describe("bootstrap.compose", () => {
   const detection = {
     git: { remote: "git@github.com:acme/foo.git", defaultBranch: "main", ownerRepo: "acme/foo" },
@@ -1041,5 +1123,53 @@ describe("bootstrap.compose", () => {
     assert.equal("release" in cfg.trackers, true, "null releaseTracker must still produce a release key");
     assert.equal(cfg.trackers.release, null, "null passes through verbatim");
     assert.equal(validate(schema, cfg).ok, false, "null release must fail schema validation");
+  });
+
+  // PR 8: workspace block is optional. Single-repo (answers.workspace
+  // undefined) must omit the `workspace` key entirely so the schema's
+  // single-repo path is exercised. Bad inputs (null) propagate so
+  // downstream schema catches them.
+  it("omits cfg.workspace when answers.workspace is undefined (single-repo default)", () => {
+    const cfg = compose(detection, answers, ".claude/agents/agent-staff-engineer");
+    assert.equal("workspace" in cfg, false, "cfg.workspace must be absent for single-repo");
+  });
+
+  it("emits cfg.workspace when answers.workspace is provided (multi-repo)", async () => {
+    const schema = await loadSchemaOnce();
+    const { validate } = await import("../scripts/lib/schema.mjs");
+    const workspace = {
+      members: [
+        {
+          path: ".",
+          name: "primary",
+          trackers: { dev: { kind: "github", owner: "acme", repo: "primary", projects: [], depth: "full" } },
+        },
+        {
+          path: "libs/shared",
+          name: "shared",
+          trackers: {
+            dev: {
+              kind: "jira",
+              site: "acme.atlassian.net",
+              project: "SHARED",
+              depth: "full",
+              status_values: { backlog: "Backlog", in_progress: "In progress", done: "Done" },
+            },
+          },
+        },
+      ],
+    };
+    const cfg = compose(detection, { ...answers, workspace }, ".claude/agents/agent-staff-engineer");
+    assert.deepEqual(cfg.workspace, workspace, "workspace block composed verbatim");
+    assert.ok(validate(schema, cfg).ok, `composed config with workspace must validate: ${JSON.stringify(validate(schema, cfg).errors ?? null)}`);
+  });
+
+  it("compose propagates null workspace to fail schema (not silently omit)", async () => {
+    const schema = await loadSchemaOnce();
+    const { validate } = await import("../scripts/lib/schema.mjs");
+    const cfg = compose(detection, { ...answers, workspace: null }, ".claude/agents/agent-staff-engineer");
+    assert.equal("workspace" in cfg, true, "null workspace must still produce the key");
+    assert.equal(cfg.workspace, null);
+    assert.equal(validate(schema, cfg).ok, false, "null workspace must fail schema validation");
   });
 });

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -904,6 +904,19 @@ describe("bootstrap.interviewWorkspaceMembers", () => {
     assert.equal(out.members.length, 2);
     assert.equal(out.members[1].name, "shared");
   });
+
+  // PR 8 R11 (Copilot): askNonEmpty can throw after its own 3-attempt
+  // cap on empty inputs; prior to this commit that throw aborted
+  // the entire bootstrap run. Now the name-prompt try/catch in
+  // interviewWorkspaceMembers converts the throw into a clean
+  // loop-exit. The try/catch is defence-in-depth: today every call
+  // site passes a non-empty default (so `ask` always returns the
+  // default on empty input, and askNonEmpty never exhausts), but
+  // a future refactor that allows an empty default would otherwise
+  // silently regress and crash the bootstrap mid-workspace. Asserted
+  // by inspection of the source; a unit test would need a direct
+  // mock of askNonEmpty and would just reassert the try/catch shape
+  // we can read in the code.
 });
 
 describe("bootstrap.compose", () => {

--- a/tests/trackers_dispatcher.test.mjs
+++ b/tests/trackers_dispatcher.test.mjs
@@ -281,6 +281,27 @@ describe("pickTrackerForMember: workspace dispatch", () => {
       /role must be "dev" or "release"/,
     );
   });
+
+  // PR 8 R5 (Copilot): pickTrackerForMember previously used
+  // `Array.find` which silently picks the first match if the
+  // config somehow ended up with duplicate member names (hand-edit
+  // after bootstrap's prompt-time rejection). Now hard-refuses with
+  // a pointed error listing both colliding indices so the user
+  // sees exactly which entries clash.
+  it("throws on duplicate workspace member names (defence for hand-edited configs)", () => {
+    const cfg = {
+      workspace: {
+        members: [
+          { path: ".", name: "primary", trackers: { dev: { kind: "github", owner: "a", repo: "x", projects: [] } } },
+          { path: "lib", name: "primary", trackers: { dev: { kind: "github", owner: "b", repo: "y", projects: [] } } },
+        ],
+      },
+    };
+    assert.throws(
+      () => pickTrackerForMember(cfg, "primary"),
+      /duplicate workspace member name 'primary'.*members\[0\].*members\[1\]/s,
+    );
+  });
 });
 
 describe("resolveMemberFromPath: workspace resolution", () => {

--- a/tests/trackers_dispatcher.test.mjs
+++ b/tests/trackers_dispatcher.test.mjs
@@ -12,6 +12,7 @@ import {
   hasReleaseTracker,
   pickTrackerForMember,
   resolveMemberFromPath,
+  normaliseMemberPath,
 } from "../scripts/lib/trackers/dispatcher.mjs";
 import {
   NotSupportedError,
@@ -343,7 +344,7 @@ describe("resolveMemberFromPath: workspace resolution", () => {
     );
     assert.throws(
       () => resolveMemberFromPath(WORKSPACE_CFG, "../escape/path.ts"),
-      /project-relative/,
+      /'\.\.'/,
     );
   });
 
@@ -356,5 +357,86 @@ describe("resolveMemberFromPath: workspace resolution", () => {
   it("throws on empty or non-string filePath", () => {
     assert.throws(() => resolveMemberFromPath(WORKSPACE_CFG, ""), /non-empty string/);
     assert.throws(() => resolveMemberFromPath(WORKSPACE_CFG, null), /non-empty string/);
+  });
+
+  // PR 8 R1 (Copilot): empty-after-normalisation inputs like "./" and
+  // "////" previously produced fileParts = [""] and silently resolved
+  // to the root member. Now rejected at the normaliser.
+  it("throws on inputs that collapse to empty after normalisation", () => {
+    assert.throws(() => resolveMemberFromPath(WORKSPACE_CFG, "./"), /collapses to empty/);
+    assert.throws(() => resolveMemberFromPath(WORKSPACE_CFG, "////"), /absolute/); // leading '/' now caught explicitly
+  });
+
+  // PR 8 R1 (Copilot): Windows backslashes in either filePath or
+  // member.path previously never matched POSIX diff input.
+  it("normalises backslashes in filePath so Windows-style input matches POSIX member paths", () => {
+    assert.equal(resolveMemberFromPath(WORKSPACE_CFG, "libs\\shared\\x.ts"), "shared");
+  });
+
+  it("normalises backslashes in member.path so a Windows-style config matches POSIX diff input", () => {
+    const winCfg = {
+      workspace: {
+        members: [
+          {
+            path: "libs\\shared",
+            name: "shared",
+            trackers: { dev: { kind: "github", owner: "acme", repo: "s", projects: [] } },
+          },
+        ],
+      },
+    };
+    assert.equal(resolveMemberFromPath(winCfg, "libs/shared/x.ts"), "shared");
+  });
+});
+
+describe("normaliseMemberPath: the canonical path normaliser", () => {
+  it("strips leading './' and trailing '/'", () => {
+    assert.equal(normaliseMemberPath("./libs/shared/", "x"), "libs/shared");
+    assert.equal(normaliseMemberPath("libs/shared", "x"), "libs/shared");
+  });
+
+  it("converts backslashes to forward slashes", () => {
+    assert.equal(normaliseMemberPath("libs\\shared", "x"), "libs/shared");
+    assert.equal(normaliseMemberPath(".\\libs\\shared\\", "x"), "libs/shared");
+  });
+
+  it("rejects absolute paths", () => {
+    assert.throws(() => normaliseMemberPath("/absolute", "x"), /absolute/);
+    assert.throws(() => normaliseMemberPath("/foo/bar", "x"), /absolute/);
+  });
+
+  it("rejects Windows drive paths", () => {
+    assert.throws(() => normaliseMemberPath("C:\\foo", "x"), /drive/);
+    assert.throws(() => normaliseMemberPath("D:/bar", "x"), /drive/);
+  });
+
+  it("rejects '..' segments", () => {
+    assert.throws(() => normaliseMemberPath("../escape", "x"), /'\.\.'/);
+    assert.throws(() => normaliseMemberPath("libs/../escape", "x"), /'\.\.'/);
+  });
+
+  it("rejects empty string and non-string", () => {
+    assert.throws(() => normaliseMemberPath("", "x"), /non-empty/);
+    assert.throws(() => normaliseMemberPath(null, "x"), /non-empty/);
+    assert.throws(() => normaliseMemberPath(42, "x"), /non-empty/);
+  });
+
+  it("rejects collapse-to-empty without allowRoot", () => {
+    assert.throws(() => normaliseMemberPath(".", "x"), /collapses to empty/);
+    assert.throws(() => normaliseMemberPath("./", "x"), /collapses to empty/);
+  });
+
+  it("returns '.' for collapse-to-empty WITH allowRoot (member root convention)", () => {
+    assert.equal(normaliseMemberPath(".", "x", { allowRoot: true }), ".");
+    assert.equal(normaliseMemberPath("./", "x", { allowRoot: true }), ".");
+  });
+
+  it("includes the label in every error message for debuggability", () => {
+    try {
+      normaliseMemberPath("/absolute", "member 'shared' path");
+      assert.fail("expected throw");
+    } catch (e) {
+      assert.match(e.message, /member 'shared' path/);
+    }
   });
 });

--- a/tests/trackers_dispatcher.test.mjs
+++ b/tests/trackers_dispatcher.test.mjs
@@ -439,4 +439,36 @@ describe("normaliseMemberPath: the canonical path normaliser", () => {
       assert.match(e.message, /member 'shared' path/);
     }
   });
+
+  // PR 8 R2 (Copilot): consecutive separators ("libs//shared") and
+  // interior "." segments ("libs/./shared") were accepted verbatim,
+  // but real git-diff paths never contain them. A member.path like
+  // "libs//shared" would then never match "libs/shared/x.ts" at
+  // runtime. Canonicalise to a single "/" with no "." segments.
+  it("collapses consecutive slashes to a single separator", () => {
+    assert.equal(normaliseMemberPath("libs//shared", "x"), "libs/shared");
+    assert.equal(normaliseMemberPath("libs///shared///x", "x"), "libs/shared/x");
+  });
+
+  it("drops interior '.' segments", () => {
+    assert.equal(normaliseMemberPath("libs/./shared", "x"), "libs/shared");
+    assert.equal(normaliseMemberPath("a/./b/./c", "x"), "a/b/c");
+  });
+
+  it("normalises mixed backslash+double-slash+'.' inputs", () => {
+    assert.equal(normaliseMemberPath("libs\\\\shared/./x", "x"), "libs/shared/x");
+  });
+
+  it("treats './././' as a rootOnly collapse (allowRoot only)", () => {
+    assert.equal(normaliseMemberPath("././", "x", { allowRoot: true }), ".");
+    assert.throws(() => normaliseMemberPath("././", "x"), /collapses to empty/);
+  });
+
+  // Regression: now that the normaliser collapses '//' and '.'
+  // segments, resolveMemberFromPath should transparently accept
+  // caller inputs with those artefacts and still resolve correctly.
+  it("resolveMemberFromPath accepts inputs with '//' and '.' segments", () => {
+    assert.equal(resolveMemberFromPath(WORKSPACE_CFG, "libs//shared/x.ts"), "shared");
+    assert.equal(resolveMemberFromPath(WORKSPACE_CFG, "libs/./shared/x.ts"), "shared");
+  });
 });

--- a/tests/trackers_dispatcher.test.mjs
+++ b/tests/trackers_dispatcher.test.mjs
@@ -10,6 +10,8 @@ import {
   pickReviewProvider,
   resolveTrackerKind,
   hasReleaseTracker,
+  pickTrackerForMember,
+  resolveMemberFromPath,
 } from "../scripts/lib/trackers/dispatcher.mjs";
 import {
   NotSupportedError,
@@ -191,5 +193,168 @@ describe("hasReleaseTracker", () => {
     assert.equal(hasReleaseTracker({ trackers: { release: {} } }), false);
     assert.equal(hasReleaseTracker({ trackers: { release: { kind: "" } } }), false);
     assert.equal(hasReleaseTracker({ trackers: { release: { kind: 42 } } }), false);
+  });
+});
+
+// PR 8: workspace multi-repo dispatch. Two new helpers for projects
+// that bind multiple sibling repos (mid-migration monorepos, toolchain
+// workspaces). Single-repo projects MUST keep working without change;
+// that is the core compatibility contract locked by these tests.
+const WORKSPACE_CFG = {
+  trackers: {
+    dev: { kind: "github", owner: "acme", repo: "primary", projects: [] },
+    release: { kind: "github", owner: "acme", projects: [] },
+  },
+  workspace: {
+    members: [
+      {
+        path: ".",
+        name: "primary",
+        trackers: {
+          dev: { kind: "github", owner: "acme", repo: "primary", projects: [] },
+        },
+      },
+      {
+        path: "libs/shared",
+        name: "shared",
+        trackers: {
+          dev: { kind: "jira", site: "acme.atlassian.net", project: "SHARED", status_values: { backlog: "Backlog", in_progress: "In progress", done: "Done" } },
+          release: { kind: "github", owner: "acme", projects: [] },
+        },
+      },
+    ],
+  },
+};
+
+describe("pickTrackerForMember: workspace dispatch", () => {
+  it("falls back to pickTracker(cfg, role) when memberName is null", () => {
+    const { tracker, kind, memberName } = pickTrackerForMember(GITHUB_DEV, null, "dev");
+    assert.equal(kind, "github");
+    assert.equal(memberName, null);
+    assert.equal(typeof tracker, "object");
+  });
+
+  it("also falls back when memberName is undefined (positional call)", () => {
+    const { kind, memberName } = pickTrackerForMember(GITHUB_DEV, undefined);
+    assert.equal(kind, "github");
+    assert.equal(memberName, null);
+  });
+
+  it("routes to the member-specific tracker when a valid memberName is passed", () => {
+    const { kind, memberName } = pickTrackerForMember(WORKSPACE_CFG, "shared", "dev");
+    assert.equal(kind, "jira", "member 'shared' declares kind=jira");
+    assert.equal(memberName, "shared");
+  });
+
+  it("routes primary member (path='.') to its own tracker (not the root block)", () => {
+    const { kind, memberName } = pickTrackerForMember(WORKSPACE_CFG, "primary", "dev");
+    assert.equal(kind, "github");
+    assert.equal(memberName, "primary");
+  });
+
+  it("throws when memberName is supplied but cfg.workspace is absent", () => {
+    assert.throws(
+      () => pickTrackerForMember(GITHUB_DEV, "shared"),
+      /workspace\.members is absent or empty/,
+    );
+  });
+
+  it("throws with a pointed 'unknown member' error listing known names", () => {
+    assert.throws(
+      () => pickTrackerForMember(WORKSPACE_CFG, "typo"),
+      /unknown workspace member 'typo'.*primary.*shared/s,
+    );
+  });
+
+  it("throws when the member does not declare the requested role", () => {
+    // primary member declares only trackers.dev, not .release
+    assert.throws(
+      () => pickTrackerForMember(WORKSPACE_CFG, "primary", "release"),
+      /member 'primary' is missing trackers\.release/,
+    );
+  });
+
+  it("validates role just like pickTracker", () => {
+    assert.throws(
+      () => pickTrackerForMember(WORKSPACE_CFG, "shared", "observed"),
+      /role must be "dev" or "release"/,
+    );
+  });
+});
+
+describe("resolveMemberFromPath: workspace resolution", () => {
+  it("returns null when cfg.workspace is absent (single-repo project)", () => {
+    assert.equal(resolveMemberFromPath(GITHUB_DEV, "src/index.ts"), null);
+  });
+
+  it("returns null when workspace.members is empty", () => {
+    assert.equal(resolveMemberFromPath({ workspace: { members: [] } }, "src/index.ts"), null);
+  });
+
+  it("resolves a file under a nested member path to that member", () => {
+    assert.equal(resolveMemberFromPath(WORKSPACE_CFG, "libs/shared/utils.ts"), "shared");
+  });
+
+  it("prefers the deepest matching member (nested wins over root)", () => {
+    // libs/shared/x is under BOTH '.' (the primary root) and 'libs/shared'.
+    // Deepest-first must pick the nested 'shared' member.
+    assert.equal(resolveMemberFromPath(WORKSPACE_CFG, "libs/shared/x.ts"), "shared");
+  });
+
+  it("falls back to the root member for files outside any nested member", () => {
+    assert.equal(resolveMemberFromPath(WORKSPACE_CFG, "src/main.ts"), "primary");
+  });
+
+  it("returns null when no member covers the file and there is no root member", () => {
+    const noRoot = {
+      workspace: {
+        members: [
+          {
+            path: "libs/shared",
+            name: "shared",
+            trackers: { dev: { kind: "github", owner: "acme", repo: "s", projects: [] } },
+          },
+        ],
+      },
+    };
+    assert.equal(resolveMemberFromPath(noRoot, "src/main.ts"), null);
+  });
+
+  it("normalises leading './' and trailing '/' in both file and member paths", () => {
+    assert.equal(resolveMemberFromPath(WORKSPACE_CFG, "./libs/shared/x.ts"), "shared");
+    const trailingSlash = {
+      workspace: {
+        members: [
+          {
+            path: "libs/shared/",
+            name: "shared",
+            trackers: { dev: { kind: "github", owner: "acme", repo: "s", projects: [] } },
+          },
+        ],
+      },
+    };
+    assert.equal(resolveMemberFromPath(trailingSlash, "libs/shared/x.ts"), "shared");
+  });
+
+  it("rejects absolute paths and parent-traversal as ambiguous", () => {
+    assert.throws(
+      () => resolveMemberFromPath(WORKSPACE_CFG, "/absolute/path.ts"),
+      /project-relative/,
+    );
+    assert.throws(
+      () => resolveMemberFromPath(WORKSPACE_CFG, "../escape/path.ts"),
+      /project-relative/,
+    );
+  });
+
+  it("does NOT match a prefix-only path that doesn't break on a segment boundary", () => {
+    // `libs/shared-v2/x.ts` must NOT match `libs/shared` — the member
+    // path must align with path segments, not raw string prefixes.
+    assert.equal(resolveMemberFromPath(WORKSPACE_CFG, "libs/shared-v2/x.ts"), "primary");
+  });
+
+  it("throws on empty or non-string filePath", () => {
+    assert.throws(() => resolveMemberFromPath(WORKSPACE_CFG, ""), /non-empty string/);
+    assert.throws(() => resolveMemberFromPath(WORKSPACE_CFG, null), /non-empty string/);
   });
 });

--- a/tests/trackers_dispatcher.test.mjs
+++ b/tests/trackers_dispatcher.test.mjs
@@ -439,6 +439,17 @@ describe("normaliseMemberPath: the canonical path normaliser", () => {
     assert.throws(() => normaliseMemberPath("Z:bar/baz", "x"), /drive/);
   });
 
+  // PR 8 R10 (Copilot): `./C:foo` bypassed the raw-input drive
+  // check because the `./` prefix made the regex miss, and the
+  // post-strip form re-exposed `C:foo`. Re-check after stripping
+  // so no prefix spelling of a drive path slips through.
+  it("rejects './C:foo' and backslash variants (drive path hidden behind './ prefix)", () => {
+    assert.throws(() => normaliseMemberPath("./C:foo", "x"), /drive/);
+    assert.throws(() => normaliseMemberPath(".\\C:foo", "x"), /drive/);
+    assert.throws(() => normaliseMemberPath("./D:/bar", "x"), /drive/);
+    assert.throws(() => normaliseMemberPath(".//C:foo", "x"), /drive/);
+  });
+
   it("rejects '..' segments", () => {
     assert.throws(() => normaliseMemberPath("../escape", "x"), /'\.\.'/);
     assert.throws(() => normaliseMemberPath("libs/../escape", "x"), /'\.\.'/);

--- a/tests/trackers_dispatcher.test.mjs
+++ b/tests/trackers_dispatcher.test.mjs
@@ -431,6 +431,14 @@ describe("normaliseMemberPath: the canonical path normaliser", () => {
     assert.throws(() => normaliseMemberPath("D:/bar", "x"), /drive/);
   });
 
+  // PR 8 R8 (Copilot): drive-relative form `C:foo` (no separator
+  // after the colon) is still drive-qualified on Windows and must
+  // also be rejected; the earlier guard only matched `[A-Za-z]:[\\/]`.
+  it("rejects Windows drive-relative paths (no separator after colon)", () => {
+    assert.throws(() => normaliseMemberPath("C:foo", "x"), /drive/);
+    assert.throws(() => normaliseMemberPath("Z:bar/baz", "x"), /drive/);
+  });
+
   it("rejects '..' segments", () => {
     assert.throws(() => normaliseMemberPath("../escape", "x"), /'\.\.'/);
     assert.throws(() => normaliseMemberPath("libs/../escape", "x"), /'\.\.'/);


### PR DESCRIPTION
## Summary

Adds full per-member dispatch for multi-repo workspaces. Single-repo projects keep working with zero changes. Multi-repo projects (sibling directories with their own git origins and possibly different trackers) now get:

- A new `pickTrackerForMember(cfg, memberName, role)` dispatcher that routes through the named member's tracker, or falls back to the project-level `pickTracker` when `memberName` is null / undefined.
- A new `resolveMemberFromPath(cfg, filePath)` helper that walks `workspace.members[]` deepest-first to resolve the owning member from a project-relative file path. Segment-aligned prefix match (`libs/shared-v2/x.ts` does NOT match `libs/shared`).
- A new bootstrap interview topic (Q7; interview grows from 9 to 10 topics): "Multi-repo workspace?" yes/no, with a member-collection loop on yes. Cap at 16 members.
- Install preflight that fails with a pointed error listing any `workspace.members[].path` that doesn't exist on disk (a missing path is almost always a bad commit from a teammate's checkout).
- SKILL.md updates on tracker-sync, dev-loop, pr-iteration documenting the `memberName` parameter and resolution flow.
- README section on multi-repo workspaces; removed the corresponding line from "Things the interview does not ask".

## Files changed

- `scripts/lib/trackers/dispatcher.mjs` — two new exports
- `scripts/bootstrap.mjs` — `interviewWorkspaceMembers()` helper, Q7 integration, compose + pickDefaults wiring
- `scripts/install.mjs` — preflight for member path existence
- `skills/tracker-sync/SKILL.md`, `skills/dev-loop/SKILL.md`, `skills/pr-iteration/SKILL.md` — prose updates
- `README.md` — new "Multi-repo workspaces" section
- `tests/trackers_dispatcher.test.mjs` — 18 new tests
- `tests/bootstrap.test.mjs` — 6 new tests (3 compose + 3 interview)

## Test plan

- [x] `npm test` — 439 tests pass (24 new)
- [x] `npm run validate` — PASS
- [x] `npm run lint` — 0 errors
- [ ] Copilot review on this PR; iterate to clean terminal state

## Plan reference

`/Users/developer/.claude/plans/can-we-make-the-binary-emerson.md` PR 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)