### PR TITLE
feat(pr-iteration): autonomous wakeup-driven tick (PR 14)

### DIFF
--- a/bundle-index.md
+++ b/bundle-index.md
@@ -50,9 +50,10 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 
 ### Iterating on review comments on an open PR
 
-- [skills/pr-iteration/SKILL.md](skills/pr-iteration/SKILL.md): the post-push loop orchestration.
+- [skills/pr-iteration/SKILL.md](skills/pr-iteration/SKILL.md): the post-push loop orchestration (autonomous wakeup-driven tick or legacy in-session poll).
 - [skills/pr-iteration/runbook.md](skills/pr-iteration/runbook.md): canonical how-to with GraphQL recipes.
 - [rules/pr-iteration.md](rules/pr-iteration.md): loop contract + exit conditions.
+- [rules/agent-boot.md](rules/agent-boot.md): session-start resume prompt for pending iteration loops.
 - [rules/ambiguity-halt.md](rules/ambiguity-halt.md): halt-and-ask contract when state is weird.
 - [templates/pr-iteration-report.md](templates/pr-iteration-report.md): per-round artefact.
 
@@ -136,9 +137,10 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 - [skills/regression-handler/SKILL.md](skills/regression-handler/SKILL.md): bug triage + linked-issue proposal.
 - [skills/release-tracker/SKILL.md](skills/release-tracker/SKILL.md): Release umbrella status computation.
 
-### Rules (12)
+### Rules (13)
 
 - [rules/adaptation.md](rules/adaptation.md): when to invoke adapt-system.
+- [rules/agent-boot.md](rules/agent-boot.md): session-start checks; scans for pending PR iteration loops and surfaces a resume prompt.
 - [rules/ambiguity-halt.md](rules/ambiguity-halt.md): halt-and-ask when state is weird.
 - [rules/issue-discovery.md](rules/issue-discovery.md): the three-clause intake rule (never guess; 2-4 options plus custom; delegate writes).
 - [rules/subagent-orchestration.md](rules/subagent-orchestration.md): the Captain/Soldier binding contract; when to delegate, roles, inherited invariants.

--- a/examples/ops.config.example.json
+++ b/examples/ops.config.example.json
@@ -141,7 +141,12 @@
       "bots": { "github": ["copilot-pull-request-reviewer"] },
       "poll_interval_seconds": 30,
       "poll_timeout_seconds": 1200,
-      "auto_resolve_stale_after_commits": 1
+      "auto_resolve_stale_after_commits": 1,
+      "autonomous": {
+        "enabled": true,
+        "default_interval_seconds": 270,
+        "max_consecutive_wakes": 96
+      }
     },
     "orchestration": {
       "enabled": true,

--- a/rules/agent-boot.md
+++ b/rules/agent-boot.md
@@ -1,0 +1,44 @@
+---
+name: agent-boot
+description: Session-start checks the agent runs before acting on the user's message. Scans for pending PR iteration loops and surfaces a resume prompt per pending PR. Never auto-resumes silently.
+portable: true
+scope: every agent invocation on a project with autonomous pr-iteration enabled
+---
+
+# Agent boot
+
+## The rule
+
+On every agent invocation, before the user's message is acted on, scan `.development/local/pr-iteration/*.json` for pending iteration states (files without a `.stopped` or `.paused` sidecar). For each pending state, surface a single prompt to the user:
+
+> PR #N (`<owner>/<repo>#<number>`) has a pending iteration loop (last checked M minutes ago, state: `<lastPollResult.ciState>`, unresolved: `<lastPollResult.unresolvedCount>`). **Resume / defer / stop?**
+
+The user's answer determines the next action:
+
+- **Resume**: call `runTick` immediately from `scripts/lib/pr-iteration/tick.mjs`. If the tick returns `needs-triage`, enter the fix round per `rules/pr-iteration.md` steps 5-6, then reschedule the next wakeup. If `still-waiting`, reschedule directly. If `complete`, report and stop.
+- **Defer**: leave the state file in place. Skip this session without rescheduling. The state file stays for the next session's boot check.
+- **Stop**: call `markPrStateStopped` from `scripts/lib/pr-iteration/state.mjs` with reason "user stopped at session start". The next wakeup fire (if any) reads the sidecar and exits cleanly.
+
+## Why never auto-resume
+
+A user may have opened the IDE for unrelated work. Auto-resuming a PR iteration loop mid-conversation would inject unexpected tool calls and context consumption. The prompt keeps the user in control.
+
+## Paused states
+
+If a `.paused` sidecar exists (safety cap was hit), surface a different prompt:
+
+> PR #N iteration loop was paused (safety cap: N consecutive wakes without progress). Last known state: CI `<ciState>`, unresolved: `<count>`. **Resume / investigate / dismiss?**
+
+- **Resume**: delete the `.paused` file, reset `consecutiveWakes` to 0 in the state file, and run a tick.
+- **Investigate**: read the state file and last poll result, surface a summary, let the user decide.
+- **Dismiss**: leave the `.paused` file. The loop stays paused.
+
+## Config
+
+- `workflow.external_review.autonomous.enabled`: when `false`, skip this entire boot check (no autonomous loops to resume).
+
+## Related
+
+- `rules/pr-iteration.md`: the binding contract for the iteration loop.
+- `skills/pr-iteration/SKILL.md`: the orchestration skill.
+- `scripts/lib/pr-iteration/state.mjs`: state read/write/list.

--- a/rules/agent-boot.md
+++ b/rules/agent-boot.md
@@ -17,7 +17,7 @@ The user's answer determines the next action:
 
 - **Resume**: call `runTick` immediately from `scripts/lib/pr-iteration/tick.mjs`. If the tick returns `needs-triage`, enter the fix round per `rules/pr-iteration.md` steps 5-6, then reschedule the next wakeup. If `still-waiting`, reschedule directly. If `complete`, report and stop.
 - **Defer**: leave the state file in place. Skip this session without rescheduling. The state file stays for the next session's boot check.
-- **Stop**: call `markPrStateStopped` from `scripts/lib/pr-iteration/state.mjs` with reason "user stopped at session start". The next wakeup fire (if any) reads the sidecar and exits cleanly.
+- **Stop**: call `markPrStateStopped` from `scripts/lib/pr-iteration/state.mjs` with reason "user stopped at session start". When the next wakeup fires (if any), it reads the sidecar and exits cleanly.
 
 ## Why never auto-resume
 

--- a/rules/pr-iteration.md
+++ b/rules/pr-iteration.md
@@ -24,7 +24,7 @@ Each round is the same six steps. The loop repeats until the exit conditions hol
 1. **Assert local review GO on HEAD.** Delegate to `rules/review-loop.md`. If the local review is not GO, fix and re-run before pushing. Never push with outstanding Critical or Important findings.
 2. **Push** the feature branch to `origin`. Re-use the existing branch; do not rename between rounds.
 3. **Request external review** on current HEAD via `tracker.review.requestReview`. Implementation for GitHub is in `scripts/lib/trackers/github.mjs` and uses the `requestReviews` GraphQL mutation with `botIds`. The REST endpoint silently no-ops for bots; never use it.
-4. **Poll** at `workflow.external_review.poll_interval_seconds` (default 30s). Stop polling when CI reaches a terminal state (`SUCCESS` / `FAILURE` / `ERROR`) AND (any unresolved threads exist OR the reviewer has posted a review on the current HEAD). Cap the wait at `poll_timeout_seconds` (default 1200s) and surface a clear timeout to the human if hit.
+4. **Check once** via `tracker.review.pollForReview` (single call, not a loop). If autonomous mode is enabled (`workflow.external_review.autonomous.enabled`, default `true`), persist state to `.development/local/pr-iteration/<owner>__<repo>__<number>.json` and call `ScheduleWakeup` with the configured interval (default 270s, inside the 5-minute Anthropic prompt-cache window). The agent re-enters on wake with the `/resume-pr-iteration <prId>` prompt and runs another tick. If autonomous mode is disabled, fall back to the legacy in-session poll at `poll_interval_seconds` (default 30s) capped by `poll_timeout_seconds` (default 1200s).
 5. **Fetch unresolved threads** via `tracker.review.fetchUnresolvedThreads`. Triage into three buckets (the runbook documents the detection heuristics):
    - **Stale**: the reviewer re-emitted a comment on already-fixed code (same `path:line`, unchanged content since the last push, or posted on a superseded SHA). Mark for resolution without a code change. The agent tracks the recurrence count per thread fingerprint and auto-resolves once the count crosses `auto_resolve_stale_after_commits` (default 1), surfacing the decision in the per-round report. Set the threshold to `0` to require manual triage for every thread.
    - **Net-new actionable**: real issue. Fix. Lock the fix in with a regression test when the issue was behavioural (security, TOCTOU, exit code, parsing).
@@ -33,10 +33,12 @@ Each round is the same six steps. The loop repeats until the exit conditions hol
 
 ## Stop conditions
 
-- All three exit conditions hold: report state, write a final `pr-iteration-report.md` artefact into the wiki (per `rules/llm-wiki.md`), and stop. Never merge.
-- Poll timeout: surface the timeout with the last-known poll state and stop without committing any changes. Human decides whether to keep waiting, investigate CI, or close the PR.
+- All three exit conditions hold: report state, write a final `pr-iteration-report.md` artefact into the wiki (per `rules/llm-wiki.md`), delete the state file, and stop. Never merge.
+- Max consecutive wakes reached (default 96, roughly 7.2 hours of elapsed wall time at 270s intervals): the tick writes a `.paused` sidecar next to the state file and stops rescheduling. Surface a "loop paused: manual inspection needed" message with the last-known state. Human deletes the `.paused` file to resume on the next session.
+- User cancels ("stop the PR iteration"): agent writes a `.stopped` sidecar. The next wakeup fire reads the sidecar and exits without rescheduling, archiving the state as `<prId>.stopped.json`.
 - Provider declines (`NotSupportedError`): the provider is the stub for this tracker kind. Surface a clean "pr-iteration not supported for tracker kind '<kind>'; halting at In review" message to the human and stop. Do not fall back to a silent no-op.
 - CI goes red: fetch failed-step log lines, include them in the round's report, fix, re-push. Same loop.
+- Legacy poll timeout (autonomous mode disabled only): surface the timeout with the last-known poll state and stop without committing any changes.
 
 ## Per-round artefact
 
@@ -48,6 +50,9 @@ Every round writes a `pr-iteration-report.md` into `.development/shared/reports/
 - `provider` (`auto` / `github` / `none`): `auto` picks from `trackers.dev.kind` via the dispatcher; `github` forces the GitHub impl (for projects where code lives on GitHub but tickets are elsewhere); `none` is equivalent to `enabled: false`.
 - `bots`: per-kind map of reviewer LOGINS (portable across repos). For GitHub each value is the bot's login string (e.g. `copilot-pull-request-reviewer`). The skill resolves each login to its GraphQL node ID once per PR via the capture recipe below and caches the mapping in the in-memory iteration state. Config never stores node IDs: they vary across installations and are not portable.
 - `poll_interval_seconds`, `poll_timeout_seconds`, `auto_resolve_stale_after_commits`: see the schema for ranges and defaults.
+- `autonomous.enabled` (default `true`): when true, step 4 uses `ScheduleWakeup` ticks instead of the in-session poll. When false, restores the pre-PR-14 in-session poll behaviour.
+- `autonomous.default_interval_seconds` (default `270`): seconds between wakeup ticks. 270 stays inside the 5-minute Anthropic prompt-cache window. Honours a free-form user override.
+- `autonomous.max_consecutive_wakes` (default `96`): safety cap. After this many consecutive wakes without a fix round, the loop pauses automatically.
 
 ## Capturing the Copilot bot node ID (GitHub)
 
@@ -66,5 +71,9 @@ Pick the `id` whose `login` is `copilot-pull-request-reviewer`. If the repo has 
 
 - `rules/pr-workflow.md`: full PR state machine (branch -> edits -> local review -> push -> In review -> **iteration loop** -> merge human gate -> Done human gate).
 - `rules/review-loop.md`: the pre-push local review.
+- `rules/agent-boot.md`: session-start resume prompt for pending iteration loops.
 - `skills/pr-iteration/SKILL.md`: the orchestration skill this rule governs.
 - `skills/pr-iteration/runbook.md`: the canonical how-to with GraphQL snippets and known gotchas. Lives in the bundle so the lint + dash validators cover it; target projects mirror into their wiki via `@ctxr/skill-llm-wiki`.
+- `scripts/lib/pr-iteration/state.mjs`: persistent state read/write/list.
+- `scripts/lib/pr-iteration/tick.mjs`: one-shot tick (poll + exit-condition check).
+- `scripts/lib/pr-iteration/reschedule.mjs`: interval computation + wakeup prompt builder.

--- a/rules/pr-iteration.md
+++ b/rules/pr-iteration.md
@@ -35,7 +35,7 @@ Each round is the same six steps. The loop repeats until the exit conditions hol
 
 - All three exit conditions hold: report state, write a final `pr-iteration-report.md` artefact into the wiki (per `rules/llm-wiki.md`), delete the state file, and stop. Never merge.
 - Max consecutive wakes reached (default 96, roughly 7.2 hours of elapsed wall time at 270s intervals): the tick writes a `.paused` sidecar next to the state file and stops rescheduling. Surface a "loop paused: manual inspection needed" message with the last-known state. Human deletes the `.paused` file to resume on the next session.
-- User cancels ("stop the PR iteration"): agent writes a `.stopped` sidecar. The next wakeup fire reads the sidecar and exits without rescheduling, archiving the state as `<prId>.stopped.json`.
+- User cancels ("stop the PR iteration"): agent writes a `.stopped` sidecar next to the state file (same basename, `.stopped` extension). The next wakeup fire reads the sidecar and exits without rescheduling. The state file remains in place for post-hoc inspection; delete it manually when no longer needed.
 - Provider declines (`NotSupportedError`): the provider is the stub for this tracker kind. Surface a clean "pr-iteration not supported for tracker kind '<kind>'; halting at In review" message to the human and stop. Do not fall back to a silent no-op.
 - CI goes red: fetch failed-step log lines, include them in the round's report, fix, re-push. Same loop.
 - Legacy poll timeout (autonomous mode disabled only): surface the timeout with the last-known poll state and stop without committing any changes.

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -410,6 +410,32 @@
               "minimum": 0,
               "default": 1,
               "description": "When the same path:line thread has been re-emitted by the reviewer on a superseded SHA (commonly 30-50% of Copilot threads after round 1 per the runbook), auto-resolve it after this many commits have landed without changing the underlying code. Set 0 to disable and require manual triage for every thread."
+            },
+            "autonomous": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Wakeup-driven autonomous iteration (PR 14). Replaces the in-session poll with a ScheduleWakeup loop that survives session close, compaction, and IDE restarts. Set enabled:false to restore the pre-PR-14 in-session poll behaviour.",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "When false, step 4 uses the legacy in-session poll loop instead of ScheduleWakeup ticks."
+                },
+                "default_interval_seconds": {
+                  "type": "integer",
+                  "minimum": 60,
+                  "maximum": 3600,
+                  "default": 270,
+                  "description": "Seconds between wakeup ticks. 270 stays inside the 5-minute Anthropic prompt-cache window, avoiding the cache-miss cost ScheduleWakeup's docs warn about for >=300s. Honours a free-form user override (e.g. 'every 10 min')."
+                },
+                "max_consecutive_wakes": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 1000,
+                  "default": 96,
+                  "description": "Safety cap: after this many consecutive wakeups without forward progress (no fix round), the loop writes a .paused sidecar and stops rescheduling. 96 * 270s is roughly 7.2 hours of elapsed wall time. Human deletes the .paused file to resume."
+                }
+              }
             }
           }
         },

--- a/schemas/pr-iteration-state.schema.json
+++ b/schemas/pr-iteration-state.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agent-staff-engineer.local/pr-iteration-state.schema.json",
+  "title": "PR iteration state",
+  "description": "Persisted state for one active PR iteration loop. Lives at .development/local/pr-iteration/<owner>__<repo>__<number>.json. Read/written by scripts/lib/pr-iteration/state.mjs; validated on read so corrupted files surface immediately rather than mid-tick with a TypeError.",
+  "type": "object",
+  "required": [
+    "prId",
+    "owner",
+    "repo",
+    "prNumber",
+    "prNodeId",
+    "botIds",
+    "botLogins",
+    "headSha",
+    "lastRound",
+    "intervalSeconds",
+    "lastPollResult",
+    "exitConditions",
+    "createdAt",
+    "updatedAt"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "prId": {
+      "type": "string",
+      "description": "Canonical PR identifier: <owner>/<repo>#<number>.",
+      "pattern": "^[A-Za-z0-9_.][A-Za-z0-9_.-]*/[A-Za-z0-9_.][A-Za-z0-9_.-]*#[0-9]+$"
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "repo": {
+      "type": "string",
+      "minLength": 1
+    },
+    "prNumber": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "memberName": {
+      "type": ["string", "null"],
+      "description": "Workspace member (multi-repo dispatch) or null for single-repo projects."
+    },
+    "prNodeId": {
+      "type": "string",
+      "description": "GitHub PR GraphQL node ID. Cached; recapturable if stale.",
+      "minLength": 1
+    },
+    "botIds": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Resolved GraphQL node IDs for the configured reviewer bots."
+    },
+    "botLogins": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Login names for the configured reviewer bots."
+    },
+    "headSha": {
+      "type": "string",
+      "description": "Last known HEAD SHA of the PR branch.",
+      "pattern": "^[0-9a-f]{7,40}$"
+    },
+    "lastRound": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Last completed review round number. 0 means no rounds completed yet."
+    },
+    "nextWakeAt": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 timestamp for the next scheduled wakeup. Null if not yet scheduled."
+    },
+    "intervalSeconds": {
+      "type": "integer",
+      "minimum": 60,
+      "maximum": 3600,
+      "description": "Seconds between wakeup ticks. Default 270 (inside the 5-min Anthropic prompt-cache window)."
+    },
+    "consecutiveWakes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Consecutive wakeups without forward progress (no fix round). Resets when the skill completes a fix round. Used by the safety cap to pause the loop after max_consecutive_wakes.",
+      "default": 0
+    },
+    "lastPollResult": {
+      "type": "object",
+      "required": ["ciState", "unresolvedCount", "reviewOnHead", "observedAt"],
+      "additionalProperties": false,
+      "properties": {
+        "ciState": {
+          "type": "string",
+          "enum": ["SUCCESS", "FAILURE", "ERROR", "PENDING"]
+        },
+        "unresolvedCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "reviewOnHead": {
+          "type": "boolean"
+        },
+        "observedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "exitConditions": {
+      "type": "object",
+      "required": ["localReviewGo", "zeroUnresolvedOnHead", "ciSuccessOnHead"],
+      "additionalProperties": false,
+      "properties": {
+        "localReviewGo": { "type": "boolean" },
+        "zeroUnresolvedOnHead": { "type": "boolean" },
+        "ciSuccessOnHead": { "type": "boolean" }
+      }
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/scripts/lib/pr-iteration/reschedule.mjs
+++ b/scripts/lib/pr-iteration/reschedule.mjs
@@ -1,0 +1,50 @@
+// lib/pr-iteration/reschedule.mjs
+// Helpers for scheduling the next wakeup tick. Pure functions; the actual
+// ScheduleWakeup tool call happens in the skill layer, not here.
+
+const DEFAULT_INTERVAL = 270;
+const MIN_INTERVAL = 60;
+const MAX_INTERVAL = 3600;
+
+/**
+ * Compute the wakeup interval in seconds.
+ *
+ * Priority: explicit user override > state.intervalSeconds > config default > 270s.
+ * Result is clamped to [60, 3600] (ScheduleWakeup's enforced range).
+ *
+ * @param {number|null|undefined} userOverrideSeconds  free-form user request (e.g. "10 min" parsed to 600)
+ * @param {object} [state]                             persisted PR iteration state
+ * @param {number} [configDefault]                     workflow.external_review.autonomous.default_interval_seconds
+ * @returns {number} clamped interval in seconds
+ */
+export function computeInterval(userOverrideSeconds, state, configDefault) {
+  const raw =
+    userOverrideSeconds ??
+    state?.intervalSeconds ??
+    configDefault ??
+    DEFAULT_INTERVAL;
+  return Math.max(MIN_INTERVAL, Math.min(MAX_INTERVAL, raw));
+}
+
+/**
+ * Build the prompt string for ScheduleWakeup.
+ * The agent re-enters on wake with this prompt and reads the state file.
+ *
+ * @param {object} state  persisted PR iteration state
+ * @returns {string} prompt for the wakeup
+ */
+export function buildWakeupPrompt(state) {
+  return `/resume-pr-iteration ${state.prId}`;
+}
+
+/**
+ * Build the human-readable reason string for ScheduleWakeup.
+ *
+ * @param {object} state  persisted PR iteration state
+ * @returns {string}
+ */
+export function buildWakeupReason(state) {
+  const ci = state.lastPollResult?.ciState ?? "unknown";
+  const threads = state.lastPollResult?.unresolvedCount ?? "?";
+  return `Checking PR ${state.prId} (CI: ${ci}, unresolved: ${threads})`;
+}

--- a/scripts/lib/pr-iteration/state.mjs
+++ b/scripts/lib/pr-iteration/state.mjs
@@ -25,7 +25,9 @@ const SCHEMA = JSON.parse(
   ),
 );
 
-const PR_ID_RE = /^([^/]+)\/([^#]+)#(\d+)$/;
+// Match owner/repo#number. Both owner and repo segments reject "/" and path
+// separators so the derived filename is always a single path component.
+const PR_ID_RE = /^([A-Za-z0-9_.][A-Za-z0-9_.-]*)\/([A-Za-z0-9_.][A-Za-z0-9_.-]*)#(\d+)$/;
 
 /**
  * Derive the state filename from a canonical prId ("owner/repo#123").
@@ -102,10 +104,16 @@ export async function listPendingPrStates(stateDir) {
     const pausedExists = await exists(join(stateDir, `${base}.paused`));
     if (stoppedExists || pausedExists) continue;
 
-    const data = await readJsonOrNull(join(stateDir, name));
-    if (data && data.prId) {
-      results.push({ prId: data.prId, state: data });
+    const filePath = join(stateDir, name);
+    const data = await readJsonOrNull(filePath);
+    if (!data || !data.prId) continue;
+
+    const { ok, errors } = validate(SCHEMA, data);
+    if (!ok) {
+      const detail = errors.map((e) => `  ${e.path}: ${e.message}`).join("\n");
+      throw new Error(`PR state file ${filePath} failed schema validation:\n${detail}`);
     }
+    results.push({ prId: data.prId, state: data });
   }
   return results;
 }

--- a/scripts/lib/pr-iteration/state.mjs
+++ b/scripts/lib/pr-iteration/state.mjs
@@ -1,0 +1,168 @@
+// lib/pr-iteration/state.mjs
+// Persistent state for the wakeup-driven PR iteration loop. Each active PR
+// gets one JSON file under .development/local/pr-iteration/, validated on
+// read against schemas/pr-iteration-state.schema.json. All writes are
+// atomic (write-to-temp then rename) via fsx.mjs.
+
+import { readdir, unlink } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  atomicWriteJson,
+  atomicWriteText,
+  exists,
+  readJsonOrNull,
+} from "../fsx.mjs";
+import { validate } from "../schema.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCHEMA = JSON.parse(
+  await readFile(
+    join(__dirname, "..", "..", "..", "schemas", "pr-iteration-state.schema.json"),
+    "utf8",
+  ),
+);
+
+const PR_ID_RE = /^([^/]+)\/([^#]+)#(\d+)$/;
+
+/**
+ * Derive the state filename from a canonical prId ("owner/repo#123").
+ * @param {string} prId
+ * @returns {string} e.g. "owner__repo__123.json"
+ */
+export function stateFileName(prId) {
+  const m = prId.match(PR_ID_RE);
+  if (!m) throw new Error(`Invalid prId format: ${prId} (expected owner/repo#number)`);
+  return `${m[1]}__${m[2]}__${m[3]}.json`;
+}
+
+function stateFilePath(stateDir, prId) {
+  return join(stateDir, stateFileName(prId));
+}
+
+function sidecarPath(stateDir, prId, ext) {
+  return stateFilePath(stateDir, prId).replace(/\.json$/, `.${ext}`);
+}
+
+/**
+ * Read and validate a PR iteration state file.
+ * @param {string} stateDir absolute path to the state directory
+ * @param {string} prId     canonical PR identifier
+ * @returns {Promise<object|null>} validated state or null when file absent
+ * @throws on schema validation failure (corrupt file surfaces immediately)
+ */
+export async function readPrState(stateDir, prId) {
+  const p = stateFilePath(stateDir, prId);
+  const data = await readJsonOrNull(p);
+  if (data == null) return null;
+  const { ok, errors } = validate(SCHEMA, data);
+  if (!ok) {
+    const detail = errors.map((e) => `  ${e.path}: ${e.message}`).join("\n");
+    throw new Error(`PR state file ${p} failed schema validation:\n${detail}`);
+  }
+  return data;
+}
+
+/**
+ * Atomically write a PR iteration state file. Sets updatedAt automatically.
+ * @param {string} stateDir absolute path to the state directory
+ * @param {object} state    state object (must have a valid prId)
+ * @returns {Promise<string>} absolute path written
+ */
+export async function writePrState(stateDir, state) {
+  state.updatedAt = new Date().toISOString();
+  return atomicWriteJson(stateFilePath(stateDir, state.prId), state);
+}
+
+/**
+ * List all pending (not stopped, not paused) PR iteration states.
+ * Returns a deterministic (sorted by filename) array.
+ * @param {string} stateDir absolute path to the state directory
+ * @returns {Promise<Array<{prId: string, state: object}>>}
+ */
+export async function listPendingPrStates(stateDir) {
+  let entries;
+  try {
+    entries = await readdir(stateDir);
+  } catch (err) {
+    if (err.code === "ENOENT") return [];
+    throw err;
+  }
+
+  const results = [];
+  for (const name of entries.sort()) {
+    if (!name.endsWith(".json")) continue;
+    // Skip archived stopped states
+    if (name.endsWith(".stopped.json")) continue;
+
+    const base = name.replace(/\.json$/, "");
+    const stoppedExists = await exists(join(stateDir, `${base}.stopped`));
+    const pausedExists = await exists(join(stateDir, `${base}.paused`));
+    if (stoppedExists || pausedExists) continue;
+
+    const data = await readJsonOrNull(join(stateDir, name));
+    if (data && data.prId) {
+      results.push({ prId: data.prId, state: data });
+    }
+  }
+  return results;
+}
+
+/**
+ * Write a .stopped sidecar so the next wakeup fire exits without rescheduling.
+ * @param {string} stateDir absolute path to the state directory
+ * @param {string} prId     canonical PR identifier
+ * @param {string} reason   human-readable reason for stopping
+ * @returns {Promise<string>} absolute path of the sidecar file
+ */
+export async function markPrStateStopped(stateDir, prId, reason) {
+  const content = JSON.stringify(
+    { reason, stoppedAt: new Date().toISOString() },
+    null,
+    2,
+  ) + "\n";
+  return atomicWriteText(sidecarPath(stateDir, prId, "stopped"), content);
+}
+
+/**
+ * Write a .paused sidecar (safety cap reached). Human deletes the file to resume.
+ * @param {string} stateDir absolute path to the state directory
+ * @param {string} prId     canonical PR identifier
+ * @param {string} reason   human-readable reason for pausing
+ * @returns {Promise<string>} absolute path of the sidecar file
+ */
+export async function markPrStatePaused(stateDir, prId, reason) {
+  const content = JSON.stringify(
+    { reason, pausedAt: new Date().toISOString() },
+    null,
+    2,
+  ) + "\n";
+  return atomicWriteText(sidecarPath(stateDir, prId, "paused"), content);
+}
+
+/** Check whether a .stopped sidecar exists for the given PR. */
+export async function isStateStopped(stateDir, prId) {
+  return exists(sidecarPath(stateDir, prId, "stopped"));
+}
+
+/** Check whether a .paused sidecar exists for the given PR. */
+export async function isStatePaused(stateDir, prId) {
+  return exists(sidecarPath(stateDir, prId, "paused"));
+}
+
+/**
+ * Remove the state file for a completed PR. Best-effort; ignores ENOENT.
+ * @param {string} stateDir absolute path to the state directory
+ * @param {string} prId     canonical PR identifier
+ */
+export async function removePrState(stateDir, prId) {
+  try {
+    await unlink(stateFilePath(stateDir, prId));
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+}
+
+export { SCHEMA as PR_ITERATION_STATE_SCHEMA };

--- a/scripts/lib/pr-iteration/state.mjs
+++ b/scripts/lib/pr-iteration/state.mjs
@@ -106,7 +106,22 @@ export async function listPendingPrStates(stateDir) {
 
     const filePath = join(stateDir, name);
     const data = await readJsonOrNull(filePath);
-    if (!data || !data.prId) continue;
+    if (!data) continue;
+
+    if (!data.prId) {
+      throw new Error(
+        `PR state file ${filePath} is missing the required prId field`,
+      );
+    }
+
+    // Verify the prId inside the file matches the filename to detect
+    // renames or edits that would cause write-back to the wrong file.
+    const expectedName = stateFileName(data.prId);
+    if (expectedName !== name) {
+      throw new Error(
+        `PR state file ${filePath}: prId "${data.prId}" does not match filename "${name}" (expected "${expectedName}")`,
+      );
+    }
 
     const { ok, errors } = validate(SCHEMA, data);
     if (!ok) {
@@ -119,7 +134,7 @@ export async function listPendingPrStates(stateDir) {
 }
 
 /**
- * Write a .stopped sidecar so the next wakeup fire exits without rescheduling.
+ * Write a .stopped sidecar so when the next wakeup fires, it exits without rescheduling.
  * @param {string} stateDir absolute path to the state directory
  * @param {string} prId     canonical PR identifier
  * @param {string} reason   human-readable reason for stopping

--- a/scripts/lib/pr-iteration/tick.mjs
+++ b/scripts/lib/pr-iteration/tick.mjs
@@ -92,12 +92,16 @@ export async function runTick(tracker, state, opts) {
     return { done: true, action: "complete", state };
   }
 
-  // ── 5. Needs triage? (CI terminal AND new threads or review arrived) ──
+  // ── 5. Needs triage? ──
+  // CI failure/error always needs triage (rule: "CI goes red: fix, re-push").
+  // CI success with threads or review also needs triage.
+  const ciFailed =
+    pollResult.ciState === "FAILURE" || pollResult.ciState === "ERROR";
   const ciTerminal = pollResult.ciState !== "PENDING";
   const hasActivity =
     pollResult.unresolvedCount > 0 || pollResult.reviewOnHead;
 
-  if (ciTerminal && hasActivity) {
+  if (ciFailed || (ciTerminal && hasActivity)) {
     state.consecutiveWakes = 0;
     await writePrState(stateDir, state);
     return { done: false, action: "needs-triage", state };

--- a/scripts/lib/pr-iteration/tick.mjs
+++ b/scripts/lib/pr-iteration/tick.mjs
@@ -1,0 +1,115 @@
+// lib/pr-iteration/tick.mjs
+// One-shot tick for the wakeup-driven PR iteration loop.
+//
+// Each tick:
+//   1. Checks for a .stopped sidecar (user cancelled).
+//   2. Polls remote state once via tracker.review.pollForReview.
+//   3. Updates exit conditions.
+//   4. Returns an action the skill caller acts on.
+//
+// The tick never does fixes, commits, or pushes. That is the skill's job
+// based on the returned action. The tick is purely a "check and report"
+// function.
+
+import {
+  isStateStopped,
+  markPrStatePaused,
+  removePrState,
+  writePrState,
+} from "./state.mjs";
+
+const DEFAULT_MAX_CONSECUTIVE_WAKES = 96;
+
+/**
+ * Build the tracker context object from persisted state.
+ * @param {object} state validated PR iteration state
+ * @returns {object} ctx suitable for tracker.review.* methods
+ */
+function buildCtx(state) {
+  return {
+    owner: state.owner,
+    repo: state.repo,
+    prNumber: state.prNumber,
+    prNodeId: state.prNodeId,
+    botIds: state.botIds,
+    botLogins: state.botLogins,
+  };
+}
+
+/**
+ * Run one tick of the PR iteration loop.
+ *
+ * @param {object} tracker     tracker object with a .review namespace
+ * @param {object} state       validated PR iteration state (mutated in place)
+ * @param {object} opts
+ * @param {string} opts.stateDir           absolute path to the state directory
+ * @param {number} [opts.maxConsecutiveWakes=96]  safety cap before auto-pause
+ * @returns {Promise<{done: boolean, action: string, state: object}>}
+ *   action is one of:
+ *     "complete"        all three exit conditions hold; state file removed
+ *     "needs-triage"    CI terminal + threads/review arrived; skill should fix
+ *     "still-waiting"   CI pending or no review yet; reschedule
+ *     "user-cancelled"  .stopped sidecar found; no remote call made
+ *     "safety-cap"      consecutive-wakes cap reached; .paused written
+ */
+export async function runTick(tracker, state, opts) {
+  const { stateDir, maxConsecutiveWakes = DEFAULT_MAX_CONSECUTIVE_WAKES } = opts;
+
+  // ── 1. User-cancel gate ──
+  if (await isStateStopped(stateDir, state.prId)) {
+    return { done: true, action: "user-cancelled", state };
+  }
+
+  // ── 2. Single remote poll ──
+  const ctx = buildCtx(state);
+  const pollResult = await tracker.review.pollForReview(ctx);
+
+  // ── 3. Update state with poll results ──
+  state.lastPollResult = {
+    ciState: pollResult.ciState,
+    unresolvedCount: pollResult.unresolvedCount,
+    reviewOnHead: pollResult.reviewOnHead,
+    observedAt: new Date().toISOString(),
+  };
+  state.exitConditions.ciSuccessOnHead = pollResult.ciState === "SUCCESS";
+  state.exitConditions.zeroUnresolvedOnHead =
+    pollResult.unresolvedCount === 0 && pollResult.reviewOnHead;
+
+  // ── 4. All exit conditions green? ──
+  const allGreen =
+    state.exitConditions.localReviewGo &&
+    state.exitConditions.zeroUnresolvedOnHead &&
+    state.exitConditions.ciSuccessOnHead;
+
+  if (allGreen) {
+    await removePrState(stateDir, state.prId);
+    return { done: true, action: "complete", state };
+  }
+
+  // ── 5. Needs triage? (CI terminal AND new threads or review arrived) ──
+  const ciTerminal = pollResult.ciState !== "PENDING";
+  const hasActivity =
+    pollResult.unresolvedCount > 0 || pollResult.reviewOnHead;
+
+  if (ciTerminal && hasActivity) {
+    state.consecutiveWakes = 0;
+    await writePrState(stateDir, state);
+    return { done: false, action: "needs-triage", state };
+  }
+
+  // ── 6. Still waiting; bump consecutive-wakes counter ──
+  state.consecutiveWakes = (state.consecutiveWakes ?? 0) + 1;
+
+  if (state.consecutiveWakes >= maxConsecutiveWakes) {
+    await markPrStatePaused(
+      stateDir,
+      state.prId,
+      `Safety cap reached: ${maxConsecutiveWakes} consecutive wakes without forward progress`,
+    );
+    await writePrState(stateDir, state);
+    return { done: true, action: "safety-cap", state };
+  }
+
+  await writePrState(stateDir, state);
+  return { done: false, action: "still-waiting", state };
+}

--- a/scripts/lib/pr-iteration/tick.mjs
+++ b/scripts/lib/pr-iteration/tick.mjs
@@ -32,6 +32,7 @@ function buildCtx(state) {
     repo: state.repo,
     prNumber: state.prNumber,
     prNodeId: state.prNodeId,
+    headSha: state.headSha,
     botIds: state.botIds,
     botLogins: state.botLogins,
   };
@@ -51,6 +52,7 @@ function buildCtx(state) {
  *     "needs-triage"    CI terminal + threads/review arrived; skill should fix
  *     "still-waiting"   CI pending or no review yet; reschedule
  *     "user-cancelled"  .stopped sidecar found; no remote call made
+ *     "paused"          .paused sidecar found; no remote call made
  *     "safety-cap"      consecutive-wakes cap reached; .paused written
  */
 export async function runTick(tracker, state, opts) {

--- a/scripts/lib/pr-iteration/tick.mjs
+++ b/scripts/lib/pr-iteration/tick.mjs
@@ -12,6 +12,7 @@
 // function.
 
 import {
+  isStatePaused,
   isStateStopped,
   markPrStatePaused,
   removePrState,
@@ -55,9 +56,12 @@ function buildCtx(state) {
 export async function runTick(tracker, state, opts) {
   const { stateDir, maxConsecutiveWakes = DEFAULT_MAX_CONSECUTIVE_WAKES } = opts;
 
-  // ── 1. User-cancel gate ──
+  // ── 1. User-cancel / paused gates ──
   if (await isStateStopped(stateDir, state.prId)) {
     return { done: true, action: "user-cancelled", state };
+  }
+  if (await isStatePaused(stateDir, state.prId)) {
+    return { done: true, action: "paused", state };
   }
 
   // ── 2. Single remote poll ──

--- a/skills/pr-iteration/SKILL.md
+++ b/skills/pr-iteration/SKILL.md
@@ -85,7 +85,7 @@ When `workflow.external_review.autonomous.enabled` is `true` (the default), step
 2. **User cancels:** Agent writes a `.stopped` sidecar. The next wakeup reads it and exits without rescheduling.
 3. **Safety cap:** After `max_consecutive_wakes` (default 96, roughly 7.2 hours) without forward progress, the tick writes a `.paused` sidecar and stops. Human deletes the file to resume.
 
-**Legacy mode:** Set `autonomous.enabled` to `false` to restore the pre-PR-14 in-session poll at `poll_interval_seconds` (default 30s), capped by `poll_timeout_seconds` (default 1200s). The full poll loop runs in the active turn, blocking the user.
+**Legacy mode:** Set `workflow.external_review.autonomous.enabled` to `false` to restore the pre-PR-14 in-session poll at `poll_interval_seconds` (default 30s), capped by `poll_timeout_seconds` (default 1200s). The full poll loop runs in the active turn, blocking the user.
 
 ## Provider dispatch
 

--- a/skills/pr-iteration/SKILL.md
+++ b/skills/pr-iteration/SKILL.md
@@ -49,20 +49,43 @@ Hard rule baked in: **pr-iteration never merges a PR.** Merge is a human gate. E
 [tracker.review.requestReview on HEAD]
       |
       v
-[poll every poll_interval_seconds]
+[check once via tracker.review.pollForReview]
       |
-      +-- CI terminal AND (unresolved>0 OR reviewOnHead) --> [fetch threads, triage, fix + commit + push + resolve + re-request] --> back to poll
-      +-- poll_timeout_seconds exceeded --> [surface state, stop]
+      +-- CI terminal AND (unresolved>0 OR reviewOnHead)
+      |     --> [fetch threads, triage, fix + commit + push + resolve + re-request]
+      |     --> persist state, ScheduleWakeup --> (next tick re-enters here)
+      +-- CI PENDING, no threads, no review on HEAD
+      |     --> persist state, ScheduleWakeup --> (next tick re-enters here)
+      +-- .stopped sidecar present --> [exit: user cancelled]
+      +-- consecutive wakes >= max --> [write .paused, exit: safety cap]
       +-- NotSupportedError from tracker.review.* --> [clean halt at In review]
       |
       v
 [all three exit conditions hold on current HEAD]
       |
       v
-[write final report; stop]          *** HUMAN GATE 1: merge PR ***
+[write final report; delete state file; stop]   *** HUMAN GATE 1: merge PR ***
 ```
 
 The two human gates from `rules/pr-workflow.md` are preserved: merge and dev-issue Done.
+
+## Autonomous mode (default)
+
+When `workflow.external_review.autonomous.enabled` is `true` (the default), step 4 of the state machine uses `ScheduleWakeup` instead of an in-session poll. Each wakeup is one tick: poll once, evaluate exit conditions, act or reschedule. This survives session close, IDE restart, network hiccups, and context compaction.
+
+**State persistence:** One JSON file per active PR under `.development/local/pr-iteration/<owner>__<repo>__<number>.json`, validated against `schemas/pr-iteration-state.schema.json` on every read. The `.development/local/` subtree is gitignored by convention, so state never leaks into commits.
+
+**Interval:** Default 270 seconds (stays inside the 5-minute Anthropic prompt-cache window, avoiding cache-miss cost). Honours a free-form user override ("every 10 min") and the `autonomous.default_interval_seconds` config key.
+
+**Resume on session start:** On every agent invocation, `rules/agent-boot.md` scans the state directory and surfaces a "PR #N has a pending iteration loop" prompt per pending PR. The user answers resume / defer / stop. Never auto-resumes silently.
+
+**Cancel / pause:**
+
+1. **Normal completion:** All three exit conditions hold. The tick deletes the state file and writes the final report. No further wakeups.
+2. **User cancels:** Agent writes a `.stopped` sidecar. The next wakeup reads it and exits without rescheduling.
+3. **Safety cap:** After `max_consecutive_wakes` (default 96, roughly 7.2 hours) without forward progress, the tick writes a `.paused` sidecar and stops. Human deletes the file to resume.
+
+**Legacy mode:** Set `autonomous.enabled` to `false` to restore the pre-PR-14 in-session poll at `poll_interval_seconds` (default 30s), capped by `poll_timeout_seconds` (default 1200s). The full poll loop runs in the active turn, blocking the user.
 
 ## Provider dispatch
 
@@ -99,9 +122,12 @@ This skill writes into `.development/shared/reports/**` and MUST follow `rules/l
 - `workflow.external_review.enabled` (gate the whole loop).
 - `workflow.external_review.provider` (`auto` / `github` / `none`).
 - `workflow.external_review.bots` (per-kind reviewer LOGINS; for GitHub, the skill resolves login → GraphQL node ID at runtime and caches the derived IDs in the in-memory iteration state).
-- `workflow.external_review.poll_interval_seconds`.
-- `workflow.external_review.poll_timeout_seconds`.
+- `workflow.external_review.poll_interval_seconds` (legacy mode only).
+- `workflow.external_review.poll_timeout_seconds` (legacy mode only).
 - `workflow.external_review.auto_resolve_stale_after_commits`.
+- `workflow.external_review.autonomous.enabled` (gate: wakeup-driven vs. legacy poll).
+- `workflow.external_review.autonomous.default_interval_seconds` (wakeup interval).
+- `workflow.external_review.autonomous.max_consecutive_wakes` (safety cap).
 - `workflow.code_review.*` (the pre-push local review, re-checked every round).
 - `paths.reports` (report artefact target, routed through the llm-wiki per rules/llm-wiki.md).
 
@@ -127,6 +153,10 @@ Per-round artefact structure: see `templates/pr-iteration-report.md`. Minimum fi
 
 - `rules/pr-iteration.md`: binding contract.
 - `rules/pr-workflow.md`: full PR state machine in which this skill plugs after "In review".
+- `rules/agent-boot.md`: session-start resume prompt for pending iteration loops.
 - `skills/dev-loop/SKILL.md`: hands off to this skill after opening the PR.
 - `scripts/lib/trackers/*.mjs`: the Tracker implementations (GitHub real; Jira/Linear/GitLab stubbed).
+- `scripts/lib/pr-iteration/state.mjs`: persistent state read/write/list.
+- `scripts/lib/pr-iteration/tick.mjs`: one-shot tick (poll + exit-condition check).
+- `scripts/lib/pr-iteration/reschedule.mjs`: interval computation + wakeup prompt builder.
 - `skills/pr-iteration/runbook.md`: canonical how-to with full GraphQL recipes.

--- a/tests/pr_iteration_boot.test.mjs
+++ b/tests/pr_iteration_boot.test.mjs
@@ -1,0 +1,110 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  listPendingPrStates,
+  writePrState,
+  markPrStateStopped,
+  markPrStatePaused,
+} from "../scripts/lib/pr-iteration/state.mjs";
+
+const scratch = await mkdtemp(join(tmpdir(), "pr-iter-boot-"));
+after(async () => {
+  await rm(scratch, { recursive: true, force: true });
+});
+
+function makeState(overrides = {}) {
+  return {
+    prId: "acme/repo#42",
+    owner: "acme",
+    repo: "repo",
+    prNumber: 42,
+    memberName: null,
+    prNodeId: "PR_kwDOtest",
+    botIds: ["BOT_abc"],
+    botLogins: ["copilot-pull-request-reviewer"],
+    headSha: "abc1234",
+    lastRound: 0,
+    nextWakeAt: null,
+    intervalSeconds: 270,
+    consecutiveWakes: 0,
+    lastPollResult: {
+      ciState: "PENDING",
+      unresolvedCount: 0,
+      reviewOnHead: false,
+      observedAt: "2026-04-21T12:00:00.000Z",
+    },
+    exitConditions: {
+      localReviewGo: true,
+      zeroUnresolvedOnHead: false,
+      ciSuccessOnHead: false,
+    },
+    createdAt: "2026-04-21T12:00:00.000Z",
+    updatedAt: "2026-04-21T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("listPendingPrStates (boot context)", () => {
+  it("returns empty array cleanly when directory does not exist", async () => {
+    const result = await listPendingPrStates(join(scratch, "does-not-exist"));
+    assert.deepEqual(result, []);
+  });
+
+  it("returns empty array when directory exists but is empty", async () => {
+    const dir = join(scratch, "empty-dir");
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(dir, { recursive: true });
+    const result = await listPendingPrStates(dir);
+    assert.deepEqual(result, []);
+  });
+
+  it("enumerates multiple pending PRs", async () => {
+    const dir = join(scratch, "multi");
+    await writePrState(dir, makeState({ prId: "org/a#1", owner: "org", repo: "a", prNumber: 1 }));
+    await writePrState(dir, makeState({ prId: "org/b#2", owner: "org", repo: "b", prNumber: 2 }));
+    await writePrState(dir, makeState({ prId: "org/c#3", owner: "org", repo: "c", prNumber: 3 }));
+
+    const result = await listPendingPrStates(dir);
+    assert.equal(result.length, 3);
+    assert.deepEqual(
+      result.map((r) => r.prId),
+      ["org/a#1", "org/b#2", "org/c#3"],
+    );
+  });
+
+  it("skips PRs with .stopped sidecar", async () => {
+    const dir = join(scratch, "skip-stopped");
+    await writePrState(dir, makeState({ prId: "org/x#10", owner: "org", repo: "x", prNumber: 10 }));
+    await writePrState(dir, makeState({ prId: "org/x#11", owner: "org", repo: "x", prNumber: 11 }));
+    await markPrStateStopped(dir, "org/x#10", "user cancelled");
+
+    const result = await listPendingPrStates(dir);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].prId, "org/x#11");
+  });
+
+  it("skips PRs with .paused sidecar", async () => {
+    const dir = join(scratch, "skip-paused");
+    await writePrState(dir, makeState({ prId: "org/y#20", owner: "org", repo: "y", prNumber: 20 }));
+    await writePrState(dir, makeState({ prId: "org/y#21", owner: "org", repo: "y", prNumber: 21 }));
+    await markPrStatePaused(dir, "org/y#20", "safety cap");
+
+    const result = await listPendingPrStates(dir);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].prId, "org/y#21");
+  });
+
+  it("each returned entry includes the full state object", async () => {
+    const dir = join(scratch, "full-state");
+    await writePrState(dir, makeState({ prId: "org/z#5", owner: "org", repo: "z", prNumber: 5, lastRound: 3 }));
+
+    const result = await listPendingPrStates(dir);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].state.lastRound, 3);
+    assert.equal(result[0].state.prNodeId, "PR_kwDOtest");
+  });
+});

--- a/tests/pr_iteration_reschedule.test.mjs
+++ b/tests/pr_iteration_reschedule.test.mjs
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  computeInterval,
+  buildWakeupPrompt,
+  buildWakeupReason,
+} from "../scripts/lib/pr-iteration/reschedule.mjs";
+
+describe("computeInterval", () => {
+  it("returns 270 when no overrides are given", () => {
+    assert.equal(computeInterval(undefined, undefined, undefined), 270);
+  });
+
+  it("honours explicit user override", () => {
+    assert.equal(computeInterval(600, { intervalSeconds: 270 }, 270), 600);
+  });
+
+  it("falls back to state.intervalSeconds when no user override", () => {
+    assert.equal(computeInterval(null, { intervalSeconds: 180 }, 270), 180);
+  });
+
+  it("falls back to configDefault when no user override and no state", () => {
+    assert.equal(computeInterval(null, null, 300), 300);
+  });
+
+  it("clamps below minimum (60s)", () => {
+    assert.equal(computeInterval(10, null, null), 60);
+  });
+
+  it("clamps above maximum (3600s)", () => {
+    assert.equal(computeInterval(5000, null, null), 3600);
+  });
+
+  it("clamps configDefault too", () => {
+    assert.equal(computeInterval(null, null, 10), 60);
+  });
+});
+
+describe("buildWakeupPrompt", () => {
+  it("returns /resume-pr-iteration with the prId", () => {
+    const prompt = buildWakeupPrompt({ prId: "acme/repo#42" });
+    assert.equal(prompt, "/resume-pr-iteration acme/repo#42");
+  });
+});
+
+describe("buildWakeupReason", () => {
+  it("includes CI state and unresolved count", () => {
+    const reason = buildWakeupReason({
+      prId: "acme/repo#42",
+      lastPollResult: { ciState: "PENDING", unresolvedCount: 3 },
+    });
+    assert.match(reason, /acme\/repo#42/);
+    assert.match(reason, /PENDING/);
+    assert.match(reason, /3/);
+  });
+
+  it("handles missing lastPollResult gracefully", () => {
+    const reason = buildWakeupReason({ prId: "x/y#1" });
+    assert.match(reason, /x\/y#1/);
+    assert.match(reason, /unknown/);
+  });
+});

--- a/tests/pr_iteration_state.test.mjs
+++ b/tests/pr_iteration_state.test.mjs
@@ -1,0 +1,187 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  readPrState,
+  writePrState,
+  listPendingPrStates,
+  markPrStateStopped,
+  markPrStatePaused,
+  isStateStopped,
+  isStatePaused,
+  removePrState,
+  stateFileName,
+} from "../scripts/lib/pr-iteration/state.mjs";
+
+const scratch = await mkdtemp(join(tmpdir(), "pr-iter-state-"));
+after(async () => {
+  await rm(scratch, { recursive: true, force: true });
+});
+
+function makeState(overrides = {}) {
+  return {
+    prId: "acme/repo#42",
+    owner: "acme",
+    repo: "repo",
+    prNumber: 42,
+    memberName: null,
+    prNodeId: "PR_kwDOtest",
+    botIds: ["BOT_abc"],
+    botLogins: ["copilot-pull-request-reviewer"],
+    headSha: "abc1234",
+    lastRound: 0,
+    nextWakeAt: null,
+    intervalSeconds: 270,
+    consecutiveWakes: 0,
+    lastPollResult: {
+      ciState: "PENDING",
+      unresolvedCount: 0,
+      reviewOnHead: false,
+      observedAt: "2026-04-21T12:00:00.000Z",
+    },
+    exitConditions: {
+      localReviewGo: true,
+      zeroUnresolvedOnHead: false,
+      ciSuccessOnHead: false,
+    },
+    createdAt: "2026-04-21T12:00:00.000Z",
+    updatedAt: "2026-04-21T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("stateFileName", () => {
+  it("derives filename from prId", () => {
+    assert.equal(stateFileName("acme/repo#42"), "acme__repo__42.json");
+  });
+
+  it("handles dotted owner and repo names", () => {
+    assert.equal(stateFileName("my.org/my.repo#7"), "my.org__my.repo__7.json");
+  });
+
+  it("throws on invalid prId", () => {
+    assert.throws(() => stateFileName("bad-format"), /Invalid prId format/);
+    assert.throws(() => stateFileName(""), /Invalid prId format/);
+  });
+});
+
+describe("readPrState + writePrState round-trip", () => {
+  it("writes then reads back an identical state object", async () => {
+    const dir = join(scratch, "roundtrip");
+    const state = makeState();
+    await writePrState(dir, state);
+    const read = await readPrState(dir, "acme/repo#42");
+    assert.equal(read.prId, "acme/repo#42");
+    assert.equal(read.prNumber, 42);
+    assert.equal(read.intervalSeconds, 270);
+    // updatedAt is refreshed on write
+    assert.ok(read.updatedAt);
+  });
+
+  it("returns null for a missing state file", async () => {
+    const dir = join(scratch, "missing");
+    assert.equal(await readPrState(dir, "no/such#1"), null);
+  });
+
+  it("throws on schema validation failure", async () => {
+    const dir = join(scratch, "bad-schema");
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "bad__data__1.json"),
+      JSON.stringify({ prId: "bad/data#1", broken: true }),
+    );
+    await assert.rejects(
+      () => readPrState(dir, "bad/data#1"),
+      /failed schema validation/,
+    );
+  });
+
+  it("atomic write leaves no tmp file behind", async () => {
+    const dir = join(scratch, "atomic-clean");
+    await writePrState(dir, makeState());
+    const entries = await readdir(dir);
+    assert.ok(entries.every((e) => !e.includes(".tmp-")));
+  });
+});
+
+describe("listPendingPrStates", () => {
+  it("returns empty array when directory does not exist", async () => {
+    const result = await listPendingPrStates(join(scratch, "nonexistent"));
+    assert.deepEqual(result, []);
+  });
+
+  it("lists states in deterministic (sorted) order", async () => {
+    const dir = join(scratch, "list-sorted");
+    await writePrState(dir, makeState({ prId: "z/repo#2", owner: "z", repo: "repo", prNumber: 2 }));
+    await writePrState(dir, makeState({ prId: "a/repo#1", owner: "a", repo: "repo", prNumber: 1 }));
+    const result = await listPendingPrStates(dir);
+    assert.equal(result.length, 2);
+    assert.equal(result[0].prId, "a/repo#1");
+    assert.equal(result[1].prId, "z/repo#2");
+  });
+
+  it("excludes stopped states", async () => {
+    const dir = join(scratch, "list-stopped");
+    await writePrState(dir, makeState({ prId: "org/r#10", owner: "org", repo: "r", prNumber: 10 }));
+    await markPrStateStopped(dir, "org/r#10", "test");
+    const result = await listPendingPrStates(dir);
+    assert.equal(result.length, 0);
+  });
+
+  it("excludes paused states", async () => {
+    const dir = join(scratch, "list-paused");
+    await writePrState(dir, makeState({ prId: "org/r#11", owner: "org", repo: "r", prNumber: 11 }));
+    await markPrStatePaused(dir, "org/r#11", "cap");
+    const result = await listPendingPrStates(dir);
+    assert.equal(result.length, 0);
+  });
+});
+
+describe("markPrStateStopped + isStateStopped", () => {
+  it("writes a .stopped sidecar with reason", async () => {
+    const dir = join(scratch, "stopped-sidecar");
+    await writePrState(dir, makeState());
+    await markPrStateStopped(dir, "acme/repo#42", "user cancelled");
+    assert.ok(await isStateStopped(dir, "acme/repo#42"));
+    const content = JSON.parse(
+      await readFile(join(dir, "acme__repo__42.stopped"), "utf8"),
+    );
+    assert.equal(content.reason, "user cancelled");
+    assert.ok(content.stoppedAt);
+  });
+
+  it("isStateStopped returns false when no sidecar", async () => {
+    const dir = join(scratch, "no-stopped");
+    assert.equal(await isStateStopped(dir, "x/y#1"), false);
+  });
+});
+
+describe("markPrStatePaused + isStatePaused", () => {
+  it("writes a .paused sidecar with reason", async () => {
+    const dir = join(scratch, "paused-sidecar");
+    await writePrState(dir, makeState());
+    await markPrStatePaused(dir, "acme/repo#42", "safety cap");
+    assert.ok(await isStatePaused(dir, "acme/repo#42"));
+    const content = JSON.parse(
+      await readFile(join(dir, "acme__repo__42.paused"), "utf8"),
+    );
+    assert.equal(content.reason, "safety cap");
+  });
+});
+
+describe("removePrState", () => {
+  it("deletes the state file", async () => {
+    const dir = join(scratch, "remove");
+    await writePrState(dir, makeState());
+    await removePrState(dir, "acme/repo#42");
+    assert.equal(await readPrState(dir, "acme/repo#42"), null);
+  });
+
+  it("is a no-op when the file is already gone", async () => {
+    const dir = join(scratch, "remove-missing");
+    await assert.doesNotReject(() => removePrState(dir, "no/such#99"));
+  });
+});

--- a/tests/pr_iteration_tick.test.mjs
+++ b/tests/pr_iteration_tick.test.mjs
@@ -1,0 +1,187 @@
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runTick } from "../scripts/lib/pr-iteration/tick.mjs";
+import {
+  writePrState,
+  readPrState,
+  markPrStateStopped,
+  isStatePaused,
+} from "../scripts/lib/pr-iteration/state.mjs";
+import { exists } from "../scripts/lib/fsx.mjs";
+
+const scratch = await mkdtemp(join(tmpdir(), "pr-iter-tick-"));
+after(async () => {
+  await rm(scratch, { recursive: true, force: true });
+});
+
+function makeState(overrides = {}) {
+  return {
+    prId: "acme/repo#42",
+    owner: "acme",
+    repo: "repo",
+    prNumber: 42,
+    memberName: null,
+    prNodeId: "PR_kwDOtest",
+    botIds: ["BOT_abc"],
+    botLogins: ["copilot-pull-request-reviewer"],
+    headSha: "abc1234",
+    lastRound: 0,
+    nextWakeAt: null,
+    intervalSeconds: 270,
+    consecutiveWakes: 0,
+    lastPollResult: {
+      ciState: "PENDING",
+      unresolvedCount: 0,
+      reviewOnHead: false,
+      observedAt: "2026-04-21T12:00:00.000Z",
+    },
+    exitConditions: {
+      localReviewGo: true,
+      zeroUnresolvedOnHead: false,
+      ciSuccessOnHead: false,
+    },
+    createdAt: "2026-04-21T12:00:00.000Z",
+    updatedAt: "2026-04-21T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function fakeTracker(pollResult) {
+  return {
+    review: {
+      pollForReview: async () => pollResult,
+    },
+  };
+}
+
+describe("runTick: user-cancelled", () => {
+  it("returns done + user-cancelled when .stopped sidecar exists", async () => {
+    const dir = join(scratch, "cancelled");
+    const state = makeState();
+    await writePrState(dir, state);
+    await markPrStateStopped(dir, state.prId, "test");
+
+    const tracker = fakeTracker({ ciState: "SUCCESS", unresolvedCount: 0, reviewOnHead: true });
+    const result = await runTick(tracker, state, { stateDir: dir });
+
+    assert.equal(result.done, true);
+    assert.equal(result.action, "user-cancelled");
+  });
+});
+
+describe("runTick: complete", () => {
+  it("returns done + complete when all exit conditions hold", async () => {
+    const dir = join(scratch, "complete");
+    const state = makeState({ exitConditions: { localReviewGo: true, zeroUnresolvedOnHead: false, ciSuccessOnHead: false } });
+    await writePrState(dir, state);
+
+    const tracker = fakeTracker({ ciState: "SUCCESS", unresolvedCount: 0, reviewOnHead: true });
+    const result = await runTick(tracker, state, { stateDir: dir });
+
+    assert.equal(result.done, true);
+    assert.equal(result.action, "complete");
+    assert.equal(result.state.exitConditions.ciSuccessOnHead, true);
+    assert.equal(result.state.exitConditions.zeroUnresolvedOnHead, true);
+    // State file should be removed
+    assert.equal(await readPrState(dir, state.prId), null);
+  });
+});
+
+describe("runTick: still-waiting", () => {
+  it("returns not-done + still-waiting when CI is PENDING and no activity", async () => {
+    const dir = join(scratch, "waiting");
+    const state = makeState();
+    await writePrState(dir, state);
+
+    const tracker = fakeTracker({ ciState: "PENDING", unresolvedCount: 0, reviewOnHead: false });
+    const result = await runTick(tracker, state, { stateDir: dir });
+
+    assert.equal(result.done, false);
+    assert.equal(result.action, "still-waiting");
+    assert.equal(result.state.consecutiveWakes, 1);
+    // State should be persisted
+    const persisted = await readPrState(dir, state.prId);
+    assert.equal(persisted.consecutiveWakes, 1);
+  });
+});
+
+describe("runTick: needs-triage", () => {
+  it("returns not-done + needs-triage when CI terminal + threads exist", async () => {
+    const dir = join(scratch, "triage-threads");
+    const state = makeState({ consecutiveWakes: 5 });
+    await writePrState(dir, state);
+
+    const tracker = fakeTracker({ ciState: "SUCCESS", unresolvedCount: 3, reviewOnHead: true });
+    const result = await runTick(tracker, state, { stateDir: dir });
+
+    assert.equal(result.done, false);
+    assert.equal(result.action, "needs-triage");
+    assert.equal(result.state.consecutiveWakes, 0, "resets on forward progress");
+    assert.equal(result.state.lastPollResult.unresolvedCount, 3);
+  });
+
+  it("returns needs-triage when CI SUCCESS + review on HEAD (zero threads)", async () => {
+    const dir = join(scratch, "triage-review");
+    const state = makeState();
+    await writePrState(dir, state);
+
+    // Review on HEAD with 0 threads is still "needs-triage" because the
+    // skill must verify all conditions before declaring complete
+    // (localReviewGo may be false after a code change)
+    const tracker = fakeTracker({ ciState: "SUCCESS", unresolvedCount: 0, reviewOnHead: true });
+    // localReviewGo is false so it won't be "complete"
+    state.exitConditions.localReviewGo = false;
+    const result = await runTick(tracker, state, { stateDir: dir });
+
+    // CI terminal + reviewOnHead = needs-triage (even if 0 threads)
+    assert.equal(result.done, false);
+    assert.equal(result.action, "needs-triage");
+  });
+
+  it("returns needs-triage when CI FAILURE (regardless of threads)", async () => {
+    const dir = join(scratch, "triage-ci-fail");
+    const state = makeState();
+    await writePrState(dir, state);
+
+    const tracker = fakeTracker({ ciState: "FAILURE", unresolvedCount: 0, reviewOnHead: true });
+    const result = await runTick(tracker, state, { stateDir: dir });
+
+    assert.equal(result.done, false);
+    assert.equal(result.action, "needs-triage");
+  });
+});
+
+describe("runTick: safety-cap", () => {
+  it("returns done + safety-cap when max consecutive wakes reached", async () => {
+    const dir = join(scratch, "safety-cap");
+    const state = makeState({ consecutiveWakes: 2 });
+    await writePrState(dir, state);
+
+    const tracker = fakeTracker({ ciState: "PENDING", unresolvedCount: 0, reviewOnHead: false });
+    const result = await runTick(tracker, state, { stateDir: dir, maxConsecutiveWakes: 3 });
+
+    assert.equal(result.done, true);
+    assert.equal(result.action, "safety-cap");
+    assert.equal(result.state.consecutiveWakes, 3);
+    assert.ok(await isStatePaused(dir, state.prId));
+  });
+});
+
+describe("runTick: lastPollResult is always updated", () => {
+  it("persists the poll result in state even when still-waiting", async () => {
+    const dir = join(scratch, "poll-persist");
+    const state = makeState();
+    await writePrState(dir, state);
+
+    const tracker = fakeTracker({ ciState: "PENDING", unresolvedCount: 0, reviewOnHead: false });
+    await runTick(tracker, state, { stateDir: dir });
+
+    const persisted = await readPrState(dir, state.prId);
+    assert.equal(persisted.lastPollResult.ciState, "PENDING");
+    assert.ok(persisted.lastPollResult.observedAt);
+  });
+});

--- a/tests/pr_iteration_tick.test.mjs
+++ b/tests/pr_iteration_tick.test.mjs
@@ -9,9 +9,9 @@ import {
   writePrState,
   readPrState,
   markPrStateStopped,
+  markPrStatePaused,
   isStatePaused,
 } from "../scripts/lib/pr-iteration/state.mjs";
-import { exists } from "../scripts/lib/fsx.mjs";
 
 const scratch = await mkdtemp(join(tmpdir(), "pr-iter-tick-"));
 after(async () => {
@@ -70,6 +70,27 @@ describe("runTick: user-cancelled", () => {
 
     assert.equal(result.done, true);
     assert.equal(result.action, "user-cancelled");
+  });
+});
+
+describe("runTick: paused", () => {
+  it("returns done + paused when .paused sidecar exists (no remote call)", async () => {
+    const dir = join(scratch, "paused-gate");
+    const state = makeState();
+    await writePrState(dir, state);
+    await markPrStatePaused(dir, state.prId, "safety cap");
+
+    let pollCalled = false;
+    const tracker = {
+      review: {
+        pollForReview: async () => { pollCalled = true; return {}; },
+      },
+    };
+    const result = await runTick(tracker, state, { stateDir: dir });
+
+    assert.equal(result.done, true);
+    assert.equal(result.action, "paused");
+    assert.equal(pollCalled, false, "should not call pollForReview when paused");
   });
 });
 

--- a/tests/pr_iteration_tick.test.mjs
+++ b/tests/pr_iteration_tick.test.mjs
@@ -174,6 +174,30 @@ describe("runTick: needs-triage", () => {
     assert.equal(result.done, false);
     assert.equal(result.action, "needs-triage");
   });
+
+  it("returns needs-triage when CI FAILURE with no threads and no review", async () => {
+    const dir = join(scratch, "triage-ci-fail-no-activity");
+    const state = makeState();
+    await writePrState(dir, state);
+
+    const tracker = fakeTracker({ ciState: "FAILURE", unresolvedCount: 0, reviewOnHead: false });
+    const result = await runTick(tracker, state, { stateDir: dir });
+
+    assert.equal(result.done, false);
+    assert.equal(result.action, "needs-triage");
+  });
+
+  it("returns needs-triage when CI ERROR with no activity", async () => {
+    const dir = join(scratch, "triage-ci-error");
+    const state = makeState();
+    await writePrState(dir, state);
+
+    const tracker = fakeTracker({ ciState: "ERROR", unresolvedCount: 0, reviewOnHead: false });
+    const result = await runTick(tracker, state, { stateDir: dir });
+
+    assert.equal(result.done, false);
+    assert.equal(result.action, "needs-triage");
+  });
 });
 
 describe("runTick: safety-cap", () => {


### PR DESCRIPTION
## Summary

- Replaces the in-session poll loop (step 4 of the PR iteration state machine) with a `ScheduleWakeup`-driven tick that survives session close, IDE restart, context compaction, and network hiccups
- Each active PR gets one JSON state file under `.development/local/pr-iteration/`, validated on read against `schemas/pr-iteration-state.schema.json`; all writes are atomic (write-to-temp then rename)
- Three user-visible exits: normal completion (all exit conditions hold), user cancel (`.stopped` sidecar), safety cap (`.paused` sidecar after 96 consecutive wakes without forward progress, roughly 7.2 hours)
- New `rules/agent-boot.md` scans for pending loops on session start and surfaces a resume/defer/stop prompt per pending PR (never auto-resumes)
- Legacy in-session poll preserved behind `workflow.external_review.autonomous.enabled: false` for projects that prefer it

## New files

| File | Purpose |
|------|---------|
| `schemas/pr-iteration-state.schema.json` | Frozen schema for the per-PR state file |
| `scripts/lib/pr-iteration/state.mjs` | Read, write, list, stop, pause state files |
| `scripts/lib/pr-iteration/tick.mjs` | One-shot poll + exit-condition evaluator |
| `scripts/lib/pr-iteration/reschedule.mjs` | Interval computation + wakeup prompt builder |
| `rules/agent-boot.md` | Session-start resume prompt for pending loops |
| `tests/pr_iteration_{state,tick,reschedule,boot}.test.mjs` | 40 tests |

## Changed files

| File | Change |
|------|--------|
| `rules/pr-iteration.md` | Step 4 rewritten for wakeup tick; stop conditions updated |
| `skills/pr-iteration/SKILL.md` | Autonomous mode section; updated state machine diagram |
| `schemas/ops.config.schema.json` | `autonomous` block under `external_review` |
| `examples/ops.config.example.json` | Autonomous example values |
| `bundle-index.md` | `agent-boot.md` registered; rule count 12 to 13 |

## Test plan

- [x] `npm run validate` passes
- [x] `npm run lint` passes (0 errors across 52 files)
- [x] `npm test` passes (683 tests, 0 failures)
- [x] Pre-commit hooks (preflight + validate + lint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)