### PR TITLE
feat(issue-discovery): staff-engineer intake skill (PR 16)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -41,6 +41,7 @@ Before acting on any user request, check the target project's state:
 
 ## What you do when fully configured
 
+- Before driving any dev work, confirm the user's intent via the `issue-discovery` skill when no resolvable issue reference was supplied. Staff engineers ask before guessing.
 - Drive dev issues from Backlog / Ready to In review via the `dev-loop` skill. Never merge a PR. Never set a dev issue to Done. Both are human gates.
 - Reconcile labels, open PRs / MRs, request reviewers, and post comments through the `tracker-sync` skill. Every other skill routes tracker writes through it.
 - Compute release umbrella status via the `release-tracker` skill.
@@ -72,6 +73,7 @@ Running `node <BUNDLE>/scripts/install.mjs --target <project> --update` refreshe
 - No em or en dashes in anything you author: issue bodies, PR descriptions, comments, reports, plan files.
 - Run the full local review loop (format, lint, type, unit, integration, e2e where applicable, self-review) before pushing. The self-review step delegates to `ctxr-dev/skill-code-review` by default.
 - Never touch the target project's `daily/` or `knowledge/` folders; those are owned by the project's own hooks.
+- Never guess what to work on. When the user asks "what should I work on?" or gives a free-form description with no issue reference, run `skills/issue-discovery/SKILL.md` and offer 2-4 options plus custom at every branch.
 
 Full rule texts live at `<BUNDLE>/rules/*.md`, surfaced through the generated wrappers at `.claude/rules/agent-staff-engineer_*.md`.
 

--- a/bundle-index.md
+++ b/bundle-index.md
@@ -22,6 +22,15 @@ When you add or remove a bundle doc, update this file in the same PR.
 
 Most skills are triggered by a concrete intent. Map the user's ask to the minimal doc set.
 
+### Discovering what to work on next (no issue ref yet)
+
+- [skills/issue-discovery/SKILL.md](skills/issue-discovery/SKILL.md): the staff-engineer intake interview the agent runs before any dev-loop.
+- [skills/issue-discovery/runbook.md](skills/issue-discovery/runbook.md): branch-by-branch Q&A script with exact wording and halt scenarios.
+- [rules/issue-discovery.md](rules/issue-discovery.md): the three-clause binding rule (never guess; 2-4 options plus custom; delegate writes to tracker-sync).
+- [rules/ambiguity-halt.md](rules/ambiguity-halt.md): minimum halt contract the interview sits on.
+- [memory-seeds/issue-discovery-posture.md](memory-seeds/issue-discovery-posture.md): memory seed for the intake posture.
+- [templates/issue-discovery-session.md](templates/issue-discovery-session.md): human-readable rendering of a session scratch file.
+
 ### Opening or driving a dev issue to "In review"
 
 - [skills/dev-loop/SKILL.md](skills/dev-loop/SKILL.md): the state machine (branch, edits, local review, self-review, push, PR open, issue -> In review, hand off to pr-iteration).
@@ -112,21 +121,23 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 
 ## By surface
 
-### Skills (8)
+### Skills (9)
 
 - [skills/adapt-system/SKILL.md](skills/adapt-system/SKILL.md): reshape config/labels/templates/rules/seeds on project-intent changes.
 - [skills/bootstrap-ops-config/SKILL.md](skills/bootstrap-ops-config/SKILL.md): interactive first-install interview.
 - [skills/dev-loop/SKILL.md](skills/dev-loop/SKILL.md): issue -> branch -> local review -> PR open -> In review.
+- [skills/issue-discovery/SKILL.md](skills/issue-discovery/SKILL.md): staff-engineer intake interview when no issue ref is supplied.
 - [skills/tracker-sync/SKILL.md](skills/tracker-sync/SKILL.md): sole tracker writer (github / jira / linear / gitlab); depth-gated per tracker target.
 - [skills/plan-keeper/SKILL.md](skills/plan-keeper/SKILL.md): plan folder / frontmatter / lifecycle.
 - [skills/pr-iteration/SKILL.md](skills/pr-iteration/SKILL.md): post-push loop until exit conditions hold.
 - [skills/regression-handler/SKILL.md](skills/regression-handler/SKILL.md): bug triage + linked-issue proposal.
 - [skills/release-tracker/SKILL.md](skills/release-tracker/SKILL.md): Release umbrella status computation.
 
-### Rules (10)
+### Rules (11)
 
 - [rules/adaptation.md](rules/adaptation.md): when to invoke adapt-system.
 - [rules/ambiguity-halt.md](rules/ambiguity-halt.md): halt-and-ask when state is weird.
+- [rules/issue-discovery.md](rules/issue-discovery.md): the three-clause intake rule (never guess; 2-4 options plus custom; delegate writes).
 - [rules/tracker-source-of-truth.md](rules/tracker-source-of-truth.md): the configured tracker(s) own state; local files are projections.
 - [rules/llm-wiki.md](rules/llm-wiki.md): project-side wiki read/write contract.
 - [rules/memory-hygiene.md](rules/memory-hygiene.md): project memory boundaries.
@@ -136,10 +147,11 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 - [rules/pr-workflow.md](rules/pr-workflow.md): PR state machine + two human gates.
 - [rules/review-loop.md](rules/review-loop.md): pre-push local review stages.
 
-### Templates (11)
+### Templates (12)
 
 - [templates/code-review-report.md](templates/code-review-report.md): fallback self-review artefact.
 - [templates/issue-bug.md](templates/issue-bug.md): bug issue body.
+- [templates/issue-discovery-session.md](templates/issue-discovery-session.md): human-readable render of an issue-discovery session scratch file.
 - [templates/issue-feature.md](templates/issue-feature.md): feature issue body.
 - [templates/issue-refactor.md](templates/issue-refactor.md): refactor issue body.
 - [templates/issue-release.md](templates/issue-release.md): release umbrella body.
@@ -150,10 +162,11 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 - [templates/regression-report.md](templates/regression-report.md): regression triage report.
 - [templates/release-readiness-checklist.md](templates/release-readiness-checklist.md): release-readiness artefact.
 
-### Memory seeds (9)
+### Memory seeds (10)
 
 - [memory-seeds/commit-style-conventional.md](memory-seeds/commit-style-conventional.md): conventional commits.
 - [memory-seeds/dash-free-writing.md](memory-seeds/dash-free-writing.md): no-dashes rule seed.
+- [memory-seeds/issue-discovery-posture.md](memory-seeds/issue-discovery-posture.md): intake posture; run issue-discovery before any dev-loop without an issue ref.
 - [memory-seeds/ops-config-usage.md](memory-seeds/ops-config-usage.md): cite the keys you used.
 - [memory-seeds/plan-lifecycle-moves.md](memory-seeds/plan-lifecycle-moves.md): plan lifecycle states + moves.
 - [memory-seeds/planning-parallel-agents.md](memory-seeds/planning-parallel-agents.md): Phase-1 parallel Explore.

--- a/examples/ops.config.example.json
+++ b/examples/ops.config.example.json
@@ -142,6 +142,13 @@
       "poll_interval_seconds": 30,
       "poll_timeout_seconds": 1200,
       "auto_resolve_stale_after_commits": 1
+    },
+    "issue_discovery": {
+      "title_templates": [],
+      "stakeholders": [],
+      "domain_glossary": {},
+      "default_type": null,
+      "topic_confirmation": true
     }
   },
 

--- a/memory-seeds/issue-discovery-posture.md
+++ b/memory-seeds/issue-discovery-posture.md
@@ -18,7 +18,7 @@ The agent treats "no issue reference yet" as a first-class intake state, not a p
 - dev-loop invoked with an unresolvable issue ref: dev-loop halts at entry and hands off to `issue-discovery`.
 - Every branch in the interview offers 2 to 4 concrete options plus a custom escape hatch. No fewer (hides deliberation), no more (overloads the user).
 - Custom choices that fall outside the configured surface (labels, trackers, intents) halt per `rules/ambiguity-halt.md` and name `/adapt-system` as the next step.
-- No tracker writes fire without the Q6 confirmation gate returning `Proceed`. Silent defaults are forbidden.
+- Tracker writes are user-ack'd at explicit gates. Issue creation fires only after the Q6 confirmation returns `Proceed`. New-umbrella creation fires only after the user's Q4c pick of "Create a new umbrella" plus completion of Q5.1-Q5.8; the umbrella gate runs before Q6, not through it. Silent defaults are forbidden on both paths.
 - Session state lives under `.development/local/issue-discovery/`; it never promotes to `ops.config.json` or to persistent memory.
 
-Writes route through `tracker-sync` for issues and through `release-tracker.createUmbrellaForIntent` for new umbrellas; the skill never calls the tracker API directly.
+Writes route through `tracker-sync.issues.createIssue` for issues and through `release-tracker.createUmbrellaForIntent` for new umbrellas; the skill never calls the tracker API directly.

--- a/memory-seeds/issue-discovery-posture.md
+++ b/memory-seeds/issue-discovery-posture.md
@@ -1,0 +1,24 @@
+---
+name: Issue discovery posture
+description: When the user asks "what should I work on?" or starts without a resolvable issue, run the staff-engineer intake interview. Never guess; 2-4 options plus custom at every branch; delegate writes to tracker-sync.
+type: feedback
+portable: true
+tags: []
+placeholders: []
+---
+
+The agent treats "no issue reference yet" as a first-class intake state, not a prompt to guess. It runs the `issue-discovery` skill before any dev-loop.
+
+**Why:** picking the wrong thing to work on is the most expensive mistake a staff engineer can make on behalf of a manager. A short structured interview with named options beats a confident guess, even when the guess would be right more often than not. The cost of asking one more question is low; the cost of shipping work the user didn't ask for is high.
+
+**How to apply:**
+
+- Free-form user intent with no issue reference: invoke `skills/issue-discovery/SKILL.md`.
+- "Pick up next / what should I work on?" with no args: same.
+- dev-loop invoked with an unresolvable issue ref: dev-loop halts at entry and hands off to `issue-discovery`.
+- Every branch in the interview offers 2 to 4 concrete options plus a custom escape hatch. No fewer (hides deliberation), no more (overloads the user).
+- Custom choices that fall outside the configured surface (labels, trackers, intents) halt per `rules/ambiguity-halt.md` and name `/adapt-system` as the next step.
+- No tracker writes fire without the Q6 confirmation gate returning `Proceed`. Silent defaults are forbidden.
+- Session state lives under `.development/local/issue-discovery/`; it never promotes to `ops.config.json` or to persistent memory.
+
+Writes route through `tracker-sync` for issues and through `release-tracker.createUmbrellaForIntent` for new umbrellas; the skill never calls the tracker API directly.

--- a/rules/issue-discovery.md
+++ b/rules/issue-discovery.md
@@ -28,9 +28,11 @@ Applies to:
 
 ### Clause 2: 2 to 4 options plus custom at every branch
 
-Every node where the user must choose from the configuration surface (trackers, areas, intents, umbrellas, templates) presents **2 to 4 concrete options and one custom escape hatch**. Fewer than 2 collapses the branch to yes or no and hides the deliberation the intake is designed to surface. More than 4 overloads the user.
+Every node where the user must choose from the configuration surface (trackers, areas, intents, umbrellas, templates) presents **2 to 4 concrete domain options and one custom escape hatch**. Fewer than 2 domain options collapses the branch to yes or no and hides the deliberation the intake is designed to surface. More than 4 domain options overloads the user.
 
-- Shortlists (issues, umbrellas) are ranked by a deterministic criterion (priority + age for issues; status + target date for umbrellas) and capped at 4. A "show more" option is always offered.
+"Domain options" means the actual choices drawn from the configured surface (trackers in `trackers.dev[]`, areas in `labels.area`, the configured umbrellas, etc.). Meta-options (a "show more" pager on shortlists, the "something else" custom escape hatch) are navigational controls and do NOT count toward the 2-4 limit. A shortlist prompt can legally render 4 issues + "show more" + "file a new one" and still satisfy the contract.
+
+- Shortlists (issues, umbrellas) are ranked by a deterministic criterion (priority + age for issues; status + target date for umbrellas) and capped at 4 domain options. A "show more" meta-option is always offered on top when more candidates exist on the tracker.
 - "Custom" is always the last option and always triggers a halt per [rules/ambiguity-halt.md](ambiguity-halt.md) when the custom value falls outside the configured surface (e.g. an area that does not exist in `labels.area`, an intent not in `labels.intent`). Halt surfaces the next step as an `adapt-system` invocation.
 
 ### Clause 3: delegate every tracker write to tracker-sync
@@ -48,7 +50,7 @@ Every prompt in the interview follows the shape:
 
 <short question ending with `?`>
 
-1. <option one — concrete, quotable>
+1. <option one (concrete, quotable)>
 2. <option two>
 (3. <option three if present>)
 (4. <option four if present>)

--- a/rules/issue-discovery.md
+++ b/rules/issue-discovery.md
@@ -28,9 +28,14 @@ Applies to:
 
 ### Clause 2: 2 to 4 options plus custom at every branch
 
-Every node where the user must choose from the configuration surface (trackers, areas, intents, umbrellas, templates) presents **2 to 4 concrete domain options and one custom escape hatch**. Fewer than 2 domain options collapses the branch to yes or no and hides the deliberation the intake is designed to surface. More than 4 domain options overloads the user.
+This clause scopes precisely to **configured-surface nodes**: prompts where the user must pick a value from `trackers.dev[]`, `labels.area`, `labels.intent`, the list of open umbrellas, the list of open issues, or any similar configured-surface set. At those nodes, the skill presents **2 to 4 concrete domain options and one custom escape hatch**. Fewer than 2 domain options collapses the branch to yes or no and hides the deliberation the intake is designed to surface. More than 4 domain options overloads the user.
 
-"Domain options" means the actual choices drawn from the configured surface (trackers in `trackers.dev[]`, areas in `labels.area`, the configured umbrellas, etc.). Meta-options (a "show more" pager on shortlists, the "something else" custom escape hatch) are navigational controls and do NOT count toward the 2-4 limit. A shortlist prompt can legally render 4 issues + "show more" + "file a new one" and still satisfy the contract.
+Two kinds of node sit outside this clause and follow their own contract:
+
+1. **Fixed-enumeration nodes** (priority high / medium / low; size small / medium / large; issue type feature / task / refactor / bug). The allowed values are a closed taxonomy not configurable per-project; no custom escape hatch applies. The 2-4 limit still holds (the enumeration has 3 or 4 values).
+2. **Free-form capture nodes** (Q3b title free-form, Q5.2 umbrella goal, Q5.7 rollback plan). The user types text the skill records verbatim. No options list and no custom escape hatch; validation happens on shape (min-length, regex) rather than on a configured allow-list.
+
+"Domain options" means the actual choices drawn from the configured surface. Meta-options (a "show more" pager on shortlists, the "something else" custom escape hatch) are navigational controls and do NOT count toward the 2-4 limit. A shortlist prompt can legally render 4 issues + "show more" + "file a new one" and still satisfy the contract.
 
 - Shortlists (issues, umbrellas) are ranked by a deterministic criterion (priority + age for issues; status + target date for umbrellas) and capped at 4 domain options. A "show more" meta-option is always offered on top when more candidates exist on the tracker.
 - "Custom" is always the last option and always triggers a halt per [rules/ambiguity-halt.md](ambiguity-halt.md) when the custom value falls outside the configured surface (e.g. an area that does not exist in `labels.area`, an intent not in `labels.intent`). Halt surfaces the next step as an `adapt-system` invocation.

--- a/rules/issue-discovery.md
+++ b/rules/issue-discovery.md
@@ -1,0 +1,104 @@
+---
+name: issue-discovery
+description: When the user asks "what should I work on?" or gives a free-form description with no issue reference, run the staff-engineer intake interview instead of guessing. Never guess. Offer 2-4 options plus custom at every branch. Delegate all tracker writes through tracker-sync.
+portable: true
+scope: every session where the agent is about to start work on a dev issue that has not yet been named
+---
+
+# Issue discovery
+
+## The rule
+
+When a session is about to begin work on a dev issue and the user has not supplied a resolvable issue reference, the agent runs the `issue-discovery` skill as its first step. The skill interviews the user as a staff engineer would interview a manager: short, decision-by-decision prompts that refuse to progress without an explicit answer, and never silently invent a default.
+
+Three clauses are binding on every node of the interview, every surface that consumes its output, and every skill that delegates into it.
+
+### Clause 1: never guess
+
+The skill does not "pick a reasonable default" to move the session forward. When the facts needed to proceed are thin, incomplete, or contradictory, the skill halts per [rules/ambiguity-halt.md](ambiguity-halt.md) and asks. Staff engineers escalate judgement calls to their manager; the skill does the same to the user.
+
+Applies to:
+
+- Choosing a target project when more than one writable `trackers.dev` is configured.
+- Selecting an issue from the open-issues shortlist.
+- Picking the issue type, area label, priority, size, or release umbrella.
+- Filling in acceptance criteria, non-goals, rollback plan, or any other required field.
+
+"I'll just pick the first one" is not a valid path. "The most recent issue" is not a valid path. "The area that appears in the user's sentence" is not a valid path. The skill asks.
+
+### Clause 2: 2 to 4 options plus custom at every branch
+
+Every node where the user must choose from the configuration surface (trackers, areas, intents, umbrellas, templates) presents **2 to 4 concrete options and one custom escape hatch**. Fewer than 2 collapses the branch to yes or no and hides the deliberation the intake is designed to surface. More than 4 overloads the user.
+
+- Shortlists (issues, umbrellas) are ranked by a deterministic criterion (priority + age for issues; status + target date for umbrellas) and capped at 4. A "show more" option is always offered.
+- "Custom" is always the last option and always triggers a halt per [rules/ambiguity-halt.md](ambiguity-halt.md) when the custom value falls outside the configured surface (e.g. an area that does not exist in `labels.area`, an intent not in `labels.intent`). Halt surfaces the next step as an `adapt-system` invocation.
+
+### Clause 3: delegate every tracker write to tracker-sync
+
+The skill reads from and collects structured data about the tracker, but **never calls the tracker API directly**. Every create, update, link, and read routes through [skills/tracker-sync/SKILL.md](../skills/tracker-sync/SKILL.md). This mirrors [rules/tracker-source-of-truth.md](tracker-source-of-truth.md) but is called out explicitly here because the intake is the first place a newly-arriving user's intent hits bundle code: a single direct `gh`/`jira`/`linear` call here would break the invariant for every downstream skill.
+
+The one public exception is `release-tracker`: the skill calls the `release-tracker` public entry point `createUmbrellaForIntent(intent, payload)` rather than `tracker-sync.create_release_umbrella` directly, so release-tracker can recompute umbrella status as a side effect. `release-tracker` owns the final tracker-sync dispatch.
+
+## Message shape
+
+Every prompt in the interview follows the shape:
+
+```text
+<one-sentence context restating what the skill knows so far>
+
+<short question ending with `?`>
+
+1. <option one — concrete, quotable>
+2. <option two>
+(3. <option three if present>)
+(4. <option four if present>)
+N. Something else (I'll halt so we can decide).
+```
+
+- No emojis.
+- No em or en dashes (see [rules/no-dashes.md](no-dashes.md)).
+- No apology framing, no filler, no hedging.
+- The numbered list is strict: the user's reply is parsed by number first, then free-form.
+
+Matches the [rules/ambiguity-halt.md](ambiguity-halt.md) minimum contract; this rule adds the option-count and custom-escape format on top. If a caller ever picks between the two, ambiguity-halt wins: its message shape is the portable minimum every skill honours.
+
+## Hard never-do list
+
+While the interview is open (a session-state file under `.development/local/issue-discovery/` exists and has not been archived), the skill MUST NOT:
+
+- Call `tracker-sync.issues.createIssue` without a completed Q6 confirmation gate.
+- Call `release-tracker.createUmbrellaForIntent` (or any other umbrella-create surface) without a completed Q5 or Q4a branch.
+- Infer a default from the user's first message and skip ahead to Q6.
+- Auto-resume a stale session (older than 24 hours) without explicit user confirmation.
+- Promote anything from the session scratch file into `ops.config.json` or into persistent project memory.
+- Start a second `issue-discovery` session in parallel for the same target project.
+
+Read-only work (listing open issues, listing umbrellas, scoring areas against the user's intent) stays allowed. The skill may gather more context to improve the options it presents before asking.
+
+## Resume protocol
+
+On agent boot (future work covered by the session-resume rule), an open session under `.development/local/issue-discovery/` is surfaced as:
+
+```text
+Found an unfinished issue-discovery session from <ISO timestamp> about "<intent>".
+Last node reached: <node id>.
+
+1. Resume from where we left off.
+2. Discard and start over.
+3. Leave it; I'll come back to it later.
+```
+
+The user's answer is authoritative. "Leave it" does not promote the state to durable config; the file stays where it is for the next session to surface again.
+
+## What counts as a stale session
+
+A session file older than 24 hours is treated as stale. The skill still surfaces it on resume, but the default offered answer is "Discard and start over". The user can still pick "Resume from where we left off"; the choice is explicit either way.
+
+## Related
+
+- [skills/issue-discovery/SKILL.md](../skills/issue-discovery/SKILL.md): the skill contract and the decision tree.
+- [skills/issue-discovery/runbook.md](../skills/issue-discovery/runbook.md): the branch-by-branch Q&A script with exact wording and halt scenarios.
+- [rules/ambiguity-halt.md](ambiguity-halt.md): the portable minimum halt contract this rule sits on top of.
+- [rules/tracker-source-of-truth.md](tracker-source-of-truth.md): the tracker-is-source rule this rule reinforces.
+- [rules/pr-workflow.md](pr-workflow.md): the two human gates every dev-loop hand-off respects (merge, Done). Issue-discovery sits BEFORE dev-loop and does not cross either gate.
+- [memory-seeds/issue-discovery-posture.md](../memory-seeds/issue-discovery-posture.md): the one-paragraph memory seed that travels to every installed project.

--- a/schemas/issue-discovery-handoff.schema.json
+++ b/schemas/issue-discovery-handoff.schema.json
@@ -5,9 +5,9 @@
   "oneOf": [
     {
       "type": "object",
-      "required": ["issueRef"],
+      "required": ["issueRef", "umbrellaRef", "memberName"],
       "additionalProperties": false,
-      "description": "Success handoff: the interview reached Q6 Proceed and tracker-sync.issues.createIssue returned a resolvable issue.",
+      "description": "Success handoff: the interview reached Q6 Proceed and tracker-sync.issues.createIssue returned a resolvable issue. `umbrellaRef` and `memberName` are required AS fields but may hold null when the intake decided against an umbrella link or the project is single-repo; this keeps the three-field tuple contract stable so callers don't branch on absent-vs-null.",
       "properties": {
         "issueRef": {
           "type": "object",

--- a/schemas/issue-discovery-handoff.schema.json
+++ b/schemas/issue-discovery-handoff.schema.json
@@ -1,0 +1,77 @@
+{
+  "$id": "https://ctxr-dev.github.io/agent-staff-engineer/schemas/issue-discovery-handoff.schema.json",
+  "title": "issue-discovery handoff tuple",
+  "description": "Shape of the object skills/issue-discovery/SKILL.md returns to its caller (typically skills/dev-loop/SKILL.md). The tuple encodes the decisions the interview reached so the caller can resume its own state machine with no further user prompts. Either a complete tuple (success) or a cancelled marker.",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": ["issueRef"],
+      "additionalProperties": false,
+      "description": "Success handoff: the interview reached Q6 Proceed and tracker-sync.issues.createIssue returned a resolvable issue.",
+      "properties": {
+        "issueRef": {
+          "type": "object",
+          "required": ["number"],
+          "additionalProperties": false,
+          "description": "Minimal issue reference the caller can use to dispatch subsequent tracker-sync calls. Mirrors the shape tracker-sync.issues.createIssue returns.",
+          "properties": {
+            "number": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Issue number on the target tracker."
+            },
+            "nodeId": {
+              "type": "string",
+              "description": "GraphQL node ID (GitHub) or equivalent opaque ID for other trackers. Optional because not every tracker exposes one.",
+              "minLength": 1
+            },
+            "url": {
+              "type": "string",
+              "description": "Canonical URL of the created / linked issue.",
+              "format": "uri"
+            }
+          }
+        },
+        "umbrellaRef": {
+          "type": ["object", "null"],
+          "required": ["number"],
+          "additionalProperties": false,
+          "description": "Release umbrella the issue links to, if any. Null when trackers.release is absent, when the user picked 'no umbrella', or when the tracker kind does not implement umbrellas yet.",
+          "properties": {
+            "number": { "type": "integer", "minimum": 1 },
+            "nodeId": { "type": "string", "minLength": 1 },
+            "url": { "type": "string", "format": "uri" }
+          }
+        },
+        "memberName": {
+          "type": ["string", "null"],
+          "description": "Name of the workspace.members[] entry the issue belongs to, when the target project is a multi-repo workspace. Null for single-repo projects and for workspace configs where the issue falls outside any nested member.",
+          "minLength": 1
+        },
+        "cancelled": {
+          "type": "boolean",
+          "const": false,
+          "description": "Present only on the success shape; always false. Callers can branch on `handoff.cancelled` without inspecting other fields.",
+          "default": false
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["cancelled"],
+      "additionalProperties": false,
+      "description": "Cancel handoff: the user picked Q6 Cancel. No tracker writes fired; the caller should stop cleanly without halting or opening any followup.",
+      "properties": {
+        "cancelled": {
+          "type": "boolean",
+          "const": true
+        },
+        "reason": {
+          "type": "string",
+          "description": "Optional free-form cancellation reason captured at Q6 (e.g. 'user wants to think about it'). Not required.",
+          "maxLength": 500
+        }
+      }
+    }
+  ]
+}

--- a/schemas/issue-discovery-handoff.schema.json
+++ b/schemas/issue-discovery-handoff.schema.json
@@ -51,7 +51,7 @@
         "cancelled": {
           "type": "boolean",
           "const": false,
-          "description": "Present only on the success shape; always false. Callers can branch on `handoff.cancelled` without inspecting other fields.",
+          "description": "Optional on the success shape; when present it is always false. Callers may branch on `handoff.cancelled` and treat a missing value as false without inspecting other fields.",
           "default": false
         }
       }

--- a/schemas/issue-discovery-session.schema.json
+++ b/schemas/issue-discovery-session.schema.json
@@ -18,8 +18,8 @@
   "properties": {
     "sessionId": {
       "type": "string",
-      "description": "Session identifier. Format: `<YYYYMMDD-HHMMSS>-<short-slug>` where slug is a 6-char urlsafe hash of the intent text; makes listing deterministic and scannable.",
-      "pattern": "^[0-9]{8}-[0-9]{6}-[A-Za-z0-9_-]{4,16}$"
+      "description": "Session identifier. Format: `<YYYYMMDD-HHMMSS>-<4 hex chars>` as produced by scripts/lib/issueDiscovery.mjs#newSessionId. The hex tail is 2 random bytes rendered as hex; the date/time stamp is UTC so listings sort chronologically.",
+      "pattern": "^[0-9]{8}-[0-9]{6}-[0-9a-f]{4}$"
     },
     "version": {
       "type": "integer",
@@ -74,20 +74,49 @@
       "description": "True once Q0 (topic confirmation) returned 'Correct' or an edited version the user accepted."
     },
     "trackerTarget": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "Minimal tracker coordinates the skill dispatches against. Resolved at Q1 (or at ENTRY when exactly one writable target exists).",
-      "properties": {
-        "kind": { "type": "string", "enum": ["github", "jira", "linear", "gitlab"] },
-        "owner": { "type": "string", "minLength": 1 },
-        "repo": { "type": "string", "minLength": 1 },
-        "site": { "type": "string", "minLength": 1 },
-        "project": { "type": "string", "minLength": 1 },
-        "workspace": { "type": "string", "minLength": 1 },
-        "team": { "type": "string", "minLength": 1 },
-        "host": { "type": "string", "minLength": 1 },
-        "project_path": { "type": "string", "minLength": 1 }
-      }
+      "description": "Minimal tracker coordinates the skill dispatches against. Resolved at Q1 (or at ENTRY when exactly one writable target exists). `kind`-keyed discriminated union so each backend requires the right coordinate set; an empty object or a kind-only object fails validation.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "owner", "repo"],
+          "properties": {
+            "kind": { "type": "string", "const": "github" },
+            "owner": { "type": "string", "minLength": 1 },
+            "repo": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "site", "project"],
+          "properties": {
+            "kind": { "type": "string", "const": "jira" },
+            "site": { "type": "string", "minLength": 1 },
+            "project": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "workspace", "team"],
+          "properties": {
+            "kind": { "type": "string", "const": "linear" },
+            "workspace": { "type": "string", "minLength": 1 },
+            "team": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "host", "project_path"],
+          "properties": {
+            "kind": { "type": "string", "const": "gitlab" },
+            "host": { "type": "string", "minLength": 1 },
+            "project_path": { "type": "string", "minLength": 1 }
+          }
+        }
+      ]
     },
     "memberName": {
       "type": ["string", "null"],

--- a/schemas/issue-discovery-session.schema.json
+++ b/schemas/issue-discovery-session.schema.json
@@ -1,0 +1,186 @@
+{
+  "$id": "https://ctxr-dev.github.io/agent-staff-engineer/schemas/issue-discovery-session.schema.json",
+  "title": "issue-discovery session state",
+  "description": "Ephemeral scratch state the issue-discovery skill persists under .development/local/issue-discovery/<session-id>.json. Validated on every read (scripts/lib/issueDiscovery.mjs#readSession) so a corrupted file fails loud instead of crashing mid-interview. Never promoted to durable config; archived on Q6 terminal nodes with a .completed.json or .cancelled.json suffix.",
+  "type": "object",
+  "required": [
+    "sessionId",
+    "version",
+    "startedAt",
+    "updatedAt",
+    "currentStep",
+    "intentText",
+    "topicConfirmed",
+    "trackerTarget",
+    "answers"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "sessionId": {
+      "type": "string",
+      "description": "Session identifier. Format: `<YYYYMMDD-HHMMSS>-<short-slug>` where slug is a 6-char urlsafe hash of the intent text; makes listing deterministic and scannable.",
+      "pattern": "^[0-9]{8}-[0-9]{6}-[A-Za-z0-9_-]{4,16}$"
+    },
+    "version": {
+      "type": "integer",
+      "description": "Schema version for migrations. 1 is the initial shape.",
+      "const": 1
+    },
+    "startedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp of the session start."
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp of the last persisted mutation. Updated on every node transition."
+    },
+    "currentStep": {
+      "type": "string",
+      "enum": [
+        "q0",
+        "q1",
+        "q2",
+        "q3a",
+        "q3b",
+        "q3c",
+        "q3d",
+        "q3e-priority",
+        "q3e-size",
+        "q3f",
+        "q4a",
+        "q4c",
+        "q5.1",
+        "q5.2",
+        "q5.3",
+        "q5.4",
+        "q5.5",
+        "q5.6",
+        "q5.7",
+        "q5.8",
+        "q6",
+        "done"
+      ],
+      "description": "Which node of the decision tree is awaiting the user's answer. `done` is the terminal state reached after Q6 Proceed (and before archival)."
+    },
+    "intentText": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The user's first-message free-form intent, recorded verbatim. Never mutated downstream."
+    },
+    "topicConfirmed": {
+      "type": "boolean",
+      "description": "True once Q0 (topic confirmation) returned 'Correct' or an edited version the user accepted."
+    },
+    "trackerTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Minimal tracker coordinates the skill dispatches against. Resolved at Q1 (or at ENTRY when exactly one writable target exists).",
+      "properties": {
+        "kind": { "type": "string", "enum": ["github", "jira", "linear", "gitlab"] },
+        "owner": { "type": "string", "minLength": 1 },
+        "repo": { "type": "string", "minLength": 1 },
+        "site": { "type": "string", "minLength": 1 },
+        "project": { "type": "string", "minLength": 1 },
+        "workspace": { "type": "string", "minLength": 1 },
+        "team": { "type": "string", "minLength": 1 },
+        "host": { "type": "string", "minLength": 1 },
+        "project_path": { "type": "string", "minLength": 1 }
+      }
+    },
+    "memberName": {
+      "type": ["string", "null"],
+      "description": "Workspace member name when the target project uses workspace.members[]. Null for single-repo projects.",
+      "minLength": 1
+    },
+    "answers": {
+      "type": "array",
+      "description": "Ordered log of every user answer. Each entry records the node id, the raw user input, and a short summary the confirmation-gate renderer uses.",
+      "items": {
+        "type": "object",
+        "required": ["nodeId", "timestamp", "rawInput"],
+        "additionalProperties": false,
+        "properties": {
+          "nodeId": { "type": "string", "minLength": 1 },
+          "timestamp": { "type": "string", "format": "date-time" },
+          "rawInput": { "type": "string" },
+          "summary": { "type": "string", "maxLength": 240 }
+        }
+      }
+    },
+    "proposedPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The issue-create payload assembled incrementally through Q3b-Q3f. Surfaced at Q6 for the user to proof-read before the Proceed.",
+      "properties": {
+        "title": { "type": "string", "minLength": 1 },
+        "type": { "type": "string", "enum": ["feature", "task", "refactor", "bug"] },
+        "labels": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "priority": { "type": "string", "enum": ["high", "medium", "low"] },
+        "size": { "type": "string", "enum": ["small", "medium", "large"] },
+        "acceptanceCriteria": { "type": ["string", "null"] }
+      }
+    },
+    "umbrellaDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The Q4/Q5 outcome. Kind encodes the branch the user picked; payload is populated only for the create-new branch.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["skip", "link-existing", "create-new"]
+        },
+        "ref": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "number": { "type": "integer", "minimum": 1 },
+            "nodeId": { "type": "string", "minLength": 1 },
+            "url": { "type": "string", "format": "uri" }
+          }
+        },
+        "payload": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "intent": { "type": "string", "minLength": 1 },
+            "goal": { "type": "string", "minLength": 30 },
+            "scopeTag": { "type": "string", "minLength": 1 },
+            "targetDate": {
+              "type": ["string", "null"],
+              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            },
+            "nonGoals": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "definitionOfDone": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "minItems": 1
+            },
+            "rollbackPlan": { "type": "string", "minLength": 20 },
+            "stakeholders": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "createdIssueRef": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "description": "Populated after Q6 Proceed with the ref tracker-sync.issues.createIssue returned. The presence of this field with `currentStep: done` means the session is ready for archival.",
+      "properties": {
+        "number": { "type": "integer", "minimum": 1 },
+        "nodeId": { "type": "string", "minLength": 1 },
+        "url": { "type": "string", "format": "uri" }
+      }
+    }
+  }
+}

--- a/schemas/issue-discovery-session.schema.json
+++ b/schemas/issue-discovery-session.schema.json
@@ -189,7 +189,7 @@
           "type": "object",
           "additionalProperties": false,
           "required": ["kind", "payload"],
-          "description": "User elected to create a new umbrella. `payload` is required and must include every Q5 sub-answer; `ref` is populated after release-tracker.createUmbrellaForIntent returns.",
+          "description": "User elected to create a new umbrella. `payload` carries the user's Q5 answers; `intent`, `goal`, `scopeTag`, `definitionOfDone`, and `rollbackPlan` are required (the non-skippable core). `targetDate`, `nonGoals`, and `stakeholders` are optional because Q5.4 / Q5.5 / Q5.8 each accept 'none' as a valid answer and the payload stores them as null / [] / []. `ref` is populated after release-tracker.createUmbrellaForIntent returns (or stays null if the backend has not yet landed).",
           "properties": {
             "kind": { "type": "string", "const": "create-new" },
             "ref": {

--- a/schemas/issue-discovery-session.schema.json
+++ b/schemas/issue-discovery-session.schema.json
@@ -155,51 +155,83 @@
       }
     },
     "umbrellaDecision": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "The Q4/Q5 outcome. Kind encodes the branch the user picked; payload is populated only for the create-new branch.",
-      "properties": {
-        "kind": {
-          "type": "string",
-          "enum": ["skip", "link-existing", "create-new"]
-        },
-        "ref": {
-          "type": ["object", "null"],
+      "description": "The Q4/Q5 outcome. `kind` encodes the branch the user picked; the allowed `ref` / `payload` shape is a function of `kind`. A `kind`-keyed oneOf keeps partial / corrupt decision objects out: {} or a kind-only object fails validation for the create-new branch, and the skip branch refuses stray ref/payload fields.",
+      "oneOf": [
+        {
+          "type": "object",
           "additionalProperties": false,
+          "required": ["kind"],
+          "description": "Umbrella intentionally skipped. Valid even when trackers.release is present; the user confirmed the skip explicitly per the runbook's Q4a no-umbrella halt.",
           "properties": {
-            "number": { "type": "integer", "minimum": 1 },
-            "nodeId": { "type": "string", "minLength": 1 },
-            "url": { "type": "string", "format": "uri" }
+            "kind": { "type": "string", "const": "skip" }
           }
         },
-        "payload": {
-          "type": ["object", "null"],
+        {
+          "type": "object",
           "additionalProperties": false,
+          "required": ["kind", "ref"],
+          "description": "User linked to an existing open umbrella. `ref` is required.",
           "properties": {
-            "intent": { "type": "string", "minLength": 1 },
-            "goal": { "type": "string", "minLength": 30 },
-            "scopeTag": { "type": "string", "minLength": 1 },
-            "targetDate": {
-              "type": ["string", "null"],
-              "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+            "kind": { "type": "string", "const": "link-existing" },
+            "ref": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["number"],
+              "properties": {
+                "number": { "type": "integer", "minimum": 1 },
+                "nodeId": { "type": "string", "minLength": 1 },
+                "url": { "type": "string", "format": "uri" }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "payload"],
+          "description": "User elected to create a new umbrella. `payload` is required and must include every Q5 sub-answer; `ref` is populated after release-tracker.createUmbrellaForIntent returns.",
+          "properties": {
+            "kind": { "type": "string", "const": "create-new" },
+            "ref": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "number": { "type": "integer", "minimum": 1 },
+                "nodeId": { "type": "string", "minLength": 1 },
+                "url": { "type": "string", "format": "uri" }
+              }
             },
-            "nonGoals": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
-            },
-            "definitionOfDone": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 },
-              "minItems": 1
-            },
-            "rollbackPlan": { "type": "string", "minLength": 20 },
-            "stakeholders": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+            "payload": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["intent", "goal", "scopeTag", "definitionOfDone", "rollbackPlan"],
+              "properties": {
+                "intent": { "type": "string", "minLength": 1 },
+                "goal": { "type": "string", "minLength": 30 },
+                "scopeTag": { "type": "string", "minLength": 1 },
+                "targetDate": {
+                  "type": ["string", "null"],
+                  "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+                },
+                "nonGoals": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 }
+                },
+                "definitionOfDone": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 },
+                  "minItems": 1
+                },
+                "rollbackPlan": { "type": "string", "minLength": 20 },
+                "stakeholders": {
+                  "type": "array",
+                  "items": { "type": "string", "minLength": 1 }
+                }
+              }
             }
           }
         }
-      }
+      ]
     },
     "createdIssueRef": {
       "type": ["object", "null"],

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -412,6 +412,42 @@
               "description": "When the same path:line thread has been re-emitted by the reviewer on a superseded SHA (commonly 30-50% of Copilot threads after round 1 per the runbook), auto-resolve it after this many commits have landed without changing the underlying code. Set 0 to disable and require manual triage for every thread."
             }
           }
+        },
+        "issue_discovery": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Optional config for the issue-discovery intake interview (skills/issue-discovery/SKILL.md). Every key is optional; with no config the skill still runs using tracker + labels defaults. Populate via adapt-system's domain:* and audience:* cascades when the project gains new glossary terms or stakeholder names.",
+          "properties": {
+            "title_templates": {
+              "type": "array",
+              "description": "Preferred issue-title patterns, e.g. '<verb> <area>: <outcome>'. Placeholders: {verb}, {area}, {outcome}, {slug}. Surfaced at Q3b as proposal seeds; when absent, Q3b derives proposals from the user's intent plus the top-scoring area keyword.",
+              "items": { "type": "string", "minLength": 1 },
+              "default": []
+            },
+            "stakeholders": {
+              "type": "array",
+              "description": "Names or handles the skill surfaces at Q5.8 when creating a new release umbrella. Free-form strings; may be logins, team names, or email addresses.",
+              "items": { "type": "string", "minLength": 1 },
+              "default": []
+            },
+            "domain_glossary": {
+              "type": "object",
+              "additionalProperties": { "type": "string", "minLength": 1 },
+              "description": "Map of domain-specific term -> one-line definition. When a user's answer mentions a term, the skill prints the definition once so the conversation stays grounded. Example: { 'checkout': 'the cart-to-payment flow', 'waves': 'the release-umbrella grouping our team uses'}.",
+              "default": {}
+            },
+            "default_type": {
+              "type": ["string", "null"],
+              "enum": [null, "feature", "task", "refactor", "bug"],
+              "description": "Optional pre-selected option at Q3c. When set and the caller did not pre-fill type, the skill surfaces this as option 1 instead of 'feature'. null leaves the normal order.",
+              "default": null
+            },
+            "topic_confirmation": {
+              "type": "boolean",
+              "description": "Whether Q0 runs. Default true: the skill always restates its inferred intent before asking any downstream question. Set false only for testing; disabling Q0 in production means the skill is expected to infer intent from the user's first message rather than guess.",
+              "default": true
+            }
+          }
         }
       }
     },

--- a/scripts/lib/issueDiscovery.mjs
+++ b/scripts/lib/issueDiscovery.mjs
@@ -1,0 +1,462 @@
+// lib/issueDiscovery.mjs
+// Library surface for the issue-discovery skill. Provides:
+//   - DECISION_TREE: a pure data structure describing every node of
+//     the intake state machine, its predecessors, option counts, and
+//     halt conditions. The skill's SKILL.md and runbook.md read this
+//     file's JSDoc as the single source of truth; the tests in
+//     tests/issue_discovery_decision_tree.test.mjs assert its shape.
+//   - newSessionId / scoreArea / rankIssuesForShortlist: pure helpers
+//     the interview uses. No I/O, no tracker calls, no user prompts.
+//   - readSession / writeSession / archiveSession: thin wrappers over
+//     scripts/lib/sessionState.mjs scoped to the "issue-discovery"
+//     domain, with schema validation on every read.
+//
+// Everything in this module is synchronous and side-effect-free
+// except for the session-state file operations. The interview itself
+// (the "ask a question and wait for the user") lives in the agent's
+// conversation layer; this library is just the deterministic pieces.
+
+import { createHash, randomBytes } from "node:crypto";
+
+import {
+  readSession as rawReadSession,
+  writeSession as rawWriteSession,
+  listPendingSessions as rawListPending,
+  archiveSession as rawArchive,
+} from "./sessionState.mjs";
+import { validate } from "./schema.mjs";
+
+const DOMAIN = "issue-discovery";
+
+/**
+ * Decision-tree descriptor. Each node has:
+ *   - id: stable string used in session.currentStep.
+ *   - predecessors: valid incoming node ids (or ["ENTRY"] for Q0).
+ *   - next: array of branch descriptors. Each descriptor names a
+ *     condition and a target node id (or "EXIT"). Conditions are
+ *     documented in prose; the runtime chooses a branch based on
+ *     the user's answer and the node-specific handler.
+ *   - minOptions / maxOptions: the 2-4 option contract (null for
+ *     free-form nodes like Q3b-title, Q5.2-goal).
+ *   - canHalt: whether the node can halt per rules/ambiguity-halt.md.
+ *   - customEscape: true iff the node exposes a "something else" /
+ *     "I'll write my own" option that, when chosen with an answer
+ *     outside the configured surface, triggers a halt.
+ *
+ * Every field is data only. The tests treat this as the spec; if
+ * you change the state machine, change this and the runbook in the
+ * same PR.
+ */
+export const DECISION_TREE = Object.freeze({
+  entry: Object.freeze({
+    id: "ENTRY",
+    predecessors: Object.freeze([]),
+    next: Object.freeze([{ target: "q0", when: "always" }]),
+    minOptions: null,
+    maxOptions: null,
+    canHalt: true,
+    customEscape: false,
+    description:
+      "Load ops.config.json, confirm at least one writable trackers.dev, pre-fetch open issues + umbrellas + labels via tracker-sync. No user prompt; halts on no-writable-target.",
+  }),
+  q0: Object.freeze({
+    id: "q0",
+    predecessors: Object.freeze(["ENTRY"]),
+    next: Object.freeze([{ target: "q1", when: "topicConfirmed" }]),
+    minOptions: 2,
+    maxOptions: 3,
+    canHalt: true,
+    customEscape: false,
+    description: "Topic confirmation. Runs iff workflow.issue_discovery.topic_confirmation !== false.",
+  }),
+  q1: Object.freeze({
+    id: "q1",
+    predecessors: Object.freeze(["q0"]),
+    next: Object.freeze([{ target: "q2", when: "trackerTargetSelected" }]),
+    minOptions: 2,
+    maxOptions: 4,
+    canHalt: true,
+    customEscape: true,
+    description:
+      "Project / workspace-member selection. Skipped iff exactly one writable target AND no workspace.members[].",
+  }),
+  q2: Object.freeze({
+    id: "q2",
+    predecessors: Object.freeze(["q1"]),
+    next: Object.freeze([
+      { target: "q3a", when: "pickExisting" },
+      { target: "q3b", when: "fileNew" },
+    ]),
+    minOptions: 2,
+    maxOptions: 3,
+    canHalt: false,
+    customEscape: false,
+    description: "Existing or new. Skipped to q3b when the target has zero open issues.",
+  }),
+  q3a: Object.freeze({
+    id: "q3a",
+    predecessors: Object.freeze(["q2"]),
+    next: Object.freeze([
+      { target: "q6", when: "existingPicked" },
+      { target: "q3b", when: "noneFitFileNew" },
+    ]),
+    minOptions: 2,
+    maxOptions: 4,
+    canHalt: true,
+    customEscape: false,
+    description: "Shortlist of top-4 open issues + show-more + file-new options.",
+  }),
+  q3b: Object.freeze({
+    id: "q3b",
+    predecessors: Object.freeze(["q2", "q3a"]),
+    next: Object.freeze([{ target: "q3c", when: "titleRecorded" }]),
+    minOptions: 2,
+    maxOptions: 4,
+    canHalt: false,
+    // The "I'll write the title myself" option is free-form
+    // acceptance, not an adapt-system escape hatch; a title is
+    // inherently user-authored and has no configured surface to
+    // fall outside of. `customEscape` is strictly for nodes where
+    // a custom value requires a schema / labels / config change
+    // (areas, intents, trackers, types).
+    customEscape: false,
+    description: "Title. 1-3 proposals + free-form (no halt).",
+  }),
+  q3c: Object.freeze({
+    id: "q3c",
+    predecessors: Object.freeze(["q3b"]),
+    next: Object.freeze([{ target: "q3d", when: "typeSelected" }]),
+    minOptions: 4,
+    maxOptions: 4,
+    canHalt: false,
+    customEscape: false,
+    description: "Issue type. Skipped when the caller pre-filled type.",
+  }),
+  q3d: Object.freeze({
+    id: "q3d",
+    predecessors: Object.freeze(["q3c"]),
+    next: Object.freeze([{ target: "q3e-priority", when: "areaSelected" }]),
+    minOptions: 2,
+    maxOptions: 4,
+    canHalt: true,
+    customEscape: true,
+    description: "Area label. Top-3 scored from intent + custom (halts on unknown area).",
+  }),
+  "q3e-priority": Object.freeze({
+    id: "q3e-priority",
+    predecessors: Object.freeze(["q3d"]),
+    next: Object.freeze([{ target: "q3e-size", when: "prioritySelected" }]),
+    minOptions: 3,
+    maxOptions: 3,
+    canHalt: false,
+    customEscape: false,
+    description: "Priority: high / medium / low.",
+  }),
+  "q3e-size": Object.freeze({
+    id: "q3e-size",
+    predecessors: Object.freeze(["q3e-priority"]),
+    next: Object.freeze([{ target: "q3f", when: "sizeSelected" }]),
+    minOptions: 3,
+    maxOptions: 3,
+    canHalt: false,
+    customEscape: false,
+    description: "Size: small / medium / large.",
+  }),
+  q3f: Object.freeze({
+    id: "q3f",
+    predecessors: Object.freeze(["q3e-size"]),
+    next: Object.freeze([{ target: "q4a", when: "umbrellasExist" }, { target: "q4c", when: "umbrellasAbsent" }, { target: "q6", when: "releaseOptedOut" }]),
+    minOptions: 2,
+    maxOptions: 3,
+    canHalt: false,
+    customEscape: false,
+    description: "Acceptance criteria. Jumps to q6 when trackers.release is absent.",
+  }),
+  q4a: Object.freeze({
+    id: "q4a",
+    predecessors: Object.freeze(["q3f", "q5.8"]),
+    next: Object.freeze([{ target: "q6", when: "umbrellaDecided" }]),
+    minOptions: 2,
+    maxOptions: 4,
+    canHalt: true,
+    customEscape: true,
+    description: "Pick or skip umbrella (>=1 open exists). Halts on ambiguous multi-match.",
+  }),
+  q4c: Object.freeze({
+    id: "q4c",
+    predecessors: Object.freeze(["q3f"]),
+    next: Object.freeze([
+      { target: "q5.1", when: "createNew" },
+      { target: "q6", when: "skipUmbrella" },
+    ]),
+    minOptions: 2,
+    maxOptions: 2,
+    canHalt: false,
+    customEscape: false,
+    description: "No umbrellas exist: offer create-new or skip.",
+  }),
+  "q5.1": Object.freeze({
+    id: "q5.1",
+    predecessors: Object.freeze(["q4c"]),
+    next: Object.freeze([{ target: "q5.2", when: "intentSelected" }]),
+    minOptions: 2,
+    maxOptions: 4,
+    canHalt: true,
+    customEscape: true,
+    description: "Intent label value; halts when user picks new:<slug> (adapt-system hint).",
+  }),
+  "q5.2": Object.freeze({
+    id: "q5.2",
+    predecessors: Object.freeze(["q5.1"]),
+    next: Object.freeze([{ target: "q5.3", when: "goalRecorded" }]),
+    minOptions: null,
+    maxOptions: null,
+    canHalt: false,
+    customEscape: false,
+    description: "Free-form umbrella goal (minimum 30 chars).",
+  }),
+  "q5.3": Object.freeze({
+    id: "q5.3",
+    predecessors: Object.freeze(["q5.2"]),
+    next: Object.freeze([{ target: "q5.4", when: "scopeTagRecorded" }]),
+    minOptions: null,
+    maxOptions: null,
+    canHalt: false,
+    customEscape: false,
+    description: "Free-form scope tag (kebab-cased).",
+  }),
+  "q5.4": Object.freeze({
+    id: "q5.4",
+    predecessors: Object.freeze(["q5.3"]),
+    next: Object.freeze([{ target: "q5.5", when: "targetDateRecorded" }]),
+    minOptions: null,
+    maxOptions: null,
+    canHalt: false,
+    customEscape: false,
+    description: "Target date YYYY-MM-DD or 'none'.",
+  }),
+  "q5.5": Object.freeze({
+    id: "q5.5",
+    predecessors: Object.freeze(["q5.4"]),
+    next: Object.freeze([{ target: "q5.6", when: "nonGoalsRecorded" }]),
+    minOptions: null,
+    maxOptions: null,
+    canHalt: false,
+    customEscape: false,
+    description: "Non-goals (free-form bullets or 'none').",
+  }),
+  "q5.6": Object.freeze({
+    id: "q5.6",
+    predecessors: Object.freeze(["q5.5"]),
+    next: Object.freeze([{ target: "q5.7", when: "dodRecorded" }]),
+    minOptions: null,
+    maxOptions: null,
+    canHalt: false,
+    customEscape: false,
+    description: "Definition of done; must include 'tested', 'released', 'monitored'.",
+  }),
+  "q5.7": Object.freeze({
+    id: "q5.7",
+    predecessors: Object.freeze(["q5.6"]),
+    next: Object.freeze([{ target: "q5.8", when: "rollbackRecorded" }]),
+    minOptions: null,
+    maxOptions: null,
+    canHalt: false,
+    customEscape: false,
+    description: "Rollback plan (minimum 20 chars).",
+  }),
+  "q5.8": Object.freeze({
+    id: "q5.8",
+    predecessors: Object.freeze(["q5.7"]),
+    next: Object.freeze([{ target: "q4a", when: "umbrellaCreated" }]),
+    minOptions: null,
+    maxOptions: null,
+    canHalt: false,
+    customEscape: false,
+    description:
+      "Stakeholders; triggers release-tracker.createUmbrellaForIntent, then loops back to q4a for explicit confirmation.",
+  }),
+  q6: Object.freeze({
+    id: "q6",
+    predecessors: Object.freeze(["q3a", "q3f", "q4a", "q4c"]),
+    next: Object.freeze([{ target: "done", when: "proceed" }, { target: "EXIT", when: "cancel" }]),
+    minOptions: 3,
+    maxOptions: 3,
+    canHalt: true,
+    customEscape: false,
+    description:
+      "Confirmation gate. The only node that dispatches tracker-sync.issues.createIssue (via the conversation layer after the user picks Proceed).",
+  }),
+  done: Object.freeze({
+    id: "done",
+    predecessors: Object.freeze(["q6"]),
+    next: Object.freeze([{ target: "EXIT", when: "archived" }]),
+    minOptions: null,
+    maxOptions: null,
+    canHalt: false,
+    customEscape: false,
+    description: "Terminal success state; session is archived as .completed.json.",
+  }),
+});
+
+/**
+ * Generate a deterministic-friendly session id. Format:
+ *   YYYYMMDD-HHMMSS-<4 hex>
+ * Timestamp is UTC so listings sort chronologically. The hex
+ * suffix prevents collisions when two sessions open in the same
+ * second. Accepts an optional `now` (Date) and `rand` (Buffer) for
+ * test determinism.
+ */
+export function newSessionId({ now, rand } = {}) {
+  const d = now instanceof Date ? now : new Date();
+  if (Number.isNaN(d.getTime())) {
+    throw new TypeError("issueDiscovery.newSessionId: `now` must be a valid Date");
+  }
+  const pad2 = (n) => String(n).padStart(2, "0");
+  const stamp =
+    `${d.getUTCFullYear()}${pad2(d.getUTCMonth() + 1)}${pad2(d.getUTCDate())}` +
+    `-${pad2(d.getUTCHours())}${pad2(d.getUTCMinutes())}${pad2(d.getUTCSeconds())}`;
+  const bytes = Buffer.isBuffer(rand) && rand.length >= 2 ? rand : randomBytes(2);
+  const hex = bytes.slice(0, 2).toString("hex");
+  return `${stamp}-${hex}`;
+}
+
+/**
+ * Score one candidate `area` against the user's free-form intent.
+ * Deterministic: case-insensitive keyword hits, normalised to [0, 1].
+ * Returns `{ score, matchedKeywords }`. Areas get a non-zero floor
+ * of 0 (never NaN, never negative) so every configured area is a
+ * surfaceable option even when no keyword matched.
+ *
+ * Input shape:
+ *   area = { name: "checkout", keywords: ["cart", "checkout", "payment"] }
+ */
+export function scoreArea(intent, area) {
+  if (typeof intent !== "string") return { score: 0, matchedKeywords: [] };
+  if (!area || typeof area !== "object") return { score: 0, matchedKeywords: [] };
+  const keywords = Array.isArray(area.keywords) ? area.keywords : [];
+  if (keywords.length === 0) return { score: 0, matchedKeywords: [] };
+  const hay = intent.toLowerCase();
+  const matched = [];
+  for (const kw of keywords) {
+    if (typeof kw !== "string" || kw.length === 0) continue;
+    if (hay.includes(kw.toLowerCase())) matched.push(kw);
+  }
+  const score = matched.length / keywords.length;
+  return { score, matchedKeywords: matched };
+}
+
+/**
+ * Rank open issues for the Q3a shortlist. Deterministic ordering by:
+ *   priority descending (high > medium > low > undefined)
+ *   age descending within priority (older first, more important)
+ *
+ * Accepts an array of {number, title, priority, createdAt, labels}
+ * and returns the top `cap` entries. `cap` defaults to 4 for the
+ * initial shortlist; Q3a's "show more" calls with 8.
+ */
+export function rankIssuesForShortlist(issues, cap = 4) {
+  if (!Array.isArray(issues)) return [];
+  if (!Number.isInteger(cap) || cap <= 0) {
+    throw new TypeError(`rankIssuesForShortlist: cap must be a positive integer; got ${JSON.stringify(cap)}`);
+  }
+  const priorityRank = (p) => {
+    if (p === "high") return 3;
+    if (p === "medium") return 2;
+    if (p === "low") return 1;
+    return 0;
+  };
+  const parseTime = (t) => {
+    const n = typeof t === "string" ? Date.parse(t) : Number.NaN;
+    return Number.isFinite(n) ? n : Number.NaN;
+  };
+  const sorted = issues
+    .filter((i) => i && typeof i.number === "number" && typeof i.title === "string")
+    .slice()
+    .sort((a, b) => {
+      const pa = priorityRank(a.priority);
+      const pb = priorityRank(b.priority);
+      if (pa !== pb) return pb - pa;
+      const ta = parseTime(a.createdAt);
+      const tb = parseTime(b.createdAt);
+      if (Number.isFinite(ta) && Number.isFinite(tb)) return ta - tb;
+      if (Number.isFinite(ta)) return -1;
+      if (Number.isFinite(tb)) return 1;
+      return 0;
+    });
+  return sorted.slice(0, cap);
+}
+
+/**
+ * Return a stable 6-char slug derived from the intent text. Used
+ * as the tail of `newSessionId` for deterministic tests and for
+ * the title-proposal generator at Q3b. sha1 + base32-ish alphabet
+ * to keep the slug alphanumeric and collision-rare without
+ * requiring a UUID library.
+ */
+export function slugFromIntent(intent) {
+  const normalised = typeof intent === "string" ? intent.trim().toLowerCase() : "";
+  const h = createHash("sha1").update(normalised).digest();
+  const alphabet = "abcdefghijklmnopqrstuvwxyz234567";
+  const out = [];
+  for (let i = 0; i < 6; i++) {
+    out.push(alphabet[h[i] % 32]);
+  }
+  return out.join("");
+}
+
+/**
+ * Read a session and validate against the session-state schema.
+ * Returns `{ state, errors }`. When the file is missing returns
+ * `{ state: null, errors: [] }`. Malformed JSON or schema
+ * violations surface under `errors` so the caller can halt with
+ * a pointed message rather than crashing on a property access.
+ */
+export async function readSession(target, sessionId, sessionSchema) {
+  const state = await rawReadSession(target, DOMAIN, sessionId);
+  if (state === null) return { state: null, errors: [] };
+  const { ok, errors } = validate(sessionSchema, state);
+  return { state: ok ? state : null, errors };
+}
+
+/**
+ * Write a validated session state. Throws synchronously if the
+ * state doesn't match the schema — a sketchy write would otherwise
+ * manifest as a malformed-file error on the next read.
+ */
+export async function writeSession(target, sessionId, state, sessionSchema) {
+  const { ok, errors } = validate(sessionSchema, state);
+  if (!ok) {
+    const summary = errors.map((e) => `${e.path}: ${e.message}`).join("; ");
+    throw new TypeError(
+      `issueDiscovery.writeSession: session state fails schema at [${summary}]`,
+    );
+  }
+  return rawWriteSession(target, DOMAIN, sessionId, state);
+}
+
+/**
+ * List pending (non-archived) issue-discovery sessions in a target.
+ * Thin wrapper over sessionState.listPendingSessions scoped to the
+ * "issue-discovery" domain.
+ */
+export async function listPendingSessions(target) {
+  return rawListPending(target, DOMAIN);
+}
+
+/**
+ * Archive a session. Outcome is one of the documented terminal
+ * labels: "completed" (Q6 Proceed), "cancelled" (Q6 Cancel),
+ * "timed-out" (future use once PR 14's session-resume rule lands).
+ */
+export async function archiveSession(target, sessionId, outcome) {
+  if (outcome !== "completed" && outcome !== "cancelled" && outcome !== "timed-out") {
+    throw new TypeError(
+      `issueDiscovery.archiveSession: outcome must be "completed", "cancelled", or "timed-out"; got ${JSON.stringify(outcome)}`,
+    );
+  }
+  return rawArchive(target, DOMAIN, sessionId, outcome);
+}
+
+/** Exposed for tests and adapt-system introspection. */
+export const DOMAIN_NAME = DOMAIN;

--- a/scripts/lib/issueDiscovery.mjs
+++ b/scripts/lib/issueDiscovery.mjs
@@ -68,13 +68,16 @@ export const DECISION_TREE = Object.freeze({
   entry: Object.freeze({
     id: "ENTRY",
     predecessors: Object.freeze([]),
-    next: Object.freeze([{ target: "q0", when: "always" }]),
+    next: Object.freeze([
+      { target: "q0", when: "topicConfirmationEnabled" },
+      { target: "q1", when: "topicConfirmationDisabled" },
+    ]),
     minOptions: null,
     maxOptions: null,
     canHalt: true,
     customEscape: false,
     description:
-      "Load ops.config.json, confirm at least one writable trackers.dev, pre-fetch open issues + umbrellas + labels via tracker-sync. No user prompt; halts on no-writable-target.",
+      "Load ops.config.json, confirm at least one writable trackers.dev, pre-fetch open issues + umbrellas + labels via tracker-sync. No user prompt; halts on no-writable-target. Advances to q0 when workflow.issue_discovery.topic_confirmation is true (the default); advances directly to q1 when it has been explicitly disabled.",
   }),
   q0: Object.freeze({
     id: "q0",
@@ -88,14 +91,14 @@ export const DECISION_TREE = Object.freeze({
   }),
   q1: Object.freeze({
     id: "q1",
-    predecessors: Object.freeze(["q0"]),
+    predecessors: Object.freeze(["ENTRY", "q0"]),
     next: Object.freeze([{ target: "q2", when: "trackerTargetSelected" }]),
     minOptions: 2,
     maxOptions: 4,
     canHalt: true,
     customEscape: true,
     description:
-      "Project / workspace-member selection. Skipped iff exactly one writable target AND no workspace.members[].",
+      "Project / workspace-member selection. Skipped iff exactly one writable target AND no workspace.members[]. Accepts ENTRY as a predecessor when workflow.issue_discovery.topic_confirmation is false and q0 is skipped entirely.",
   }),
   q2: Object.freeze({
     id: "q2",

--- a/scripts/lib/issueDiscovery.mjs
+++ b/scripts/lib/issueDiscovery.mjs
@@ -29,6 +29,21 @@ import { validate } from "./schema.mjs";
 const DOMAIN = "issue-discovery";
 
 /**
+ * Guard the schema argument on the library's public read/write
+ * surface. `validate` would otherwise crash with a low-level Ajv
+ * error (WeakMap lookup on `null`, etc.) and the caller wouldn't
+ * know which parameter was missing. Explicit TypeError names the
+ * parameter and the calling method.
+ */
+function assertSessionSchema(sessionSchema, method) {
+  if (sessionSchema === null || typeof sessionSchema !== "object" || Array.isArray(sessionSchema)) {
+    throw new TypeError(
+      `issueDiscovery.${method}: sessionSchema must be a plain object (load it via readJsonOrNull from schemas/issue-discovery-session.schema.json); got ${JSON.stringify(sessionSchema)}`,
+    );
+  }
+}
+
+/**
  * Decision-tree descriptor. Each node has:
  *   - id: stable string used in session.currentStep.
  *   - predecessors: valid incoming node ids (or ["ENTRY"] for Q0).
@@ -418,6 +433,7 @@ export function slugFromIntent(intent) {
  * rather than crashing on a property access.
  */
 export async function readSession(target, sessionId, sessionSchema) {
+  assertSessionSchema(sessionSchema, "readSession");
   let state;
   try {
     state = await rawReadSession(target, DOMAIN, sessionId);
@@ -448,6 +464,7 @@ export async function readSession(target, sessionId, sessionSchema) {
  * rejection rather than expecting a synchronous throw.
  */
 export async function writeSession(target, sessionId, state, sessionSchema) {
+  assertSessionSchema(sessionSchema, "writeSession");
   const { ok, errors } = validate(sessionSchema, state);
   if (!ok) {
     const summary = errors.map((e) => `${e.path}: ${e.message}`).join("; ");

--- a/scripts/lib/issueDiscovery.mjs
+++ b/scripts/lib/issueDiscovery.mjs
@@ -11,10 +11,12 @@
 //     scripts/lib/sessionState.mjs scoped to the "issue-discovery"
 //     domain, with schema validation on every read.
 //
-// Everything in this module is synchronous and side-effect-free
-// except for the session-state file operations. The interview itself
-// (the "ask a question and wait for the user") lives in the agent's
-// conversation layer; this library is just the deterministic pieces.
+// Everything in this module is deterministic and side-effect-free
+// except for the async session-state I/O wrappers. The interview
+// itself (the "ask a question and wait for the user") lives in the
+// agent's conversation layer; this library is just the
+// deterministic pieces plus thin async wrappers for persisted
+// session state.
 
 import { createHash, randomBytes } from "node:crypto";
 

--- a/scripts/lib/issueDiscovery.mjs
+++ b/scripts/lib/issueDiscovery.mjs
@@ -183,11 +183,12 @@ export const DECISION_TREE = Object.freeze({
     id: "q3f",
     predecessors: Object.freeze(["q3e-size"]),
     next: Object.freeze([{ target: "q4a", when: "umbrellasExist" }, { target: "q4c", when: "umbrellasAbsent" }, { target: "q6", when: "releaseOptedOut" }]),
-    minOptions: 2,
+    minOptions: 3,
     maxOptions: 3,
     canHalt: false,
     customEscape: false,
-    description: "Acceptance criteria. Jumps to q6 when trackers.release is absent.",
+    description:
+      "Acceptance criteria. Three fixed options (write now / use template placeholders / exploratory). Jumps to q6 when trackers.release is absent, otherwise to q4a or q4c depending on whether umbrellas exist.",
   }),
   q4a: Object.freeze({
     id: "q4a",

--- a/scripts/lib/issueDiscovery.mjs
+++ b/scripts/lib/issueDiscovery.mjs
@@ -441,9 +441,11 @@ export async function readSession(target, sessionId, sessionSchema) {
 }
 
 /**
- * Write a validated session state. Throws synchronously if the
- * state doesn't match the schema — a sketchy write would otherwise
- * manifest as a malformed-file error on the next read.
+ * Write a validated session state. Returns a rejected promise (the
+ * function is async) if the state doesn't match the schema; a
+ * sketchy write would otherwise manifest as a malformed-file error
+ * on the next read. Callers should `await` or `.catch(...)` the
+ * rejection rather than expecting a synchronous throw.
  */
 export async function writeSession(target, sessionId, state, sessionSchema) {
   const { ok, errors } = validate(sessionSchema, state);

--- a/scripts/lib/issueDiscovery.mjs
+++ b/scripts/lib/issueDiscovery.mjs
@@ -389,10 +389,14 @@ export function rankIssuesForShortlist(issues, cap = 4) {
 
 /**
  * Return a stable 6-char slug derived from the intent text. Used
- * as the tail of `newSessionId` for deterministic tests and for
- * the title-proposal generator at Q3b. sha1 + base32-ish alphabet
- * to keep the slug alphanumeric and collision-rare without
- * requiring a UUID library.
+ * anywhere a deterministic, compact alphanumeric identifier is
+ * needed from user-visible intent text: title-proposal generation
+ * at Q3b, any "open-or-resume" key the skill wants keyed on intent
+ * rather than time. Not used in `newSessionId` today (session ids
+ * use random hex so two sessions started from the same intent text
+ * still get distinct ids). sha1 + base32-ish alphabet keeps the
+ * slug alphanumeric and collision-rare without pulling in a UUID
+ * library.
  */
 export function slugFromIntent(intent) {
   const normalised = typeof intent === "string" ? intent.trim().toLowerCase() : "";
@@ -408,12 +412,29 @@ export function slugFromIntent(intent) {
 /**
  * Read a session and validate against the session-state schema.
  * Returns `{ state, errors }`. When the file is missing returns
- * `{ state: null, errors: [] }`. Malformed JSON or schema
- * violations surface under `errors` so the caller can halt with
- * a pointed message rather than crashing on a property access.
+ * `{ state: null, errors: [] }`. Malformed JSON (readJsonOrNull
+ * throws on parse errors) and schema violations both surface
+ * under `errors` so the caller can halt with a pointed message
+ * rather than crashing on a property access.
  */
 export async function readSession(target, sessionId, sessionSchema) {
-  const state = await rawReadSession(target, DOMAIN, sessionId);
+  let state;
+  try {
+    state = await rawReadSession(target, DOMAIN, sessionId);
+  } catch (error) {
+    return {
+      state: null,
+      errors: [
+        {
+          path: "$",
+          message:
+            error instanceof Error
+              ? `failed to read session: ${error.message}`
+              : `failed to read session: ${String(error)}`,
+        },
+      ],
+    };
+  }
   if (state === null) return { state: null, errors: [] };
   const { ok, errors } = validate(sessionSchema, state);
   return { state: ok ? state : null, errors };

--- a/scripts/lib/sessionState.mjs
+++ b/scripts/lib/sessionState.mjs
@@ -1,0 +1,200 @@
+// lib/sessionState.mjs
+// Shared scratch-state helper for skills that persist cross-session
+// ephemeral data (issue-discovery today, pr-iteration when PR 14 lands,
+// other future skills). Everything here operates on JSON files under
+// `<target>/.development/local/<domain>/<session-id>.json`, which the
+// bundle's standing `.development/local/` convention gitignores.
+//
+// The helper is intentionally small. It does not know about any
+// specific domain's schema. Callers validate their own state shape
+// after `readSession` returns (typically via scripts/lib/schema.mjs).
+//
+// Lifecycle:
+//   - writeSession(target, domain, sessionId, state) -> atomic JSON write
+//   - readSession(target, domain, sessionId) -> parsed JSON or null
+//   - listPendingSessions(target, domain) -> [{sessionId, path, state, ageMs}]
+//   - archiveSession(target, domain, sessionId, outcome) -> renames the
+//     file to "<sessionId>.<outcome>.json" (e.g. outcome "completed" or
+//     "cancelled") so a future scan doesn't see it as pending. Outcome
+//     is a caller-chosen suffix; the helper normalises to kebab-case
+//     ASCII and rejects anything else to keep listings scannable.
+//
+// Everything is side-effect-isolated to `<target>/.development/local/<domain>/`.
+// The helper refuses to operate outside that subtree.
+
+import { join, resolve, basename } from "node:path";
+import { readdir, stat, rename } from "node:fs/promises";
+import {
+  ensureDir,
+  atomicWriteJson,
+  readJsonOrNull,
+  isDirectory,
+} from "./fsx.mjs";
+
+// kebab-case ASCII; rejects slashes, dots, whitespace, unicode. Keeps
+// listings safe across macOS/Linux/Windows and defuses any "outcome"
+// value that a caller might accidentally pass through from user input.
+const OUTCOME_RE = /^[a-z][a-z0-9-]{0,30}$/;
+
+// Session ID must be filesystem-safe. Enforced here too (not just in
+// schemas) so listSessions never surfaces an arbitrary attacker-chosen
+// filename. The validate-on-read in caller-specific lib enforces the
+// stronger pattern (e.g. "<YYYYMMDD-HHMMSS>-<slug>").
+const SESSION_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const DOMAIN_RE = /^[a-z][a-z0-9-]{0,30}$/;
+
+function assertTargetAbs(target, label) {
+  if (typeof target !== "string" || target.trim().length === 0) {
+    throw new TypeError(`sessionState.${label}: target must be a non-empty string`);
+  }
+}
+
+function assertDomain(domain, label) {
+  if (!DOMAIN_RE.test(domain ?? "")) {
+    throw new TypeError(
+      `sessionState.${label}: domain must be kebab-case ASCII (^[a-z][a-z0-9-]{0,30}$); got ${JSON.stringify(domain)}`,
+    );
+  }
+}
+
+function assertSessionId(sessionId, label) {
+  if (!SESSION_ID_RE.test(sessionId ?? "")) {
+    throw new TypeError(
+      `sessionState.${label}: sessionId must match ^[A-Za-z0-9_-]{1,64}$; got ${JSON.stringify(sessionId)}`,
+    );
+  }
+}
+
+function sessionDir(target, domain) {
+  return join(resolve(target), ".development", "local", domain);
+}
+
+function sessionPath(target, domain, sessionId, suffix = "") {
+  const filename = suffix ? `${sessionId}.${suffix}.json` : `${sessionId}.json`;
+  return join(sessionDir(target, domain), filename);
+}
+
+/**
+ * Atomically write a session state file. Creates the session directory
+ * if missing. The caller is responsible for validating `state` against
+ * its domain schema before calling this; the helper does NOT validate.
+ *
+ * Returns the absolute path the file was written to.
+ */
+export async function writeSession(target, domain, sessionId, state) {
+  assertTargetAbs(target, "writeSession");
+  assertDomain(domain, "writeSession");
+  assertSessionId(sessionId, "writeSession");
+  if (state === null || typeof state !== "object" || Array.isArray(state)) {
+    throw new TypeError(
+      `sessionState.writeSession: state must be a plain object; got ${JSON.stringify(state)}`,
+    );
+  }
+  const dir = sessionDir(target, domain);
+  await ensureDir(dir);
+  const path = sessionPath(target, domain, sessionId);
+  return atomicWriteJson(path, state);
+}
+
+/**
+ * Read a session state file. Returns `null` when the file doesn't
+ * exist. Throws on malformed JSON (same as `readJsonOrNull`) so the
+ * caller sees a file-specific parse error rather than a silent null.
+ */
+export async function readSession(target, domain, sessionId) {
+  assertTargetAbs(target, "readSession");
+  assertDomain(domain, "readSession");
+  assertSessionId(sessionId, "readSession");
+  return readJsonOrNull(sessionPath(target, domain, sessionId));
+}
+
+/**
+ * Enumerate every non-archived session in the domain directory.
+ * Returns `[{sessionId, path, state, ageMs}]` sorted by startedAt
+ * ascending (when state has a startedAt field; falls back to mtime).
+ *
+ * Archived files (`*.<outcome>.json` where outcome matches
+ * OUTCOME_RE) are skipped; this is what lets the list reflect
+ * "pending" sessions only. Malformed files are surfaced with a
+ * `state: null, error: string` entry rather than dropping them
+ * silently — callers can decide whether to log or to halt.
+ */
+export async function listPendingSessions(target, domain) {
+  assertTargetAbs(target, "listPendingSessions");
+  assertDomain(domain, "listPendingSessions");
+  const dir = sessionDir(target, domain);
+  if (!(await isDirectory(dir))) return [];
+  const entries = await readdir(dir);
+  const now = Date.now();
+  const out = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const name = basename(entry, ".json");
+    // Archived file shape: <sessionId>.<outcome>.json -> basename contains a dot.
+    if (name.includes(".")) continue;
+    if (!SESSION_ID_RE.test(name)) continue; // defensive: ignore hand-edited names
+    const path = join(dir, entry);
+    try {
+      const state = await readJsonOrNull(path);
+      const startedAt = typeof state?.startedAt === "string" ? Date.parse(state.startedAt) : NaN;
+      let ageMs;
+      if (Number.isFinite(startedAt)) {
+        ageMs = now - startedAt;
+      } else {
+        const s = await stat(path);
+        ageMs = now - s.mtimeMs;
+      }
+      out.push({ sessionId: name, path, state, ageMs });
+    } catch (err) {
+      out.push({ sessionId: name, path, state: null, ageMs: null, error: String(err?.message ?? err) });
+    }
+  }
+  // Oldest first so the resume prompt surfaces the most-stale session
+  // at the top; callers can re-sort if they want newest first.
+  out.sort((a, b) => {
+    const aAge = a.ageMs ?? Number.POSITIVE_INFINITY;
+    const bAge = b.ageMs ?? Number.POSITIVE_INFINITY;
+    return bAge - aAge;
+  });
+  return out;
+}
+
+/**
+ * Rename a pending session to `<sessionId>.<outcome>.json` so it no
+ * longer shows up in `listPendingSessions`. Idempotent: if the file
+ * is already archived (or missing), returns null. Returns the new
+ * absolute path on success.
+ *
+ * `outcome` is caller-chosen (`completed`, `cancelled`, `timed-out`);
+ * validated against OUTCOME_RE to keep filenames safe and scannable.
+ */
+export async function archiveSession(target, domain, sessionId, outcome) {
+  assertTargetAbs(target, "archiveSession");
+  assertDomain(domain, "archiveSession");
+  assertSessionId(sessionId, "archiveSession");
+  if (!OUTCOME_RE.test(outcome ?? "")) {
+    throw new TypeError(
+      `sessionState.archiveSession: outcome must match ^[a-z][a-z0-9-]{0,30}$; got ${JSON.stringify(outcome)}`,
+    );
+  }
+  const src = sessionPath(target, domain, sessionId);
+  const dst = sessionPath(target, domain, sessionId, outcome);
+  try {
+    await rename(src, dst);
+    return dst;
+  } catch (err) {
+    if (err && err.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/**
+ * For tests and programmatic inspection. Returns the absolute path
+ * of the domain directory under the given target; does NOT create
+ * the directory.
+ */
+export function sessionDirFor(target, domain) {
+  assertTargetAbs(target, "sessionDirFor");
+  assertDomain(domain, "sessionDirFor");
+  return sessionDir(target, domain);
+}

--- a/scripts/lib/sessionState.mjs
+++ b/scripts/lib/sessionState.mjs
@@ -200,11 +200,17 @@ export async function listPendingSessions(target, domain) {
       out.push({ sessionId: name, path, state: null, ageMs: null, error: String(err?.message ?? err) });
     }
   }
-  // Oldest first so the resume prompt surfaces the most-stale session
-  // at the top; callers can re-sort if they want newest first.
+  // Oldest first so the resume prompt surfaces the most-stale
+  // session at the top; callers can re-sort if they want newest
+  // first. Entries with ageMs=null (malformed files surfaced with
+  // state: null) sort to the END by treating their age as
+  // -Infinity in the descending compare. The prior
+  // `?? +Infinity` pushed corrupt entries to the top, which
+  // displaced the oldest resumable session from the natural
+  // resume-prompt slot.
   out.sort((a, b) => {
-    const aAge = a.ageMs ?? Number.POSITIVE_INFINITY;
-    const bAge = b.ageMs ?? Number.POSITIVE_INFINITY;
+    const aAge = a.ageMs ?? Number.NEGATIVE_INFINITY;
+    const bAge = b.ageMs ?? Number.NEGATIVE_INFINITY;
     return bAge - aAge;
   });
   return out;

--- a/scripts/lib/sessionState.mjs
+++ b/scripts/lib/sessionState.mjs
@@ -16,8 +16,9 @@
 //   - archiveSession(target, domain, sessionId, outcome) -> renames the
 //     file to "<sessionId>.<outcome>.json" (e.g. outcome "completed" or
 //     "cancelled") so a future scan doesn't see it as pending. Outcome
-//     is a caller-chosen suffix; the helper normalises to kebab-case
-//     ASCII and rejects anything else to keep listings scannable.
+//     is a caller-chosen suffix; it must already be kebab-case ASCII,
+//     and the helper rejects anything else (via OUTCOME_RE) to keep
+//     listings scannable. No transformation is applied.
 //
 // Everything is side-effect-isolated to `<target>/.development/local/<domain>/`.
 // The helper refuses to operate outside that subtree.

--- a/scripts/lib/sessionState.mjs
+++ b/scripts/lib/sessionState.mjs
@@ -30,6 +30,7 @@ import {
   atomicWriteJson,
   readJsonOrNull,
   isDirectory,
+  exists,
 } from "./fsx.mjs";
 
 // kebab-case ASCII; rejects slashes, dots, whitespace, unicode. Keeps
@@ -218,9 +219,13 @@ export async function listPendingSessions(target, domain) {
 
 /**
  * Rename a pending session to `<sessionId>.<outcome>.json` so it no
- * longer shows up in `listPendingSessions`. Idempotent: if the file
- * is already archived (or missing), returns null. Returns the new
- * absolute path on success.
+ * longer shows up in `listPendingSessions`. Idempotent on missing
+ * source (returns null) and on an archive that already exists at
+ * the destination (returns the existing destination path). Throws
+ * a pointed error when the source is still pending AND a different
+ * archive of the same session exists at the destination, because
+ * that pair means we'd either overwrite a prior archive (POSIX) or
+ * error opaquely (Windows) on the rename.
  *
  * `outcome` is caller-chosen (`completed`, `cancelled`, `timed-out`);
  * validated against OUTCOME_RE to keep filenames safe and scannable.
@@ -236,13 +241,28 @@ export async function archiveSession(target, domain, sessionId, outcome) {
   }
   const src = sessionPath(target, domain, sessionId);
   const dst = sessionPath(target, domain, sessionId, outcome);
-  try {
-    await rename(src, dst);
+  const [srcExists, dstExists] = await Promise.all([exists(src), exists(dst)]);
+  if (!srcExists && dstExists) {
+    // Archive already in place, source is gone. Idempotent
+    // success: return the existing destination path so a retry
+    // sees the same success as the first call.
     return dst;
-  } catch (err) {
-    if (err && err.code === "ENOENT") return null;
-    throw err;
   }
+  if (!srcExists && !dstExists) {
+    // Nothing to archive. Matches the prior ENOENT behaviour.
+    return null;
+  }
+  if (srcExists && dstExists) {
+    // Both exist. On POSIX rename would silently overwrite the
+    // prior archive; on Windows it errors opaquely. Refuse
+    // explicitly so the caller can inspect the state rather than
+    // either lose data or hit a cryptic EEXIST.
+    throw new Error(
+      `sessionState.archiveSession: destination already exists at ${dst} while source is still pending at ${src}; refusing to overwrite. Inspect both files and archive under a different outcome or remove the stale one first.`,
+    );
+  }
+  await rename(src, dst);
+  return dst;
 }
 
 /**

--- a/scripts/lib/sessionState.mjs
+++ b/scripts/lib/sessionState.mjs
@@ -140,10 +140,14 @@ export async function listPendingSessions(target, domain) {
       const startedAt = typeof state?.startedAt === "string" ? Date.parse(state.startedAt) : NaN;
       let ageMs;
       if (Number.isFinite(startedAt)) {
-        ageMs = now - startedAt;
+        // Clamp negatives to 0: clock skew, a hand-edited file, or a
+        // corrupted startedAt can yield a future timestamp. Callers
+        // use ageMs for staleness decisions + sorting, so a negative
+        // value would invert the intended "oldest first" ordering.
+        ageMs = Math.max(0, now - startedAt);
       } else {
         const s = await stat(path);
-        ageMs = now - s.mtimeMs;
+        ageMs = Math.max(0, now - s.mtimeMs);
       }
       out.push({ sessionId: name, path, state, ageMs });
     } catch (err) {

--- a/scripts/lib/sessionState.mjs
+++ b/scripts/lib/sessionState.mjs
@@ -44,7 +44,7 @@ const OUTCOME_RE = /^[a-z][a-z0-9-]{0,30}$/;
 const SESSION_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
 const DOMAIN_RE = /^[a-z][a-z0-9-]{0,30}$/;
 
-function assertTargetAbs(target, label) {
+function assertTargetPath(target, label) {
   if (typeof target !== "string" || target.trim().length === 0) {
     throw new TypeError(`sessionState.${label}: target must be a non-empty string`);
   }
@@ -83,7 +83,7 @@ function sessionPath(target, domain, sessionId, suffix = "") {
  * Returns the absolute path the file was written to.
  */
 export async function writeSession(target, domain, sessionId, state) {
-  assertTargetAbs(target, "writeSession");
+  assertTargetPath(target, "writeSession");
   assertDomain(domain, "writeSession");
   assertSessionId(sessionId, "writeSession");
   if (state === null || typeof state !== "object" || Array.isArray(state)) {
@@ -103,7 +103,7 @@ export async function writeSession(target, domain, sessionId, state) {
  * caller sees a file-specific parse error rather than a silent null.
  */
 export async function readSession(target, domain, sessionId) {
-  assertTargetAbs(target, "readSession");
+  assertTargetPath(target, "readSession");
   assertDomain(domain, "readSession");
   assertSessionId(sessionId, "readSession");
   return readJsonOrNull(sessionPath(target, domain, sessionId));
@@ -121,7 +121,7 @@ export async function readSession(target, domain, sessionId) {
  * silently — callers can decide whether to log or to halt.
  */
 export async function listPendingSessions(target, domain) {
-  assertTargetAbs(target, "listPendingSessions");
+  assertTargetPath(target, "listPendingSessions");
   assertDomain(domain, "listPendingSessions");
   const dir = sessionDir(target, domain);
   if (!(await isDirectory(dir))) return [];
@@ -220,7 +220,7 @@ export async function listPendingSessions(target, domain) {
  * validated against OUTCOME_RE to keep filenames safe and scannable.
  */
 export async function archiveSession(target, domain, sessionId, outcome) {
-  assertTargetAbs(target, "archiveSession");
+  assertTargetPath(target, "archiveSession");
   assertDomain(domain, "archiveSession");
   assertSessionId(sessionId, "archiveSession");
   if (!OUTCOME_RE.test(outcome ?? "")) {
@@ -245,7 +245,7 @@ export async function archiveSession(target, domain, sessionId, outcome) {
  * the directory.
  */
 export function sessionDirFor(target, domain) {
-  assertTargetAbs(target, "sessionDirFor");
+  assertTargetPath(target, "sessionDirFor");
   assertDomain(domain, "sessionDirFor");
   return sessionDir(target, domain);
 }

--- a/scripts/lib/sessionState.mjs
+++ b/scripts/lib/sessionState.mjs
@@ -168,7 +168,22 @@ export async function listPendingSessions(target, domain) {
     }
     try {
       const state = await readJsonOrNull(path);
-      const startedAt = typeof state?.startedAt === "string" ? Date.parse(state.startedAt) : NaN;
+      // readJsonOrNull returns null on EISDIR (directory named like
+      // a session file) AND on a literal JSON `null`. Treat both as
+      // malformed: a valid session is always a plain non-null
+      // object per the session-state schema. Callers need a non-empty
+      // `error` to tell corruption apart from legitimate state.
+      if (state === null || typeof state !== "object" || Array.isArray(state)) {
+        out.push({
+          sessionId: name,
+          path,
+          state: null,
+          ageMs: null,
+          error: `Malformed session file: expected a plain JSON object; got ${state === null ? "null or directory" : typeof state}`,
+        });
+        continue;
+      }
+      const startedAt = typeof state.startedAt === "string" ? Date.parse(state.startedAt) : NaN;
       let ageMs;
       if (Number.isFinite(startedAt)) {
         // Clamp negatives to 0: clock skew, a hand-edited file, or a

--- a/scripts/lib/sessionState.mjs
+++ b/scripts/lib/sessionState.mjs
@@ -131,10 +131,41 @@ export async function listPendingSessions(target, domain) {
   for (const entry of entries) {
     if (!entry.endsWith(".json")) continue;
     const name = basename(entry, ".json");
-    // Archived file shape: <sessionId>.<outcome>.json -> basename contains a dot.
-    if (name.includes(".")) continue;
-    if (!SESSION_ID_RE.test(name)) continue; // defensive: ignore hand-edited names
     const path = join(dir, entry);
+    // Archived file shape: <sessionId>.<outcome>.json. Split on the
+    // first dot from the right and require BOTH halves to be valid
+    // before skipping. A "weird" extra-dot name (hand-edit, partial
+    // rename, crash mid-archival) gets surfaced as an error entry
+    // rather than silently ignored, which was the docstring's
+    // original promise.
+    const lastDot = name.lastIndexOf(".");
+    if (lastDot !== -1) {
+      const head = name.slice(0, lastDot);
+      const tail = name.slice(lastDot + 1);
+      if (SESSION_ID_RE.test(head) && OUTCOME_RE.test(tail)) {
+        // Valid archived file. Skip per the listPendingSessions contract.
+        continue;
+      }
+      // Malformed: filename has a dot but neither half passes validation.
+      out.push({
+        sessionId: SESSION_ID_RE.test(head) ? head : name,
+        path,
+        state: null,
+        ageMs: null,
+        error: `Malformed session filename: expected <sessionId>.json or <sessionId>.<outcome>.json; got ${entry}`,
+      });
+      continue;
+    }
+    if (!SESSION_ID_RE.test(name)) {
+      out.push({
+        sessionId: name,
+        path,
+        state: null,
+        ageMs: null,
+        error: `Malformed session filename: invalid session id in ${entry}`,
+      });
+      continue;
+    }
     try {
       const state = await readJsonOrNull(path);
       const startedAt = typeof state?.startedAt === "string" ? Date.parse(state.startedAt) : NaN;

--- a/skills/adapt-system/SKILL.md
+++ b/skills/adapt-system/SKILL.md
@@ -58,8 +58,8 @@ Reshapes a live installation when the project's context changes. Every change is
 | --- | --- |
 | `compliance:*` | `ops.config.json -> compliance.*`, `labels.area` additions, new `rules/product-*.md`, template sections |
 | `stack:add:*` / `stack:drop:*` | `ops.config.json -> stack.*`, memory seeds installed, `workflow.pr.tests_required` / `e2e_required_on` if relevant |
-| `domain:*` | `labels.area` additions, `area_keywords` updates, optional `rules/product-*.md`, template sections |
-| `audience:*` | `labels.area` additions (e.g. `area/enterprise`), `templates/release-readiness-checklist.md` sections (e.g. SLA) |
+| `domain:*` | `labels.area` additions, `area_keywords` updates, optional `rules/product-*.md`, template sections, `workflow.issue_discovery.domain_glossary` entries so the intake interview prints a one-line definition when a user's answer mentions the term |
+| `audience:*` | `labels.area` additions (e.g. `area/enterprise`), `templates/release-readiness-checklist.md` sections (e.g. SLA), `workflow.issue_discovery.stakeholders` appends so the Q5.8 stakeholder prompt lists the configured names |
 | `dependency:add:*` / `dependency:drop:*` | `area_keywords`, regression-handler lookup paths, memory-seed removals for dropped stacks |
 | `platform:*` | `stack.platform`, memory seeds, branch patterns if relevant |
 | `cadence:*` | `labels.intent`, release umbrella list (re-derived), `workflow.phase_term` |

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -21,9 +21,9 @@ Hard rule baked in: **the dev-loop never merges a PR and never sets a dev issue 
 
 ## Inputs
 
-- Issue reference (number or URL) on a `dev_project` with `depth` permitting writes.
+- Issue reference (number or URL) on a `dev_project` with `depth` permitting writes. When the input is absent, unresolvable, or the issue is in a state dev-loop refuses to work on (Done, closed without merge, `depth: read-only`), dev-loop halts its own state machine at entry and hands off to `skills/issue-discovery/SKILL.md`. dev-loop resumes only once `issue-discovery` returns a handoff tuple conforming to `schemas/issue-discovery-handoff.schema.json` (`{issueRef, umbrellaRef | null, memberName | null}` on success, or `{cancelled: true}` on user-cancel at Q6).
 - Optional work plan or acceptance-criteria override the user supplies up front.
-- Optional workspace member. For single-repo projects, omit (the skill routes through `trackers.dev`). For multi-repo projects (`workspace.members[]` present), the skill resolves the owning member by walking the diff's file paths through `resolveMemberFromPath(cfg, filePath)` before picking the tracker via `pickTrackerForMember(cfg, memberName, "dev")`. Deepest-first match wins; files outside any nested member fall back to a root member ONLY when `workspace.members[]` contains an entry whose normalised path is `.`. Without an explicit root member, `resolveMemberFromPath` returns `null` for unmatched files and the caller routes through the top-level `trackers.dev` instead.
+- Optional workspace member. For single-repo projects, omit (the skill routes through `trackers.dev`). For multi-repo projects (`workspace.members[]` present), the skill resolves the owning member by walking the diff's file paths through `resolveMemberFromPath(cfg, filePath)` before picking the tracker via `pickTrackerForMember(cfg, memberName, "dev")`. Deepest-first match wins; files outside any nested member fall back to a root member ONLY when `workspace.members[]` contains an entry whose normalised path is `.`. Without an explicit root member, `resolveMemberFromPath` returns `null` for unmatched files and the caller routes through the top-level `trackers.dev` instead. When `issue-discovery` supplies `memberName`, this resolution step is skipped in favour of the supplied value.
 
 ## Outputs
 
@@ -131,6 +131,7 @@ The ctxr-skill-code-review default is the recommended path. Projects opt out via
 
 ## Cross-skill handoffs
 
+- `issue-discovery`: invoked at entry when no resolvable issue reference was supplied. dev-loop halts its own state machine until the intake interview returns a handoff tuple (or a cancelled marker). See `rules/issue-discovery.md` for the three-clause contract the intake honours.
 - `tracker-sync`: open PR, request review, update issue status, post comments on the PR.
 - `release-tracker`: triggered by `tracker-sync` side-effects when a dev issue moves or links change.
 - `plan-keeper`: flip plan one-liner on gate crossings if `workflow.pr.update_plan_oneliner` is true.

--- a/skills/issue-discovery/SKILL.md
+++ b/skills/issue-discovery/SKILL.md
@@ -153,7 +153,7 @@ Every arrow is explicit. The flow never falls through on silence; each node sits
 
 ## Session persistence
 
-The session scratch file is ephemeral local state, not a durable artefact. Unlike reports and runbooks (see [rules/llm-wiki.md](../../rules/llm-wiki.md) for the wiki-routed shared-topic contract), this skill's state is transient: written with `atomicWriteJson`, validated against `schemas/issue-discovery-session.schema.json` on read, and archived or discarded on terminal nodes. It never passes through `@ctxr/skill-llm-wiki` and never lands in `.development/shared/`.
+The session scratch file is ephemeral local state, not a durable artefact. Unlike reports and runbooks (see [rules/llm-wiki.md](../../rules/llm-wiki.md) for the wiki-routed shared-topic contract), this skill's state is transient: written with `atomicWriteJson`, validated against `schemas/issue-discovery-session.schema.json` on read, and archived on terminal nodes (renamed to `<session-id>.<outcome>.json`; never deleted). It never passes through `@ctxr/skill-llm-wiki` and never lands in `.development/shared/`.
 
 - Location: `.development/local/issue-discovery/<session-id>.json`, gitignored per the bundle's standing `.development/local/` convention.
 - Format: validated against `schemas/issue-discovery-session.schema.json` on every read so a corrupted file fails loud.

--- a/skills/issue-discovery/SKILL.md
+++ b/skills/issue-discovery/SKILL.md
@@ -11,7 +11,7 @@ do_not_trigger_on:
   - ops.config.json is missing or invalid (halt and point at bootstrap-ops-config first).
   - "Every configured `trackers.dev` has depth read-only (halt; the skill cannot create issues anywhere)."
   - Another `issue-discovery` session is already open on this target project (surface the existing session per Resume protocol; never run two in parallel).
-writes_to_github: no, via tracker-sync only and only after the Q6 confirmation gate returns "Proceed"
+writes_to_github: yes, delegated only. Issue creation routes through `tracker-sync.issues.createIssue` and is gated by the Q6 confirmation gate returning "Proceed". New-umbrella creation routes through `release-tracker.createUmbrellaForIntent` (which dispatches to `tracker-sync` internally) and fires at the end of Q5.8, gated by the user's explicit Q4c pick of "Create a new umbrella" plus completion of Q5.1-Q5.8. The skill never calls a tracker API directly.
 writes_to_filesystem: yes, a session-scratch JSON under .development/local/issue-discovery/<session-id>.json (gitignored; managed via scripts/lib/sessionState.mjs)
 ---
 
@@ -30,7 +30,7 @@ Hard rule baked in: **the skill never calls a tracker API directly.** Every crea
 ## Outputs
 
 - On success: a resolved handoff tuple `{issueRef, umbrellaRef | null, memberName | null}` conforming to `schemas/issue-discovery-handoff.schema.json`. The caller (typically `dev-loop`) consumes the tuple and resumes its own state machine.
-- On user-cancel at Q6: no tracker writes; the session state file is archived with `status: "cancelled"` for audit. The skill returns control to the caller with a cancelled-handoff result.
+- On user-cancel at Q6: no issue is created; the session state file is archived under the shared filename-suffix scheme (`<session-id>.cancelled.json`). If the user reached Q5 and the skill already dispatched `release-tracker.createUmbrellaForIntent`, that write stands; the umbrella exists regardless of whether the user later cancels at Q6 (there is no rollback surface). The skill returns control to the caller with a cancelled-handoff result.
 - On halt per ambiguity-halt: no tracker writes; the session state file is preserved at the current node for resume on the next turn.
 
 ## State machine

--- a/skills/issue-discovery/SKILL.md
+++ b/skills/issue-discovery/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: issue-discovery
+description: Staff-engineer intake interview the agent runs before any dev-loop when the user has no resolvable issue reference. Asks every decision point with 2-4 options plus custom; never guesses; halts per rules/ambiguity-halt.md on thin facts; delegates every tracker write to tracker-sync. One invocation produces one issue (and optionally one new release umbrella), then hands the resolved handoff tuple to dev-loop.
+trigger_on:
+  - User says "what should I work on?", "pick up next", "get me unstuck", or any equivalent with no issue reference.
+  - dev-loop is invoked without an issue reference, or with one that tracker-sync.issues.getIssue cannot resolve; dev-loop halts its own state machine at entry and hands off here.
+  - User explicitly runs `/issue-discovery [hint]`.
+  - regression-handler concludes "file new bug issue" and delegates issue creation here with a pre-filled type of bug in the payload.
+do_not_trigger_on:
+  - User supplied a resolvable issue reference up front (dev-loop takes it directly).
+  - ops.config.json is missing or invalid (halt and point at bootstrap-ops-config first).
+  - "Every configured `trackers.dev` has depth read-only (halt; the skill cannot create issues anywhere)."
+  - Another `issue-discovery` session is already open on this target project (surface the existing session per Resume protocol; never run two in parallel).
+writes_to_github: no, via tracker-sync only and only after the Q6 confirmation gate returns "Proceed"
+writes_to_filesystem: yes, a session-scratch JSON under .development/local/issue-discovery/<session-id>.json (gitignored; managed via scripts/lib/sessionState.mjs)
+---
+
+# issue-discovery
+
+Before acting, read the target project's `.claude/ops.config.json`. Refuse to run if missing or invalid; hand the user back to `bootstrap-ops-config`.
+
+Hard rule baked in: **the skill never calls a tracker API directly.** Every create, update, link, and read routes through [skills/tracker-sync/SKILL.md](../tracker-sync/SKILL.md). The one public exception is [skills/release-tracker/SKILL.md](../release-tracker/SKILL.md)'s `createUmbrellaForIntent` entry point for new-umbrella creation; release-tracker owns the final tracker-sync dispatch.
+
+## Inputs
+
+- Optional free-form intent from the user (e.g. "I want to work on the checkout flow"). When absent, Q0 starts with "What do you want to work on?".
+- Optional `type` pre-fill when delegated from `regression-handler` (e.g. `{type: "bug"}` skips Q3c; other nodes still run).
+- Optional `memberName` pre-fill when delegated from `dev-loop` with a workspace member it already identified (e.g. from a file path under a `workspace.members[]` entry); Q1 still runs to confirm.
+
+## Outputs
+
+- On success: a resolved handoff tuple `{issueRef, umbrellaRef | null, memberName | null}` conforming to `schemas/issue-discovery-handoff.schema.json`. The caller (typically `dev-loop`) consumes the tuple and resumes its own state machine.
+- On user-cancel at Q6: no tracker writes; the session state file is archived with `status: "cancelled"` for audit. The skill returns control to the caller with a cancelled-handoff result.
+- On halt per ambiguity-halt: no tracker writes; the session state file is preserved at the current node for resume on the next turn.
+
+## State machine
+
+```text
+[ENTRY]
+  preconditions: valid ops.config.json; at least one writable trackers.dev
+  load: trackers.dev[], trackers.release?[], workspace.members[]?
+  pre-fetch (via tracker-sync, read-only): open issues, open umbrellas, labels
+      |
+      v
+[Q0. ONE-LINER TOPIC CONFIRMATION]
+  agent proposes: "I understand you want to <inferred>. Correct?"
+  1. Yes, continue.
+  2. Adjust: <free-form edit>.
+  3. I misunderstood; start over.
+      |
+      v
+[Q1. WHICH PROJECT OR WORKSPACE MEMBER?]
+  skipped iff exactly one writable dev-tracker AND no workspace.members[]
+  1..N: each writable target (at most 4; "show more" at N+1)
+  N+1: something else -> halt per ambiguity-halt with `/adapt-system` hint
+      |
+      v
+[Q2. EXISTING OR NEW?]
+  skipped to Q3b iff zero open issues on the target
+  1. Pick from the existing open issues (go to Q3a).
+  2. File a new one (go to Q3b).
+  3. Show me the full list first (re-enters Q2 with an expanded shortlist).
+      |
+      |-- existing -> [Q3a. PICK FROM SHORTLIST]
+      |                 top 4 ranked by (priority, age)
+      |                 5. Show more (up to 8 total).
+      |                 6. None of these; file a new one (go to Q3b).
+      |
+      v (new)
+[Q3b. TITLE FOR NEW ISSUE]
+  agent proposes 2 to 3 titles derived from Q0 + matched area keywords
+  1..3: propose title
+  4. I will write the title.
+      |
+      v
+[Q3c. ISSUE TYPE]
+  skipped when the caller pre-filled `type`
+  1. feature
+  2. task
+  3. refactor
+  4. bug (hand off to regression-handler if this was a direct invocation)
+      |
+      v
+[Q3d. AREA LABEL]
+  agent scores user intent against area_keywords; presents top 3 plus custom
+  1..3: propose area
+  4. Something else (halt per ambiguity-halt with `/adapt-system` hint)
+      |
+      v
+[Q3e. PRIORITY + SIZE]
+  two short sequential prompts, 3 options each
+  priority: 1. high | 2. medium | 3. low
+  size: 1. small (<1d) | 2. medium (1-3d) | 3. large (split later)
+      |
+      v
+[Q3f. ACCEPTANCE CRITERIA]
+  1. Let me write them now.
+  2. Use the configured template placeholders (filled before Q6).
+  3. None; this is exploratory. (Valid choice, but picked explicitly.)
+      |
+      v
+[Q4. RELEASE UMBRELLA]
+  skipped when trackers.release is absent from ops.config.json
+      |
+      v
+  [Q4-detect] list open umbrellas via tracker-sync.issues.listIssues
+      |
+      |-- >=1 open umbrellas -> [Q4a. PICK]
+      |   1..4: open umbrellas
+      |   5. Reference by number (user types #NNN).
+      |   6. No umbrella for this one. (Halt per ambiguity-halt to confirm,
+      |      because trackers.release exists so skipping is a decision.)
+      |
+      |-- 0 umbrellas -> [Q4c. NEW UMBRELLA?]
+      |   1. Create new umbrella (go to Q5).
+      |   2. Skip umbrella link this time.
+      |
+      v
+[Q5. NEW-UMBRELLA Q&A] (only if Q4c picked "Create new umbrella")
+  8 sub-questions, one at a time (see runbook.md for exact wording):
+    5.1 intent label value (from labels.intent or "new:<slug>" -> halt)
+    5.2 umbrella goal (one paragraph)
+    5.3 scope tag (single free-form)
+    5.4 target date (YYYY-MM-DD or "none")
+    5.5 non-goals (bullets; "none" valid)
+    5.6 definition of done (bullets; must include tested + released + monitored)
+    5.7 rollback plan (one paragraph)
+    5.8 stakeholders (comma-separated or "none")
+      |
+      | call release-tracker.createUmbrellaForIntent(intent, payload);
+      | release-tracker recomputes umbrella status after creation.
+      v
+  loop back to Q4a with the new umbrella pre-selected (user still confirms)
+      |
+      v
+[Q6. CONFIRMATION GATE]
+  agent echoes the full planned action in a single block:
+    - Create issue on <project> titled "<title>" with type=<type>,
+      labels=<labels>, priority=<p>, size=<s>.
+    - Link to umbrella <umbrella_ref> (or "no link").
+    - Then hand off to dev-loop.
+  1. Proceed (calls tracker-sync.issues.createIssue).
+  2. Change something (free-form; re-enters the relevant node).
+  3. Cancel (archives session, returns cancelled-handoff).
+      |
+      v
+[EXIT]
+  return {issueRef, umbrellaRef?, memberName?} to the caller.
+  archive session state file.
+```
+
+Every arrow is explicit. The flow never falls through on silence; each node sits in "awaiting answer" until the user responds.
+
+## Session persistence
+
+The session scratch file is ephemeral local state, not a durable artefact. Unlike reports and runbooks (see [rules/llm-wiki.md](../../rules/llm-wiki.md) for the wiki-routed shared-topic contract), this skill's state is transient: written with `atomicWriteJson`, validated against `schemas/issue-discovery-session.schema.json` on read, and archived or discarded on terminal nodes. It never passes through `@ctxr/skill-llm-wiki` and never lands in `.development/shared/`.
+
+- Location: `.development/local/issue-discovery/<session-id>.json`, gitignored per the bundle's standing `.development/local/` convention.
+- Format: validated against `schemas/issue-discovery-session.schema.json` on every read so a corrupted file fails loud.
+- Write mechanism: `scripts/lib/fsx.mjs#atomicWriteJson` via the shared `scripts/lib/sessionState.mjs` helper. Never through `@ctxr/skill-llm-wiki` (the wiki is for frontmatter-bearing durable artefacts; this is ephemeral scratch).
+- Fields: `startedAt`, `intentText`, `currentStep`, `answers[]`, `proposedPayload`, `umbrellaDecision`, `topicConfirmed`, `trackerTarget`, `memberName`.
+- Resumption: on a fresh session, if a file less than 24 hours old exists for the same target project with no `createdIssueRef`, the agent surfaces it per the Resume protocol in `rules/issue-discovery.md`. Older than 24 h: still surfaced, but the default offered answer is "Discard and start over".
+- Archival: on Q6 `Proceed` (issue created) the session file is renamed with a `.completed.json` suffix; on Q6 `Cancel` it is renamed with a `.cancelled.json` suffix. Neither archive path promotes to durable config or persistent memory.
+
+## Idempotency
+
+- Re-invoking the skill with a still-open session resumes from the recorded `currentStep` after explicit user confirmation.
+- The Q6 confirmation gate is stateless: a re-run of the same interview against the same tracker state that the user previously Proceeded to completion will detect the existing issue by title + labels fingerprint via `tracker-sync.issues.createIssue`'s dedupe contract and return the existing issue number rather than creating a duplicate.
+
+## Failure modes
+
+- **ops.config.json missing or invalid**: halt and hand control to `bootstrap-ops-config`.
+- **No writable `trackers.dev`**: halt with a pointed message naming the depth of each configured target.
+- **Tracker read fails (auth, rate-limit, network)**: halt per the `tracker-sync` failure modes; the session file preserves the current node so a retry resumes cleanly.
+- **User picks a custom area / intent / type not in the configured surface**: halt per `rules/ambiguity-halt.md`; the message names `/adapt-system` as the next step.
+- **`tracker-sync.issues.createIssue` throws `NotSupportedError` (e.g. Jira backend)**: halt cleanly with the tagged error; the session file is preserved so a follow-up session can resume once the backend lands.
+- **User abandons mid-interview**: no tracker writes fire; the session file remains at its last node for resume.
+
+## Cross-skill handoffs
+
+- **`dev-loop`**: the caller that most often invokes this skill. When `dev-loop` is run without an issue reference (or with one that fails to resolve), it halts its own state machine at entry, invokes `issue-discovery`, and resumes only after the skill returns a resolved handoff tuple. The tuple shape is enforced by `schemas/issue-discovery-handoff.schema.json`.
+- **`tracker-sync`**: the only skill this one writes through. Reads use `issues.listIssues`, `issues.getIssue`, and `labels.reconcileLabels`'s dry-run plan. Writes use `issues.createIssue` (at Q6 Proceed only).
+- **`release-tracker`**: new-umbrella creation routes through `release-tracker.createUmbrellaForIntent(intent, payload)` (a public entry point release-tracker owns); release-tracker dispatches to `tracker-sync` internally and recomputes umbrella status after the create.
+- **`regression-handler`**: soft bidirectional handoff. When `regression-handler` triage concludes "file new bug issue", it invokes this skill with `{type: "bug", ...pre-fill}` and the skill skips Q3c. When Q3c is reached in a direct invocation and the user picks `bug`, the skill hands off to `regression-handler` for the triage-first flow and `regression-handler` tail-calls back.
+- **`adapt-system`**: cross-linked only. When a user's custom answer requires a schema / labels / seeds change (new area, new intent, new stakeholder), the skill halts and names `/adapt-system <short desc>` as the next command. The skill itself never invokes adapt-system automatically.
+- **`plan-keeper`**: optional. After `tracker-sync.issues.createIssue` returns a ref, if `workflow.pr.update_plan_oneliner` is true the skill calls `plan-keeper.createPlanStub({issueRef, title, owner})` (a plan-keeper public entry point) to seed a `todo/<slug>.md` stub. `plan-keeper` is the only skill that writes under `paths.plans_root`.
+
+## Project contract
+
+- `project.default_branch`, `project.principals.reviewers_default`.
+- `trackers.dev[]` (at least one entry with depth != `read-only`).
+- `trackers.release` (optional; absent means the Q4 umbrella branch is skipped entirely per the PR 7 rule).
+- `workspace.members[]` (optional; present for multi-repo workspaces).
+- `labels.type`, `labels.area`, `labels.priority`, `labels.intent`, `labels.size` (every label set the interview offers as an option comes from here).
+- `workflow.issue_discovery.title_templates` (optional; when present, Q3b uses these as the proposal seeds instead of area-keyword matching).
+- `workflow.issue_discovery.stakeholders` (optional; surfaced as options at Q5.8).
+- `workflow.issue_discovery.domain_glossary` (optional; surfaces a one-line definition when an answer matches a glossary term).
+- `workflow.issue_discovery.default_type` (optional; when set and the caller did not pre-fill `type`, Q3c surfaces this as option 1 instead of `feature`).
+- `workflow.issue_discovery.topic_confirmation` (default true; setting false suppresses Q0, but callers are warned the skill is still expected to infer intent from the user's first message rather than guess).
+- `workflow.pr.update_plan_oneliner` (optional; when true, the skill calls `plan-keeper.createPlanStub` after create).
+- `paths.plans_root` (resolved via plan-keeper).

--- a/skills/issue-discovery/SKILL.md
+++ b/skills/issue-discovery/SKILL.md
@@ -30,7 +30,7 @@ Hard rule baked in: **the skill never calls a tracker API directly.** Every crea
 ## Outputs
 
 - On success: a resolved handoff tuple `{issueRef, umbrellaRef | null, memberName | null}` conforming to `schemas/issue-discovery-handoff.schema.json`. The caller (typically `dev-loop`) consumes the tuple and resumes its own state machine.
-- On user-cancel at Q6: no issue is created; the session state file is archived under the shared filename-suffix scheme (`<session-id>.cancelled.json`). If the user reached Q5 and the skill already dispatched `release-tracker.createUmbrellaForIntent`, that write stands; the umbrella exists regardless of whether the user later cancels at Q6 (there is no rollback surface). The skill returns control to the caller with a cancelled-handoff result.
+- On user-cancel at Q6: no issue is created; the session state file is archived under the shared filename-suffix scheme (`<session-id>.cancelled.json`). If the user reached Q5 and the skill already dispatched `release-tracker.createUmbrellaForIntent`, any umbrella the dispatch created stands; there is no rollback surface. Today `release-tracker.createUmbrellaForIntent` surfaces `NotSupportedError` from its downstream `tracker-sync.create_release_umbrella` call (the low-level surface is still stubbed per `skills/tracker-sync/SKILL.md#operations`), so in practice no umbrella is created on this turn and the user's Q5 answers live only in session state. The skill returns control to the caller with a cancelled-handoff result.
 - On halt per ambiguity-halt: no tracker writes; the session state file is preserved at the current node for resume on the next turn.
 
 ## State machine

--- a/skills/issue-discovery/runbook.md
+++ b/skills/issue-discovery/runbook.md
@@ -22,7 +22,7 @@ Confirm or adjust?
 3. I misunderstood; start over.
 ```
 
-When the user says only "what should I work on?" and no intent can be inferred, the prompt still conforms to the numbered-options contract in `rules/issue-discovery.md` (2 to 4 domain options + custom). The skill offers the two most useful paths:
+When the user says only "what should I work on?" and no intent can be inferred, the prompt still conforms to the numbered-options contract in `rules/issue-discovery.md`: two domain options. The "custom escape hatch" clause of the rule applies to nodes where a user's answer must land inside the configured surface (trackers, areas, intents). Q0 has no such surface: the user is naming a topic in free text, so "something else" is meaningless here. Option 1 already IS the free-form path.
 
 ```text
 I can't infer the topic yet. Two paths:
@@ -422,7 +422,7 @@ Area "{{user_answer}}" isn't in `labels.area`: {{configured_list}}. How do you w
 
 Hard prohibitions. Listed verbatim in the skill's `do_not_trigger_on` section and repeated here for the runbook reader.
 
-1. **No silent creation.** `tracker-sync.issues.createIssue` and `release-tracker.createUmbrellaForIntent` never fire without the Q6 confirmation returning `Proceed`. An `apply: true` on the session state does not substitute; the user must ack at Q6 on this turn.
+1. **No silent creation.** Writes are user-ack'd at their respective gates: `tracker-sync.issues.createIssue` never fires without the Q6 confirmation returning `Proceed`; `release-tracker.createUmbrellaForIntent` never fires without the user's explicit Q4c pick of "Create a new umbrella" followed by completion of the Q5.1-Q5.8 sub-interview. The two gates are separate: umbrella creation is its own terminal (ack'd at Q4c), and issue creation is the Q6 terminal. An `apply: true` on the session state does not substitute for either gate.
 2. **No implicit defaults.** "First writable target", "newest umbrella", "most likely area", "shortest title" are all invalid. Every selection is either an explicit user choice from the presented options or a halt.
 3. **No compound questions.** Each prompt resolves exactly one decision. Never "Which project and which umbrella?" or "Which area, priority, and size?".
 4. **No skipping steps for convenience.** "Just start something" still visits every node. The staff-engineer mirror would still ask.

--- a/skills/issue-discovery/runbook.md
+++ b/skills/issue-discovery/runbook.md
@@ -22,11 +22,16 @@ Confirm or adjust?
 3. I misunderstood; start over.
 ```
 
-When the user says only "what should I work on?" and no intent can be inferred:
+When the user says only "what should I work on?" and no intent can be inferred, the prompt still conforms to the numbered-options contract in `rules/issue-discovery.md` (2 to 4 domain options + custom). The skill offers the two most useful paths:
 
 ```text
-What's the topic for this session? One sentence is enough; I'll confirm before we pick an issue.
+I can't infer the topic yet. Two paths:
+
+1. I'll name the topic in one sentence (I'll record it verbatim and confirm).
+2. Help me narrow it down (I'll list the open issues and the areas configured on this project and we'll pick together).
 ```
+
+Option 1 opens a free-form sub-prompt and records the answer as `session.intentText`. Option 2 pre-loads the shortlist and labels and re-enters Q0 with the confirmation prompt populated from the user's pick.
 
 Proceed to Q1 once the user's answer is recorded verbatim in `session.intentText`.
 

--- a/skills/issue-discovery/runbook.md
+++ b/skills/issue-discovery/runbook.md
@@ -1,0 +1,429 @@
+# issue-discovery runbook
+
+Branch-by-branch Q&A script with exact wording, halt scenarios, and anti-patterns. `skills/issue-discovery/SKILL.md` is the contract; this file is the script the agent reads while driving the interview.
+
+Voice: staff engineer to manager. Short, declarative. No hedging, no apology, no filler. Each prompt resolves exactly one decision; never compound.
+
+## Node wording
+
+### Q0. Topic confirmation
+
+Opening probe. Always runs first unless `workflow.issue_discovery.topic_confirmation` is explicitly false.
+
+When the user's first message contains a free-form intent:
+
+```text
+I understand you want to: {{inferred_intent}}.
+
+Confirm or adjust?
+
+1. Correct.
+2. Adjust: <tell me what I missed>.
+3. I misunderstood; start over.
+```
+
+When the user says only "what should I work on?" and no intent can be inferred:
+
+```text
+What's the topic for this session? One sentence is enough; I'll confirm before we pick an issue.
+```
+
+Proceed to Q1 once the user's answer is recorded verbatim in `session.intentText`.
+
+### Q1. Project or workspace member
+
+Skipped iff exactly one `trackers.dev` target is writable AND `workspace.members[]` is absent or empty.
+
+```text
+You have multiple writable targets. Which one owns this work?
+
+1. {{trackers.dev[0].owner}}/{{trackers.dev[0].repo}} (depth: {{depth_0}})
+2. {{trackers.dev[1].owner}}/{{trackers.dev[1].repo}} (depth: {{depth_1}})
+(3. Workspace member "{{workspace.members[i].name}}" -> {{its tracker}})
+N. Something else (I'll halt so we can wire it up via adapt-system).
+```
+
+When the user picks "Something else" and gives a free-form target, the skill halts per `rules/ambiguity-halt.md` with the message:
+
+```text
+I see you want to target "{{user_answer}}", which is not in `trackers.dev[]`. Adding a tracker target is an adapt-system change. Pick one of the configured targets, or halt for `/adapt-system "add tracker <short desc>"` first. How do you want me to proceed?
+```
+
+### Q2. Existing or new
+
+Skipped to Q3b when `open_issues.length === 0` on the target.
+
+```text
+{{project}} has {{N}} open dev issues I can pick up. Choose:
+
+1. Work on one of them (I'll show the top 8).
+2. File a new one.
+3. Show me the full list first.
+```
+
+When N == 0:
+
+```text
+{{project}} has no open dev issues I can write to. Two paths:
+
+1. File a new one now.
+2. Stop; I'll wait until something lands in the tracker.
+```
+
+Option 2 exits the skill cleanly: no tracker writes, no session archival. The file stays for a future resume if the user changes their mind.
+
+### Q3a. Shortlist
+
+Top 4 open issues by (priority descending, age ascending). `priority` and `size` labels are read off `labels.priority` and `labels.size` respectively.
+
+```text
+Top 4 open issues. Pick one:
+
+1. #{{n1}} "{{title1}}" ({{priority1}}, {{age1}} old) {{area_labels_csv_1}}
+2. #{{n2}} "{{title2}}" ({{priority2}}, {{age2}} old) {{area_labels_csv_2}}
+3. #{{n3}} "{{title3}}" ({{priority3}}, {{age3}} old) {{area_labels_csv_3}}
+4. #{{n4}} "{{title4}}" ({{priority4}}, {{age4}} old) {{area_labels_csv_4}}
+5. Show more (up to 8 total).
+6. None of these fit; file a new one.
+```
+
+On "Show more" the list extends to items 5-8 with the same ranking rules. On pick, jump to Q6 (the existing issue is the final target; no new one is created).
+
+### Q3b. Title
+
+Proposals are derived from `workflow.issue_discovery.title_templates` (if configured) or from `session.intentText` + the top-scoring area's label name.
+
+```text
+I can propose 3 titles based on what we've discussed. Pick or override:
+
+1. "{{title_proposal_1}}"
+2. "{{title_proposal_2}}"
+3. "{{title_proposal_3}}"
+4. I'll write the title myself.
+```
+
+Option 4 opens a free-form prompt. The user's input is recorded verbatim into `session.proposedPayload.title`.
+
+### Q3c. Type
+
+Skipped when the caller pre-filled `type`.
+
+```text
+What kind of work is this?
+
+1. feature (new user-visible capability)
+2. task (small, one-PR scope)
+3. refactor (internal change, no user-visible delta)
+4. bug (I'll route via regression-handler and come back)
+```
+
+If `workflow.issue_discovery.default_type` is set, it becomes option 1 and the other three shift down.
+
+Option 4 hands off to `regression-handler` with `{title, intentText, memberName}` and the skill yields. `regression-handler` is expected to tail-call back into `issue-discovery` with `{type: "bug", ...pre-fill}` once it has completed its own triage; see `skills/regression-handler/SKILL.md`.
+
+### Q3d. Area label
+
+Score `session.intentText` against the keywords attached to each entry in `labels.area` (per the bundle-standard `area_keywords` shape). Surface the top 3 plus a custom option.
+
+```text
+Based on your intent, the top 3 areas are:
+
+1. {{area_1}} (matched: {{keywords_1}})
+2. {{area_2}} (matched: {{keywords_2}})
+3. {{area_3}} (matched: {{keywords_3}})
+4. Something else (halt; new areas are an adapt-system change).
+```
+
+When the user picks option 4 and types a free-form area, if that area is not in `labels.area[]` the skill halts per `rules/ambiguity-halt.md`:
+
+```text
+I see you want area "{{user_answer}}", which isn't in `labels.area`: {{configured_list}}. Adding a new area is an adapt-system change, not something I'll do silently. Pick an existing area, halt for `/adapt-system "add area <short desc>"` first, or re-route this issue to the closest existing area. How do you want me to proceed?
+```
+
+### Q3e. Priority + size
+
+Two short sequential prompts, 3 options each. Both are required.
+
+Priority:
+
+```text
+Priority?
+
+1. high
+2. medium
+3. low
+```
+
+Size:
+
+```text
+Size?
+
+1. small (<1 day)
+2. medium (1-3 days)
+3. large (split later)
+```
+
+### Q3f. Acceptance criteria
+
+```text
+What's the definition of done for this issue?
+
+1. Let me write them now (free-form bullets).
+2. Use the template placeholders (I'll fill them before I create).
+3. None; this is exploratory. (Valid choice, but you picked it explicitly.)
+```
+
+Option 2 surfaces the configured issue template for the chosen type (`templates/issue-feature.md`, `issue-task.md`, `issue-refactor.md`, etc.) and the skill fills the `{{placeholder}}` tokens in-line with a sub-prompt per placeholder.
+
+Option 3 is a valid terminal state but is recorded as `session.answers[q3f] = "exploratory"` so the Q6 confirmation block names it explicitly.
+
+### Q4. Release umbrella
+
+Entire branch skipped when `trackers.release` is absent from `ops.config.json`.
+
+The skill runs `tracker-sync.issues.listIssues({labels:["type/release"], state:"open"})` (scoped to the configured release tracker) and branches on the result.
+
+When >= 1 open umbrella:
+
+### Q4a. Pick umbrella
+
+```text
+Which release umbrella rolls this up?
+
+1. #{{n1}} "{{umbrella_title_1}}" (status: {{status_1}}, target: {{target_date_1}})
+2. #{{n2}} "{{umbrella_title_2}}" (status: {{status_2}}, target: {{target_date_2}})
+3. #{{n3}} "{{umbrella_title_3}}" (status: {{status_3}}, target: {{target_date_3}})
+4. #{{n4}} "{{umbrella_title_4}}" (status: {{status_4}}, target: {{target_date_4}})
+5. Reference by number (I'll ask for #NNN).
+6. No umbrella for this one.
+```
+
+Option 6 is a decision (not a default), so the skill halts per `rules/ambiguity-halt.md`:
+
+```text
+Your config has `trackers.release` present but you picked "no umbrella". That's allowed but explicit. Confirm:
+
+1. Yes, skip the umbrella link for this issue.
+2. Actually, let me pick from the list again.
+```
+
+When 0 open umbrellas:
+
+### Q4c. New umbrella?
+
+```text
+Your config has `trackers.release` pointed at {{release_project}} but no umbrellas are open. Two options:
+
+1. Create a new umbrella (I'll run a short 8-question QA).
+2. Skip the umbrella link this time; I'll still apply the intent label.
+```
+
+Option 1 advances to Q5.
+
+### Q5. New-umbrella QA
+
+Eight sub-questions, one at a time. Answers are collected into `session.umbrellaDecision.payload` and passed to `release-tracker.createUmbrellaForIntent(intent, payload)` at the end of Q5.8.
+
+```text
+Let's define the umbrella. Eight questions, one at a time.
+```
+
+#### Q5.1 Intent label value
+
+```text
+Intent label value. Configured: {{labels.intent.csv}}.
+
+1. {{labels.intent[0]}}
+2. {{labels.intent[1]}}
+3. {{labels.intent[2]}}
+4. new:<slug> (I'll halt for an adapt-system cascade.)
+```
+
+#### Q5.2 Umbrella goal
+
+```text
+In one paragraph, what does shipping this umbrella mean for the user?
+```
+
+Free-form. The skill refuses to accept an answer shorter than 30 characters; anything shorter prompts "That looks thin. Expand, or say 'none' to leave the goal blank.".
+
+#### Q5.3 Scope tag
+
+```text
+Scope tag (single free-form, e.g. "app-store-launch"):
+```
+
+Single token, kebab-case. If the user types multiple tokens the skill normalises by joining with `-`.
+
+#### Q5.4 Target date
+
+```text
+Target date (YYYY-MM-DD or "none"):
+```
+
+Strict date parse. Invalid date triggers a retry prompt, not a halt.
+
+#### Q5.5 Non-goals
+
+```text
+Non-goals (bullets; one per line; "none" valid):
+```
+
+Free-form. Stored as an array of strings.
+
+#### Q5.6 Definition of done
+
+```text
+Definition of Done (bullets; must include tested + released + monitored):
+```
+
+The skill parses the user's bullets and checks for the three required substrings (case-insensitive). Missing any -> re-prompts "I need to see `tested`, `released`, and `monitored` in the DoD. Add them and resend.".
+
+#### Q5.7 Rollback plan
+
+```text
+Rollback plan (one paragraph):
+```
+
+Free-form, minimum 20 characters.
+
+#### Q5.8 Stakeholders
+
+```text
+Stakeholders to notify on Done (comma-separated or "none").
+
+Configured stakeholders: {{workflow.issue_discovery.stakeholders.csv}}.
+```
+
+Parsed as a comma-separated list. Entries not in the configured stakeholder list are preserved verbatim (with a warning printed once: "These stakeholders aren't in `workflow.issue_discovery.stakeholders`; consider adding them via adapt-system.").
+
+After Q5.8 the skill calls:
+
+```text
+release-tracker.createUmbrellaForIntent({
+  intent: session.umbrellaDecision.payload.intent,
+  payload: session.umbrellaDecision.payload,
+})
+```
+
+`release-tracker` recomputes umbrella status as a side effect and returns `{umbrellaRef}`. The skill loops back to Q4a with the new umbrella pre-selected (option 1) for explicit user confirmation.
+
+### Q6. Confirmation
+
+Final gate. The skill renders the entire planned action as a single readable block and asks the user to Proceed / Change / Cancel.
+
+```text
+Before I write anything, here's the plan:
+
+- Create issue on {{project}} titled "{{title}}".
+- Type: {{type}}. Labels: {{labels_csv}}. Priority: {{priority}}. Size: {{size}}.
+- Link to umbrella {{umbrella_ref | "none"}}.
+- Acceptance criteria: {{ac_summary | "exploratory"}}.
+- After create, hand off to dev-loop.
+
+1. Proceed.
+2. Change something (say what).
+3. Cancel.
+```
+
+On `1. Proceed`:
+
+- Call `tracker-sync.issues.createIssue(payload)`.
+- If a dedupe hit occurs (existing open issue with same title + labels fingerprint), `tracker-sync` returns the existing ref; the skill records it verbatim and continues.
+- If `workflow.pr.update_plan_oneliner` is true, call `plan-keeper.createPlanStub({issueRef, title, owner})`.
+- Archive the session file as `<session-id>.completed.json`.
+- Return `{issueRef, umbrellaRef | null, memberName | null}` to the caller.
+
+On `2. Change something`:
+
+- Free-form prompt. The skill parses the user's reply and re-enters the relevant node. Common cases: "change title", "different area", "different umbrella", "swap priority to high".
+
+On `3. Cancel`:
+
+- No tracker writes fire.
+- The session file is archived as `<session-id>.cancelled.json`.
+- Return `{cancelled: true}` to the caller.
+
+## Ambiguity-halt scenarios
+
+All follow `rules/ambiguity-halt.md`: halt before any mutating call, surface one sentence per observation, ask once with bullets, resume only after the user's answer.
+
+### Two umbrellas plausibly match
+
+At Q4a, the candidate title matches two open umbrellas with near-equal signal (e.g. both carry `area/checkout` and both are in `In progress`).
+
+```text
+Before creating the issue I noticed something I cannot classify: two release umbrellas could own "{{title}}":
+
+- #{{n1}} "{{title1}}" (status: {{status_1}}, target: {{target_1}})
+- #{{n2}} "{{title2}}" (status: {{status_2}}, target: {{target_2}})
+
+Both open, both carry `area/{{matching_area}}`. How do you want me to proceed?
+
+1. Link to #{{n1}}.
+2. Link to #{{n2}}.
+3. Skip the umbrella link for this one.
+```
+
+### Picked issue drifted mid-interview
+
+At Q3a the user chose #{{n}}; between list-fetch and Q6, `tracker-sync.issues.getIssue` reports it moved to `In review` with someone else's open PR.
+
+```text
+#{{n}} moved to `In review` and has open PR #{{pr}} by @{{other_login}}. How do you want me to proceed?
+
+1. Pick another issue from the list.
+2. Claim this one anyway (dev-loop will halt again at entry with the same observation).
+3. File a new issue instead.
+```
+
+### New intent value collides with labels.intent
+
+User answers Q5.1 with an intent not in `labels.intent[]`.
+
+```text
+You chose intent `{{user_answer}}` but `labels.intent` only has {{labels.intent.csv}}. Adding a new intent is an adapt-system change, not something I'll do silently. How do you want me to proceed?
+
+1. Pick an existing intent.
+2. Halt for `/adapt-system "add intent {{user_answer}}"` first.
+3. Pick the closest existing intent for now.
+```
+
+### Release project is read-only
+
+The interview reaches Q4 but every release project has `depth: read-only`.
+
+```text
+Your release project {{release_project}} is `read-only`, so I cannot create or link umbrellas there. How do you want me to proceed?
+
+1. Proceed without an umbrella link.
+2. Halt so you can raise the depth in `ops.config.json`.
+```
+
+### Unknown area requested
+
+Q3d answer does not match any configured area.
+
+```text
+Area "{{user_answer}}" isn't in `labels.area`: {{configured_list}}. How do you want me to proceed?
+
+1. Pick one of the configured areas.
+2. Halt for `/adapt-system "add area {{user_answer}}"`.
+3. Re-route this issue to the closest existing area (I'll propose options).
+```
+
+## Anti-patterns (MUST NOT do)
+
+Hard prohibitions. Listed verbatim in the skill's `do_not_trigger_on` section and repeated here for the runbook reader.
+
+1. **No silent creation.** `tracker-sync.issues.createIssue` and `release-tracker.createUmbrellaForIntent` never fire without the Q6 confirmation returning `Proceed`. An `apply: true` on the session state does not substitute; the user must ack at Q6 on this turn.
+2. **No implicit defaults.** "First writable target", "newest umbrella", "most likely area", "shortest title" are all invalid. Every selection is either an explicit user choice from the presented options or a halt.
+3. **No compound questions.** Each prompt resolves exactly one decision. Never "Which project and which umbrella?" or "Which area, priority, and size?".
+4. **No skipping steps for convenience.** "Just start something" still visits every node. The staff-engineer mirror would still ask.
+5. **No cross-session memorisation.** Session state is the rolling JSON under `.development/local/issue-discovery/`; it never promotes to `ops.config.json` or to persistent memory. The next `/issue-discovery` starts clean.
+6. **No inventing tracker targets, areas, intents, types.** If the user names something not in the configured surface, halt and point at `adapt-system`.
+7. **No guessing umbrella from partial title match.** Fuzzy matches trigger the "two umbrellas" halt scenario.
+8. **No batching multiple new issues.** One invocation produces one issue. Bulk issue creation is `tracker-sync.convert_rollout_to_issues`, a different operation.
+9. **No writing outside `.development/local/issue-discovery/`.** The session scratch folder is the only writable surface for this skill apart from the tracker writes it dispatches via `tracker-sync` and `release-tracker`.
+10. **No touching `daily/` or `knowledge/`.** Bundle-wide portable rule; the skill inherits it.

--- a/skills/regression-handler/SKILL.md
+++ b/skills/regression-handler/SKILL.md
@@ -56,8 +56,8 @@ The skill never sets priority silently; it proposes and the user confirms.
 
 ## Actions the skill can propose
 
-- **Reopen**: if the match is strong and close date is within the reopen window (default 14 days, configurable). Requires a target with write depth.
-- **Create new bug**: the default when no strong match is within the window; links to the suspected origin issue as "regression of".
+- **Reopen**: if the match is strong and close date is within the reopen window (default 14 days, configurable). Requires a target with write depth. Dispatches via `tracker-sync.issues.updateIssueStatus` directly.
+- **Create new bug**: the default when no strong match is within the window; links to the suspected origin issue as "regression of". Issue creation is **delegated to `skills/issue-discovery/SKILL.md`** with a pre-filled payload (`type: bug`, `title`, `intentText`, and the origin-issue link), which skips the Q3c type question but runs every other node. `issue-discovery` dispatches `tracker-sync.issues.createIssue` only after the Q6 confirmation gate returns `Proceed`; `regression-handler` does not call the tracker-write surface for new-bug creation itself.
 - **Further investigation**: when no match rises above the configured minimum score. The skill files the report anyway so the trail is preserved.
 
 ## Idempotency
@@ -73,7 +73,8 @@ Running `regression-handler` twice on the same input produces the same report an
 
 ## Cross-skill handoffs
 
-- `tracker-sync` for every read and for the approved write action.
+- `tracker-sync` for every read and for the reopen action (status update). Not called directly for new-bug creation.
+- `issue-discovery` for new-bug creation. Regression-handler passes a pre-filled payload (`type: bug`, `title`, origin-issue link) and the intake skill runs its usual state machine with Q3c skipped. The intake's Q6 confirmation gate is the only place `tracker-sync.issues.createIssue` fires for the new bug.
 - `plan-keeper` if the user wants to open a plan file for the investigation (optional).
 - Does not call `dev-loop`, `release-tracker`, `adapt-system`, `bootstrap-ops-config`.
 

--- a/skills/release-tracker/SKILL.md
+++ b/skills/release-tracker/SKILL.md
@@ -79,11 +79,19 @@ A recompute against the same underlying state is a no-op write (the skill compar
 
 - Triggered by `tracker-sync` (via an event hook or explicit call) when linked issues change.
 - Called by `adapt-system` after a change to `labels.intent` values (adds, renames, or removals), to recreate or reconcile umbrellas.
+- Called by `issue-discovery` at Q5 (new-umbrella creation). `issue-discovery` invokes `release-tracker.createUmbrellaForIntent(intent, payload)` rather than going through `tracker-sync` directly, so release-tracker can recompute umbrella status as a side effect of the create.
 - Consumes `tracker-sync` for every read and write.
 
 ## Release umbrella creation
 
-Umbrellas are created by `tracker-sync.create_release_umbrella` when a new `labels.intent` value exists without a corresponding umbrella on any configured `trackers.release.projects[]` entry. Title template from `workflow.release.umbrella_title`. `release-tracker` verifies one umbrella exists per intent value and asks `tracker-sync` to create missing ones on approval.
+Umbrellas are created via `createUmbrellaForIntent(intent, payload)`, the skill's public entry point for callers that need to create an umbrella outside the normal `reconcile` flow. Today the two callers are:
+
+- `adapt-system`, when a change to `labels.intent` introduces a value without a corresponding umbrella on any configured `trackers.release.projects[]` entry.
+- `issue-discovery`, when the Q5 sub-interview collects a full umbrella payload from the user and asks to create one.
+
+`createUmbrellaForIntent` validates the payload, dispatches `tracker-sync.create_release_umbrella` (the low-level surface) with a body rendered from `workflow.release.umbrella_title` and `templates/issue-release.md`, and re-runs the skill's status computation against the new umbrella so the "Linked Dev Issues" block and `Status` field are correct from the first read. Callers must not call `tracker-sync.create_release_umbrella` directly; that invariant keeps the side-effect (status recompute) coupled with the write.
+
+`reconcile` itself still walks every configured `trackers.release.projects[]` entry and verifies one umbrella exists per intent value; it delegates to `createUmbrellaForIntent` to fill gaps on approval.
 
 ## Project contract
 

--- a/skills/release-tracker/SKILL.md
+++ b/skills/release-tracker/SKILL.md
@@ -89,9 +89,13 @@ Umbrellas are created via `createUmbrellaForIntent(intent, payload)`, the skill'
 - `adapt-system`, when a change to `labels.intent` introduces a value without a corresponding umbrella on any configured `trackers.release.projects[]` entry.
 - `issue-discovery`, when the Q5 sub-interview collects a full umbrella payload from the user and asks to create one.
 
-`createUmbrellaForIntent` validates the payload, dispatches `tracker-sync.create_release_umbrella` (the low-level surface) with a body rendered from `workflow.release.umbrella_title` and `templates/issue-release.md`, and re-runs the skill's status computation against the new umbrella so the "Linked Dev Issues" block and `Status` field are correct from the first read. Callers must not call `tracker-sync.create_release_umbrella` directly; that invariant keeps the side-effect (status recompute) coupled with the write.
+`createUmbrellaForIntent` validates the payload and is intended to hand off to `tracker-sync.create_release_umbrella` (the low-level surface) with a body rendered from `workflow.release.umbrella_title` and `templates/issue-release.md`, then re-run the skill's status computation against the new umbrella so the "Linked Dev Issues" block and `Status` field are correct from the first read.
 
-`reconcile` itself still walks every configured `trackers.release.projects[]` entry and verifies one umbrella exists per intent value; it delegates to `createUmbrellaForIntent` to fill gaps on approval.
+**Current implementation status**: `tracker-sync.create_release_umbrella` is still on the "stubbed on every backend" track in `skills/tracker-sync/SKILL.md#operations`; it throws `NotSupportedError` pending a port of the pre-trackers code path. While the stub is in place, `createUmbrellaForIntent` collects and validates the payload (so `issue-discovery` Q5 can still walk through the user's answers and persist them into session state) but surfaces the `NotSupportedError` from the dispatched `tracker-sync` call rather than creating the umbrella. Callers halt cleanly per the tracker-sync failure-modes contract.
+
+Callers must not call `tracker-sync.create_release_umbrella` directly even once it lands; keeping creation behind `createUmbrellaForIntent` is what couples the status-recompute side effect with the write.
+
+`reconcile` itself still walks every configured `trackers.release.projects[]` entry and verifies one umbrella exists per intent value; it delegates to `createUmbrellaForIntent` to fill gaps on approval once the low-level surface is available.
 
 ## Project contract
 

--- a/skills/tracker-sync/SKILL.md
+++ b/skills/tracker-sync/SKILL.md
@@ -90,7 +90,8 @@ Violations cause the call to halt with a clear refusal message, not a silent suc
 - Called by `adapt-system` for label reconciliation and relabelling once a config exists.
 - Called by `dev-loop` for `issues.createIssue` (rare), `issues.updateIssueStatus`, `review.requestReview`, `open_pr`, `issues.comment`.
 - Called by `release-tracker` for `issues.updateIssueStatus` on Release umbrellas and `projects.listProjectItems`.
-- Called by `regression-handler` for lookups and `issues.comment`.
+- Called by `regression-handler` for lookups and `issues.comment`. New-bug-issue creation does NOT hit `tracker-sync` directly from `regression-handler`; regression-handler delegates that step to `issue-discovery`, which in turn calls `tracker-sync.issues.createIssue`.
+- Called by `issue-discovery` for read-only pre-fetch (`issues.listIssues`, `issues.getIssue`) and, after the Q6 confirmation gate, for a single `issues.createIssue`. New-umbrella creation from `issue-discovery` routes through `release-tracker.createUmbrellaForIntent` rather than through `tracker-sync` directly, so release-tracker can recompute umbrella status as a side effect.
 - Called by `plan-keeper` only for read-only status confirmation.
 - Called by `pr-iteration` for every `review.*` method.
 

--- a/templates/issue-discovery-session.md
+++ b/templates/issue-discovery-session.md
@@ -8,7 +8,7 @@ ops.config keys read:
   - workflow.issue_discovery.*            optional overrides on the intake
   - paths.plans_root                      only referenced via plan-keeper when plan stubs are enabled
 scalar placeholders:
-  {{ session_id }}                        session identifier (YYYYMMDD-HHMMSS-slug)
+  {{ session_id }}                        session identifier (YYYYMMDD-HHMMSS-<4 hex>)
   {{ started_at }}                        ISO-8601 session start timestamp
   {{ status }}                            pending | completed | cancelled
   {{ tracker_target }}                    short tracker coords, e.g. ctxr-dev/agent-staff-engineer

--- a/templates/issue-discovery-session.md
+++ b/templates/issue-discovery-session.md
@@ -13,7 +13,7 @@ The rest of the bundle's templates use plain `{{ key }}` substitution with no co
 scalar placeholders:
   {{ session_id }}                        session identifier (YYYYMMDD-HHMMSS-<4 hex>)
   {{ started_at }}                        ISO-8601 session start timestamp
-  {{ status }}                            pending | completed | cancelled
+  {{ status }}                            pending | completed | cancelled | timed-out (see scripts/lib/issueDiscovery.mjs#archiveSession for the authoritative outcome list)
   {{ tracker_target }}                    short tracker coords, e.g. ctxr-dev/agent-staff-engineer
   {{ member_suffix }}                     " (member: `libs/shared`)" or "" when no workspace member
   {{ current_step }}                      active node id (q0, q1, ..., q6, done)

--- a/templates/issue-discovery-session.md
+++ b/templates/issue-discovery-session.md
@@ -1,0 +1,72 @@
+<!--
+agent-staff-engineer template: issue-discovery-session.md
+purpose: human-readable render of a session scratch file under .development/local/issue-discovery/
+rendered by: issue-discovery skill (on "show me the session" request)
+ops.config keys read:
+  - trackers.dev[]                        to name the target project
+  - workspace.members[]                   to resolve memberName, if any
+  - workflow.issue_discovery.*            optional overrides on the intake
+  - paths.plans_root                      only referenced via plan-keeper when plan stubs are enabled
+scalar placeholders:
+  {{ session_id }}                        session identifier (YYYYMMDD-HHMMSS-slug)
+  {{ started_at }}                        ISO-8601 session start timestamp
+  {{ status }}                            pending | completed | cancelled
+  {{ tracker_target }}                    short tracker coords, e.g. ctxr-dev/agent-staff-engineer
+  {{ member_name }}                       workspace member name (or empty)
+  {{ current_step }}                      active node id (q0, q1, ..., q6, done)
+  {{ intent_text }}                       the user's first-message intent, verbatim
+  {{ next_action }}                       one-line description of what the skill will do next
+list placeholders:
+  {{ answers[] }}                         ordered node answers (nodeId + short summary)
+object placeholders:
+  {{ proposed_payload }}                  assembled Q3 payload (title/type/labels/priority/size/acceptance)
+  {{ umbrella_decision }}                 the Q4-Q5 outcome (kind, optional ref, optional payload)
+-->
+
+# Issue discovery session `{{session_id}}`
+
+Human-readable rendering of a session scratch file under `.development/local/issue-discovery/{{session_id}}.json`. The canonical state is the JSON; this template is what the agent prints when asked to show the session.
+
+- **Started:** {{started_at}}
+- **Target project:** {{tracker_target}} {{#member_name}}(member: `{{member_name}}`){{/member_name}}
+- **Current step:** `{{current_step}}`
+- **Topic:** {{intent_text}}
+
+## Decisions recorded so far
+
+One bullet per recorded answer, rendered over the `{{answers}}` array.
+
+- **{{node_id}}**: {{answer_summary}}
+
+## Proposed issue payload
+
+Present only when the interview has reached at least Q3f.
+
+- Title: {{proposed_payload.title}}
+- Type: `{{proposed_payload.type}}`
+- Labels: {{proposed_payload.labels_csv}}
+- Priority: `{{proposed_payload.priority}}`
+- Size: `{{proposed_payload.size}}`
+- Acceptance criteria: {{proposed_payload.acceptance_criteria_or_exploratory}}
+
+## Umbrella decision
+
+Present only when the interview has reached at least Q4a or Q4c. `kind` is one of `skip`, `link-existing`, or `create-new`.
+
+- Kind: `{{umbrella_decision.kind}}`
+- Linked umbrella: {{umbrella_decision.ref_or_none}}
+- Intent: `{{umbrella_decision.payload.intent_or_none}}`
+- Goal: {{umbrella_decision.payload.goal_or_none}}
+- Target date: {{umbrella_decision.payload.target_date_or_none}}
+- Non-goals: {{umbrella_decision.payload.non_goals_csv_or_none}}
+- Definition of Done: {{umbrella_decision.payload.definition_of_done_csv_or_none}}
+- Rollback plan: {{umbrella_decision.payload.rollback_plan_or_none}}
+- Stakeholders: {{umbrella_decision.payload.stakeholders_csv_or_none}}
+
+## Next action
+
+- `{{next_action}}`
+
+---
+
+This is a rendering of session scratch state, not durable config. Archival on terminal nodes: `<session-id>.completed.json` on a Q6 Proceed, `<session-id>.cancelled.json` on a Q6 Cancel. Neither archive path promotes to `ops.config.json` or to persistent memory.

--- a/templates/issue-discovery-session.md
+++ b/templates/issue-discovery-session.md
@@ -7,65 +7,43 @@ ops.config keys read:
   - workspace.members[]                   to resolve memberName, if any
   - workflow.issue_discovery.*            optional overrides on the intake
   - paths.plans_root                      only referenced via plan-keeper when plan stubs are enabled
+
+The rest of the bundle's templates use plain `{{ key }}` substitution with no control flow. This template follows the same convention: all conditionals are resolved by the caller, which pre-renders the appropriate string for each placeholder (including "none" fallbacks for absent sections). The caller concatenates the full document, not this template file line-by-line.
+
 scalar placeholders:
   {{ session_id }}                        session identifier (YYYYMMDD-HHMMSS-<4 hex>)
   {{ started_at }}                        ISO-8601 session start timestamp
   {{ status }}                            pending | completed | cancelled
   {{ tracker_target }}                    short tracker coords, e.g. ctxr-dev/agent-staff-engineer
-  {{ member_name }}                       workspace member name (or empty)
+  {{ member_suffix }}                     " (member: `libs/shared`)" or "" when no workspace member
   {{ current_step }}                      active node id (q0, q1, ..., q6, done)
   {{ intent_text }}                       the user's first-message intent, verbatim
   {{ next_action }}                       one-line description of what the skill will do next
-list placeholders:
-  {{ answers[] }}                         ordered node answers (nodeId + short summary)
-object placeholders:
-  {{ proposed_payload }}                  assembled Q3 payload (title/type/labels/priority/size/acceptance)
-  {{ umbrella_decision }}                 the Q4-Q5 outcome (kind, optional ref, optional payload)
+  {{ answers_block }}                     pre-rendered bullet list of recorded node answers
+  {{ proposed_payload_block }}            pre-rendered "## Proposed issue payload" section or empty
+  {{ umbrella_decision_block }}           pre-rendered "## Umbrella decision" section or empty
 -->
 
-# Issue discovery session `{{session_id}}`
+# Issue discovery session `{{ session_id }}`
 
-Human-readable rendering of a session scratch file under `.development/local/issue-discovery/{{session_id}}.json`. The canonical state is the JSON; this template is what the agent prints when asked to show the session.
+Human-readable rendering of a session scratch file under `.development/local/issue-discovery/{{ session_id }}.json`. The canonical state is the JSON; this template is what the agent prints when asked to show the session.
 
-- **Started:** {{started_at}}
-- **Target project:** {{tracker_target}} {{#member_name}}(member: `{{member_name}}`){{/member_name}}
-- **Current step:** `{{current_step}}`
-- **Topic:** {{intent_text}}
+- **Started:** {{ started_at }}
+- **Target project:** {{ tracker_target }}{{ member_suffix }}
+- **Current step:** `{{ current_step }}`
+- **Topic:** {{ intent_text }}
 
 ## Decisions recorded so far
 
-One bullet per recorded answer, rendered over the `{{answers}}` array.
+{{ answers_block }}
 
-- **{{node_id}}**: {{answer_summary}}
+{{ proposed_payload_block }}
 
-## Proposed issue payload
-
-Present only when the interview has reached at least Q3f.
-
-- Title: {{proposed_payload.title}}
-- Type: `{{proposed_payload.type}}`
-- Labels: {{proposed_payload.labels_csv}}
-- Priority: `{{proposed_payload.priority}}`
-- Size: `{{proposed_payload.size}}`
-- Acceptance criteria: {{proposed_payload.acceptance_criteria_or_exploratory}}
-
-## Umbrella decision
-
-Present only when the interview has reached at least Q4a or Q4c. `kind` is one of `skip`, `link-existing`, or `create-new`.
-
-- Kind: `{{umbrella_decision.kind}}`
-- Linked umbrella: {{umbrella_decision.ref_or_none}}
-- Intent: `{{umbrella_decision.payload.intent_or_none}}`
-- Goal: {{umbrella_decision.payload.goal_or_none}}
-- Target date: {{umbrella_decision.payload.target_date_or_none}}
-- Non-goals: {{umbrella_decision.payload.non_goals_csv_or_none}}
-- Definition of Done: {{umbrella_decision.payload.definition_of_done_csv_or_none}}
-- Rollback plan: {{umbrella_decision.payload.rollback_plan_or_none}}
-- Stakeholders: {{umbrella_decision.payload.stakeholders_csv_or_none}}
+{{ umbrella_decision_block }}
 
 ## Next action
 
-- `{{next_action}}`
+- `{{ next_action }}`
 
 ---
 

--- a/templates/issue-discovery-session.md
+++ b/templates/issue-discovery-session.md
@@ -29,6 +29,7 @@ scalar placeholders:
 Human-readable rendering of a session scratch file under `.development/local/issue-discovery/{{ session_id }}.json`. The canonical state is the JSON; this template is what the agent prints when asked to show the session.
 
 - **Started:** {{ started_at }}
+- **Status:** `{{ status }}`
 - **Target project:** {{ tracker_target }}{{ member_suffix }}
 - **Current step:** `{{ current_step }}`
 - **Topic:** {{ intent_text }}

--- a/templates/issue-discovery-session.md
+++ b/templates/issue-discovery-session.md
@@ -26,7 +26,7 @@ scalar placeholders:
 
 # Issue discovery session `{{ session_id }}`
 
-Human-readable rendering of a session scratch file under `.development/local/issue-discovery/{{ session_id }}.json`. The canonical state is the JSON; this template is what the agent prints when asked to show the session.
+Human-readable rendering of a session scratch file under `.development/local/issue-discovery/`. The canonical state is the JSON; this template is what the agent prints when asked to show the session. Archived sessions live at the same path under a `.completed.json` or `.cancelled.json` suffix; the template is agnostic to the filename.
 
 - **Started:** {{ started_at }}
 - **Status:** `{{ status }}`

--- a/templates/issue-discovery-session.md
+++ b/templates/issue-discovery-session.md
@@ -26,7 +26,7 @@ scalar placeholders:
 
 # Issue discovery session `{{ session_id }}`
 
-Human-readable rendering of a session scratch file under `.development/local/issue-discovery/`. The canonical state is the JSON; this template is what the agent prints when asked to show the session. Archived sessions live at the same path under a `.completed.json` or `.cancelled.json` suffix; the template is agnostic to the filename.
+Human-readable rendering of a session scratch file under `.development/local/issue-discovery/`. The canonical state is the JSON; this template is what the agent prints when asked to show the session. Archived sessions live at the same path under a `<session-id>.<outcome>.json` suffix (outcomes: `completed`, `cancelled`, `timed-out`; see `scripts/lib/issueDiscovery.mjs#archiveSession` for the authoritative list). The template is agnostic to the filename.
 
 - **Started:** {{ started_at }}
 - **Status:** `{{ status }}`
@@ -48,4 +48,4 @@ Human-readable rendering of a session scratch file under `.development/local/iss
 
 ---
 
-This is a rendering of session scratch state, not durable config. Archival on terminal nodes: `<session-id>.completed.json` on a Q6 Proceed, `<session-id>.cancelled.json` on a Q6 Cancel. Neither archive path promotes to `ops.config.json` or to persistent memory.
+This is a rendering of session scratch state, not durable config. Archival on terminal outcomes uses `<session-id>.<outcome>.json` where `<outcome>` is one of the documented terminal statuses (`completed` on a Q6 Proceed, `cancelled` on a Q6 Cancel, `timed-out` once the PR 14 session-resume rule lands). No archive path promotes to `ops.config.json` or to persistent memory.

--- a/tests/issue_discovery_decision_tree.test.mjs
+++ b/tests/issue_discovery_decision_tree.test.mjs
@@ -69,7 +69,7 @@ describe("DECISION_TREE: shape + invariants", () => {
     }
   });
 
-  it("q6 is the only node that can transition to EXIT via `proceed` (terminal write gate)", () => {
+  it("q6 is the only node that transitions to `done` via `proceed` (terminal write gate)", () => {
     const proceedTargets = [];
     for (const node of nodes) {
       for (const branch of node.next) {

--- a/tests/issue_discovery_decision_tree.test.mjs
+++ b/tests/issue_discovery_decision_tree.test.mjs
@@ -1,0 +1,163 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DECISION_TREE,
+  scoreArea,
+  rankIssuesForShortlist,
+} from "../scripts/lib/issueDiscovery.mjs";
+
+describe("DECISION_TREE: shape + invariants", () => {
+  const nodes = Object.values(DECISION_TREE);
+  const ids = new Set(nodes.map((n) => n.id));
+
+  it("every node declares id, predecessors, next, minOptions, maxOptions, canHalt, customEscape", () => {
+    for (const node of nodes) {
+      assert.ok(typeof node.id === "string", `node missing id: ${JSON.stringify(node)}`);
+      assert.ok(Array.isArray(node.predecessors), `${node.id} missing predecessors array`);
+      assert.ok(Array.isArray(node.next), `${node.id} missing next array`);
+      assert.ok("minOptions" in node, `${node.id} missing minOptions`);
+      assert.ok("maxOptions" in node, `${node.id} missing maxOptions`);
+      assert.equal(typeof node.canHalt, "boolean", `${node.id} canHalt must be boolean`);
+      assert.equal(typeof node.customEscape, "boolean", `${node.id} customEscape must be boolean`);
+    }
+  });
+
+  it("ENTRY is the only node with empty predecessors", () => {
+    const zeroPreds = nodes.filter((n) => n.predecessors.length === 0);
+    assert.deepEqual(zeroPreds.map((n) => n.id).sort(), ["ENTRY"]);
+  });
+
+  it("every `next` target is either EXIT or a known node id", () => {
+    for (const node of nodes) {
+      for (const branch of node.next) {
+        assert.ok(
+          branch.target === "EXIT" || ids.has(branch.target),
+          `${node.id} -> ${branch.target} is unknown`,
+        );
+        assert.equal(typeof branch.when, "string", `${node.id} branch ${JSON.stringify(branch)} missing when`);
+      }
+    }
+  });
+
+  it("every node (except ENTRY) is reachable from at least one predecessor's `next`", () => {
+    const incoming = new Set(["ENTRY"]);
+    for (const node of nodes) {
+      for (const branch of node.next) {
+        if (branch.target !== "EXIT") incoming.add(branch.target);
+      }
+    }
+    for (const node of nodes) {
+      assert.ok(
+        incoming.has(node.id) || node.id === "ENTRY",
+        `${node.id} is not reachable from any node's next[]`,
+      );
+    }
+  });
+
+  it("the 2-4 options contract holds for every prompt node (minOptions in [2,4] or null for free-form)", () => {
+    for (const node of nodes) {
+      if (node.minOptions === null) continue;
+      assert.ok(
+        node.minOptions >= 2 && node.minOptions <= 4,
+        `${node.id} minOptions must be 2-4; got ${node.minOptions}`,
+      );
+      assert.ok(
+        node.maxOptions >= node.minOptions && node.maxOptions <= 4,
+        `${node.id} maxOptions must be >= minOptions and <= 4; got ${node.maxOptions}`,
+      );
+    }
+  });
+
+  it("q6 is the only node that can transition to EXIT via `proceed` (terminal write gate)", () => {
+    const proceedTargets = [];
+    for (const node of nodes) {
+      for (const branch of node.next) {
+        if (branch.when === "proceed" && branch.target === "done") {
+          proceedTargets.push(node.id);
+        }
+      }
+    }
+    assert.deepEqual(proceedTargets, ["q6"]);
+  });
+
+  it("nodes with customEscape=true list `canHalt: true` (custom option must be able to halt per ambiguity rules)", () => {
+    for (const node of nodes) {
+      if (!node.customEscape) continue;
+      assert.equal(
+        node.canHalt,
+        true,
+        `${node.id} has customEscape=true but canHalt=false; a custom answer outside the configured surface must halt`,
+      );
+    }
+  });
+});
+
+describe("scoreArea", () => {
+  it("returns zero and empty matches when keywords are absent", () => {
+    assert.deepEqual(scoreArea("anything", { name: "x", keywords: [] }), {
+      score: 0,
+      matchedKeywords: [],
+    });
+  });
+
+  it("is case-insensitive and normalises against the keyword list length", () => {
+    const result = scoreArea("Let's fix the CHECKOUT payment bug", {
+      name: "checkout",
+      keywords: ["checkout", "cart", "payment", "stripe"],
+    });
+    assert.deepEqual(result.matchedKeywords.sort(), ["checkout", "payment"]);
+    assert.equal(result.score, 2 / 4);
+  });
+
+  it("handles non-string inputs without throwing", () => {
+    assert.deepEqual(scoreArea(null, { name: "x", keywords: ["x"] }), {
+      score: 0,
+      matchedKeywords: [],
+    });
+    assert.deepEqual(scoreArea("hi", null), { score: 0, matchedKeywords: [] });
+    assert.deepEqual(scoreArea("hi", { name: "x", keywords: null }), {
+      score: 0,
+      matchedKeywords: [],
+    });
+  });
+});
+
+describe("rankIssuesForShortlist", () => {
+  const ISSUES = [
+    { number: 1, title: "low-old", priority: "low", createdAt: "2026-01-01T00:00:00Z" },
+    { number: 2, title: "high-new", priority: "high", createdAt: "2026-04-01T00:00:00Z" },
+    { number: 3, title: "high-old", priority: "high", createdAt: "2026-02-01T00:00:00Z" },
+    { number: 4, title: "medium-new", priority: "medium", createdAt: "2026-04-15T00:00:00Z" },
+    { number: 5, title: "none-middle", priority: null, createdAt: "2026-03-01T00:00:00Z" },
+  ];
+
+  it("ranks high > medium > low > null; within priority, oldest first", () => {
+    const top = rankIssuesForShortlist(ISSUES, 5);
+    const order = top.map((i) => i.number);
+    // high (old before new) then medium then low then null
+    assert.deepEqual(order, [3, 2, 4, 1, 5]);
+  });
+
+  it("defaults cap to 4 and never returns more than cap entries", () => {
+    assert.equal(rankIssuesForShortlist(ISSUES).length, 4);
+    assert.equal(rankIssuesForShortlist(ISSUES, 2).length, 2);
+  });
+
+  it("skips malformed entries without throwing", () => {
+    const top = rankIssuesForShortlist([{ number: "bad", title: "x" }, { title: "no-num" }, { number: 99, title: "keep" }]);
+    assert.deepEqual(top.map((i) => i.number), [99]);
+  });
+
+  it("rejects a non-integer cap", () => {
+    assert.throws(() => rankIssuesForShortlist(ISSUES, 0), /cap must be a positive integer/);
+    assert.throws(() => rankIssuesForShortlist(ISSUES, -1), /cap must be a positive integer/);
+    assert.throws(() => rankIssuesForShortlist(ISSUES, 1.5), /cap must be a positive integer/);
+  });
+
+  it("returns [] for non-array input instead of throwing", () => {
+    assert.deepEqual(rankIssuesForShortlist(null), []);
+    assert.deepEqual(rankIssuesForShortlist(undefined), []);
+    assert.deepEqual(rankIssuesForShortlist("not an array"), []);
+  });
+});

--- a/tests/issue_discovery_state.test.mjs
+++ b/tests/issue_discovery_state.test.mjs
@@ -1,0 +1,167 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  newSessionId,
+  slugFromIntent,
+  readSession,
+  writeSession,
+  listPendingSessions,
+  archiveSession,
+  DOMAIN_NAME,
+} from "../scripts/lib/issueDiscovery.mjs";
+import { readJsonOrNull } from "../scripts/lib/fsx.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SESSION_SCHEMA = await readJsonOrNull(
+  join(__dirname, "..", "schemas", "issue-discovery-session.schema.json"),
+);
+if (!SESSION_SCHEMA) throw new Error("issue-discovery-session.schema.json missing");
+
+const scratch = await mkdtemp(join(tmpdir(), "issue-discovery-state-"));
+after(async () => {
+  await rm(scratch, { recursive: true, force: true });
+});
+
+function makeValidState(sessionId, overrides = {}) {
+  const base = {
+    sessionId,
+    version: 1,
+    startedAt: "2026-04-21T12:00:00Z",
+    updatedAt: "2026-04-21T12:00:00Z",
+    currentStep: "q0",
+    intentText: "work on checkout flow",
+    topicConfirmed: false,
+    trackerTarget: {
+      kind: "github",
+      owner: "ctxr-dev",
+      repo: "agent-staff-engineer",
+    },
+    answers: [],
+  };
+  return { ...base, ...overrides };
+}
+
+describe("issueDiscovery.newSessionId", () => {
+  it("produces a deterministic-friendly id matching the schema pattern", () => {
+    const now = new Date("2026-04-21T12:34:56Z");
+    const rand = Buffer.from([0xab, 0xcd]);
+    const id = newSessionId({ now, rand });
+    assert.equal(id, "20260421-123456-abcd");
+    assert.match(id, /^[0-9]{8}-[0-9]{6}-[A-Za-z0-9_-]{4,16}$/);
+  });
+
+  it("pads single-digit months / days / hours / minutes / seconds", () => {
+    const now = new Date("2026-01-02T03:04:05Z");
+    const rand = Buffer.from([0x00, 0x01]);
+    const id = newSessionId({ now, rand });
+    assert.equal(id, "20260102-030405-0001");
+  });
+
+  it("uses random bytes when `rand` is omitted but still matches the pattern", () => {
+    const id = newSessionId();
+    assert.match(id, /^[0-9]{8}-[0-9]{6}-[0-9a-f]{4}$/);
+  });
+
+  it("rejects an invalid Date", () => {
+    assert.throws(() => newSessionId({ now: new Date("not a date") }), /valid Date/);
+  });
+});
+
+describe("issueDiscovery.slugFromIntent", () => {
+  it("returns 6 base32-ish chars for any intent string", () => {
+    const a = slugFromIntent("hello world");
+    const b = slugFromIntent("hello world");
+    assert.equal(a, b);
+    assert.match(a, /^[a-z2-7]{6}$/);
+  });
+
+  it("normalises whitespace and case so equivalent intents get the same slug", () => {
+    assert.equal(
+      slugFromIntent("  The CHECKOUT flow  "),
+      slugFromIntent("the checkout flow"),
+    );
+  });
+
+  it("different intents get different slugs with overwhelming probability", () => {
+    assert.notEqual(slugFromIntent("alpha"), slugFromIntent("beta"));
+  });
+});
+
+describe("issueDiscovery.writeSession / readSession schema enforcement", () => {
+  it("round-trips a valid state through the session-scoped helper", async () => {
+    const state = makeValidState("20260421-120000-aaaa");
+    await writeSession(scratch, "20260421-120000-aaaa", state, SESSION_SCHEMA);
+    const { state: roundTripped, errors } = await readSession(scratch, "20260421-120000-aaaa", SESSION_SCHEMA);
+    assert.deepEqual(errors, []);
+    assert.deepEqual(roundTripped, state);
+  });
+
+  it("refuses to write a state missing required fields", async () => {
+    const bad = { sessionId: "20260421-120000-bbbb", version: 1 }; // missing startedAt, currentStep, etc.
+    await assert.rejects(
+      () => writeSession(scratch, "20260421-120000-bbbb", bad, SESSION_SCHEMA),
+      /fails schema/,
+    );
+  });
+
+  it("returns state: null with errors when the on-disk file fails schema", async () => {
+    // Write a corrupted state bypassing the schema-enforced writer.
+    const { writeSession: rawWriteSession } = await import("../scripts/lib/sessionState.mjs");
+    await rawWriteSession(scratch, DOMAIN_NAME, "20260421-120000-cccc", { whatever: "bad" });
+    const { state, errors } = await readSession(scratch, "20260421-120000-cccc", SESSION_SCHEMA);
+    assert.equal(state, null);
+    assert.ok(errors.length > 0, "expected schema errors surfaced");
+  });
+
+  it("returns state: null when the file is missing, without any errors", async () => {
+    const { state, errors } = await readSession(scratch, "missing-id-ffff", SESSION_SCHEMA);
+    assert.equal(state, null);
+    assert.deepEqual(errors, []);
+  });
+});
+
+describe("issueDiscovery.listPendingSessions + archiveSession", () => {
+  it("lists only non-archived sessions and archives with the right suffix", async () => {
+    const fresh = makeValidState("20260426-100000-dddd");
+    const older = makeValidState("20260425-100000-eeee", { startedAt: "2026-04-25T10:00:00Z" });
+    await writeSession(scratch, "20260426-100000-dddd", fresh, SESSION_SCHEMA);
+    await writeSession(scratch, "20260425-100000-eeee", older, SESSION_SCHEMA);
+
+    const before = await listPendingSessions(scratch);
+    const idsBefore = before.map((e) => e.sessionId).sort();
+    assert.ok(idsBefore.includes("20260426-100000-dddd"));
+    assert.ok(idsBefore.includes("20260425-100000-eeee"));
+
+    const archivedPath = await archiveSession(scratch, "20260425-100000-eeee", "completed");
+    assert.ok(archivedPath.endsWith("20260425-100000-eeee.completed.json"));
+
+    const after = await listPendingSessions(scratch);
+    const idsAfter = after.map((e) => e.sessionId);
+    assert.ok(!idsAfter.includes("20260425-100000-eeee"));
+  });
+
+  it("rejects an archival outcome outside the documented set", async () => {
+    await assert.rejects(
+      () => archiveSession(scratch, "anything", "bogus"),
+      /outcome must be "completed", "cancelled", or "timed-out"/,
+    );
+  });
+});
+
+describe("issueDiscovery: 24-hour staleness signal", () => {
+  it("listPendingSessions exposes ageMs so callers can decide the default resume answer", async () => {
+    const long = makeValidState("20260420-000000-ffff", { startedAt: "2026-04-20T00:00:00Z" });
+    await writeSession(scratch, "20260420-000000-ffff", long, SESSION_SCHEMA);
+    const pending = await listPendingSessions(scratch);
+    const hit = pending.find((e) => e.sessionId === "20260420-000000-ffff");
+    assert.ok(hit, "expected session to show up in pending list");
+    assert.ok(Number.isFinite(hit.ageMs));
+    // Entry's startedAt is in the past; age must be >= 0.
+    assert.ok(hit.ageMs >= 0);
+  });
+});

--- a/tests/issue_discovery_state.test.mjs
+++ b/tests/issue_discovery_state.test.mjs
@@ -155,13 +155,17 @@ describe("issueDiscovery.listPendingSessions + archiveSession", () => {
 
 describe("issueDiscovery: 24-hour staleness signal", () => {
   it("listPendingSessions exposes ageMs so callers can decide the default resume answer", async () => {
-    const long = makeValidState("20260420-000000-ffff", { startedAt: "2026-04-20T00:00:00Z" });
+    // Generate startedAt relative to the wall clock so the test
+    // isn't pinned to a specific calendar date (future CI runs must
+    // still see ageMs >= 0).
+    const startedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    const long = makeValidState("20260420-000000-ffff", { startedAt });
     await writeSession(scratch, "20260420-000000-ffff", long, SESSION_SCHEMA);
     const pending = await listPendingSessions(scratch);
     const hit = pending.find((e) => e.sessionId === "20260420-000000-ffff");
     assert.ok(hit, "expected session to show up in pending list");
     assert.ok(Number.isFinite(hit.ageMs));
-    // Entry's startedAt is in the past; age must be >= 0.
+    // Entry's startedAt is generated in the past; age must be >= 0.
     assert.ok(hit.ageMs >= 0);
   });
 });

--- a/tests/issue_discovery_state.test.mjs
+++ b/tests/issue_discovery_state.test.mjs
@@ -1,6 +1,6 @@
 import { after, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/tests/issue_discovery_state.test.mjs
+++ b/tests/issue_discovery_state.test.mjs
@@ -52,7 +52,12 @@ describe("issueDiscovery.newSessionId", () => {
     const rand = Buffer.from([0xab, 0xcd]);
     const id = newSessionId({ now, rand });
     assert.equal(id, "20260421-123456-abcd");
-    assert.match(id, /^[0-9]{8}-[0-9]{6}-[A-Za-z0-9_-]{4,16}$/);
+    // Assert on the same strict shape the session-state schema
+    // pattern enforces (YYYYMMDD-HHMMSS-<4 lowercase hex>); the
+    // looser regex would have let a drift in newSessionId slip
+    // past the test while breaking schema validation on the first
+    // persisted session.
+    assert.match(id, /^[0-9]{8}-[0-9]{6}-[0-9a-f]{4}$/);
   });
 
   it("pads single-digit months / days / hours / minutes / seconds", () => {

--- a/tests/issue_discovery_state.test.mjs
+++ b/tests/issue_discovery_state.test.mjs
@@ -80,7 +80,7 @@ describe("issueDiscovery.slugFromIntent", () => {
     assert.match(a, /^[a-z2-7]{6}$/);
   });
 
-  it("normalises whitespace and case so equivalent intents get the same slug", () => {
+  it("trims and lowercases so equivalent-modulo-edge-whitespace-and-case intents get the same slug", () => {
     assert.equal(
       slugFromIntent("  The CHECKOUT flow  "),
       slugFromIntent("the checkout flow"),

--- a/tests/session_state.test.mjs
+++ b/tests/session_state.test.mjs
@@ -61,8 +61,13 @@ describe("sessionState.writeSession / readSession", () => {
 
 describe("sessionState.listPendingSessions", () => {
   it("enumerates non-archived files in the domain directory", async () => {
-    const s1 = { sessionId: "20260420-100000-aaaa", version: 1, startedAt: "2026-04-20T10:00:00Z" };
-    const s2 = { sessionId: "20260421-110000-bbbb", version: 1, startedAt: "2026-04-21T11:00:00Z" };
+    // Generate timestamps relative to the wall clock so the test
+    // doesn't regress the moment CI clock drifts or a future run
+    // precedes the hardcoded date. `s1` is 24h older than `s2`.
+    const older = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const newer = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
+    const s1 = { sessionId: "20260420-100000-aaaa", version: 1, startedAt: older };
+    const s2 = { sessionId: "20260421-110000-bbbb", version: 1, startedAt: newer };
     await writeSession(scratch, "list-test", "20260420-100000-aaaa", s1);
     await writeSession(scratch, "list-test", "20260421-110000-bbbb", s2);
 

--- a/tests/session_state.test.mjs
+++ b/tests/session_state.test.mjs
@@ -1,0 +1,130 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  writeSession,
+  readSession,
+  listPendingSessions,
+  archiveSession,
+  sessionDirFor,
+} from "../scripts/lib/sessionState.mjs";
+
+const scratch = await mkdtemp(join(tmpdir(), "session-state-"));
+after(async () => {
+  await rm(scratch, { recursive: true, force: true });
+});
+
+describe("sessionState.writeSession / readSession", () => {
+  it("writes atomically under .development/local/<domain>/ and reads back the same object", async () => {
+    const state = {
+      sessionId: "20260421-120000-abcd",
+      version: 1,
+      startedAt: "2026-04-21T12:00:00Z",
+      whatever: "extra",
+    };
+    await writeSession(scratch, "test-domain", "20260421-120000-abcd", state);
+    const roundTripped = await readSession(scratch, "test-domain", "20260421-120000-abcd");
+    assert.deepEqual(roundTripped, state);
+    const dir = sessionDirFor(scratch, "test-domain");
+    assert.ok(dir.endsWith(join(".development", "local", "test-domain")));
+  });
+
+  it("returns null for a missing session file", async () => {
+    const state = await readSession(scratch, "test-domain", "nonexistent");
+    assert.equal(state, null);
+  });
+
+  it("rejects an invalid domain (must be kebab-case ASCII)", async () => {
+    await assert.rejects(
+      () => writeSession(scratch, "Bad Domain!", "abc", {}),
+      /domain must be kebab-case/,
+    );
+  });
+
+  it("rejects an invalid sessionId (fs-safe allow-list only)", async () => {
+    await assert.rejects(
+      () => writeSession(scratch, "dom", "../escape", {}),
+      /sessionId must match/,
+    );
+  });
+
+  it("rejects a non-object state", async () => {
+    await assert.rejects(
+      () => writeSession(scratch, "dom", "abc", "not an object"),
+      /state must be a plain object/,
+    );
+  });
+});
+
+describe("sessionState.listPendingSessions", () => {
+  it("enumerates non-archived files in the domain directory", async () => {
+    const s1 = { sessionId: "20260420-100000-aaaa", version: 1, startedAt: "2026-04-20T10:00:00Z" };
+    const s2 = { sessionId: "20260421-110000-bbbb", version: 1, startedAt: "2026-04-21T11:00:00Z" };
+    await writeSession(scratch, "list-test", "20260420-100000-aaaa", s1);
+    await writeSession(scratch, "list-test", "20260421-110000-bbbb", s2);
+
+    const pending = await listPendingSessions(scratch, "list-test");
+    const ids = pending.map((e) => e.sessionId).sort();
+    assert.deepEqual(ids, ["20260420-100000-aaaa", "20260421-110000-bbbb"]);
+    // oldest first (larger ageMs) per the helper's documented contract.
+    assert.ok(pending[0].ageMs >= pending[1].ageMs, "pending should be sorted oldest-first");
+  });
+
+  it("returns an empty array when the domain directory does not exist", async () => {
+    const result = await listPendingSessions(scratch, "never-created");
+    assert.deepEqual(result, []);
+  });
+
+  it("skips archived files (<sessionId>.<outcome>.json)", async () => {
+    const s = { sessionId: "20260422-120000-cccc", version: 1, startedAt: "2026-04-22T12:00:00Z" };
+    await writeSession(scratch, "archive-test", "20260422-120000-cccc", s);
+    await archiveSession(scratch, "archive-test", "20260422-120000-cccc", "completed");
+    const pending = await listPendingSessions(scratch, "archive-test");
+    assert.deepEqual(pending, []);
+  });
+
+  it("surfaces malformed JSON without dropping the entry silently", async () => {
+    const dir = sessionDirFor(scratch, "malformed-test");
+    await writeSession(scratch, "malformed-test", "20260423-130000-dddd", {
+      sessionId: "20260423-130000-dddd",
+      version: 1,
+      startedAt: "2026-04-23T13:00:00Z",
+    });
+    // overwrite the real file with garbage
+    const entries = await readdir(dir);
+    const target = entries.find((f) => f.startsWith("20260423"));
+    await writeFile(join(dir, target), "{not json", "utf8");
+    const pending = await listPendingSessions(scratch, "malformed-test");
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].state, null);
+    assert.ok(typeof pending[0].error === "string" && pending[0].error.length > 0);
+  });
+});
+
+describe("sessionState.archiveSession", () => {
+  it("renames the file to <sessionId>.<outcome>.json", async () => {
+    const s = { sessionId: "20260424-140000-eeee", version: 1, startedAt: "2026-04-24T14:00:00Z" };
+    await writeSession(scratch, "rename-test", "20260424-140000-eeee", s);
+    const newPath = await archiveSession(scratch, "rename-test", "20260424-140000-eeee", "completed");
+    assert.ok(newPath.endsWith("20260424-140000-eeee.completed.json"));
+    const roundTripped = JSON.parse(await readFile(newPath, "utf8"));
+    assert.deepEqual(roundTripped, s);
+  });
+
+  it("returns null when the source file does not exist (idempotent)", async () => {
+    const result = await archiveSession(scratch, "rename-test", "nope", "completed");
+    assert.equal(result, null);
+  });
+
+  it("rejects an outcome that doesn't match the allow-list", async () => {
+    const s = { sessionId: "20260425-150000-ffff", version: 1, startedAt: "2026-04-25T15:00:00Z" };
+    await writeSession(scratch, "outcome-test", "20260425-150000-ffff", s);
+    await assert.rejects(
+      () => archiveSession(scratch, "outcome-test", "20260425-150000-ffff", "Bad Outcome"),
+      /outcome must match/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a first-class **issue-discovery** intake skill the agent runs before any dev-loop when the user has no resolvable issue reference. Implements the user-priority "never guess what to work on" posture from the plan.
- Ships the skill (`skills/issue-discovery/SKILL.md` + runbook), the binding rule (`rules/issue-discovery.md`), memory seed, template, two JSON schemas (handoff tuple + session scratch), a shared `scripts/lib/sessionState.mjs` helper (scope-bounded to `.development/local/<domain>/`), and a `scripts/lib/issueDiscovery.mjs` library that exposes the decision tree as pure data.
- Cross-skill edits wire the intake into dev-loop (handoff at entry), regression-handler (new-bug delegation), release-tracker (new `createUmbrellaForIntent` public entry point), tracker-sync (new caller row), and adapt-system (`domain:*`/`audience:*` cascade into `workflow.issue_discovery.*`).

**Design principles** (enforced in the rule + decision tree):

1. Never guess. Halt per `rules/ambiguity-halt.md` when facts are thin.
2. 2 to 4 options plus custom at every branch.
3. Delegate every tracker write to `tracker-sync` (with a single public exception for `release-tracker.createUmbrellaForIntent` so umbrella status stays coupled with the create).

**Session state** lives under `.development/local/issue-discovery/<session-id>.json`, validated on every read against `schemas/issue-discovery-session.schema.json`, atomically written via the shared session-state helper, and archived (not deleted) on terminal nodes with a `.completed.json` or `.cancelled.json` suffix.

## Test plan

- [x] Full bundle gates: `npm test && npm run validate && npm run lint` (605 pass, 0 fail).
- [x] New tests:
  - `tests/session_state.test.mjs` (12 tests) — shared helper round-trip, domain + sessionId allow-lists, list/archive semantics, malformed-JSON surface.
  - `tests/issue_discovery_state.test.mjs` (13 tests) — schema enforcement on read/write, `newSessionId` determinism, `slugFromIntent` stability, 24-hour staleness signal.
  - `tests/issue_discovery_decision_tree.test.mjs` (16 tests) — DECISION_TREE shape invariants, 2-4 options contract, reachability of every node, `customEscape => canHalt`, `scoreArea`, `rankIssuesForShortlist`.
- [ ] Interview walkthrough on a scratch project once the backend surfaces land (manual; the library is deterministic but the conversation layer is what the agent drives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)