### PR TITLE
feat(issue-discovery): graceful Q3d skip when labels.area is empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "test": "node --test tests/*.test.mjs",
     "validate": "node scripts/validate_bundle.mjs",
     "preflight": "node scripts/preflight.mjs",
-    "lint": "markdownlint-cli2 '**/*.md' '#node_modules' '#tests'",
-    "lint:fix": "markdownlint-cli2 --fix '**/*.md' '#node_modules' '#tests'",
+    "lint": "markdownlint-cli2 '**/*.md' '#node_modules' '#tests' '#.claude' '#.memory' '#.idea' '#daily'",
+    "lint:fix": "markdownlint-cli2 --fix '**/*.md' '#node_modules' '#tests' '#.claude' '#.memory' '#.idea' '#daily'",
     "prepare": "husky"
   },
   "dependencies": {

--- a/rules/issue-discovery.md
+++ b/rules/issue-discovery.md
@@ -40,6 +40,10 @@ Two kinds of node sit outside this clause and follow their own contract:
 - Shortlists (issues, umbrellas) are ranked by a deterministic criterion (priority + age for issues; status + target date for umbrellas) and capped at 4 domain options. A "show more" meta-option is always offered on top when more candidates exist on the tracker.
 - "Custom" is always the last option and always triggers a halt per [rules/ambiguity-halt.md](ambiguity-halt.md) when the custom value falls outside the configured surface (e.g. an area that does not exist in `labels.area`, an intent not in `labels.intent`). Halt surfaces the next step as an `adapt-system` invocation.
 
+### Clause 2a: graceful skip when labels.area is empty
+
+When `labels.area = []` in ops.config.json (typical for fresh solo repos or projects that have not seeded a label taxonomy), Q3d MUST NOT halt. Instead it offers a 2-option prompt: add an area label inline (creating it via tracker-sync), or skip area for this issue (setting area to null and proceeding to Q3e). The skill treats the absence of area labels as a valid project state, not an error.
+
 ### Clause 3: delegate every tracker write to tracker-sync
 
 The skill reads from and collects structured data about the tracker, but **never calls the tracker API directly**. Every create, update, link, and read routes through [skills/tracker-sync/SKILL.md](../skills/tracker-sync/SKILL.md). This mirrors [rules/tracker-source-of-truth.md](tracker-source-of-truth.md) but is called out explicitly here because the intake is the first place a newly-arriving user's intent hits bundle code: a single direct `gh`/`jira`/`linear` call here would break the invariant for every downstream skill.

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -169,9 +169,9 @@
         },
         "area": {
           "type": "array",
-          "description": "Scope area/*. Project-specific. Example defaults: frontend, backend, data, security, performance, compliance, ux, devx, testing, docs.",
+          "description": "Scope area/*. Project-specific. Example defaults: frontend, backend, data, security, performance, compliance, ux, devx, testing, docs. When empty, issue-discovery Q3d gracefully skips or offers to add a label inline.",
           "items": { "type": "string", "minLength": 1 },
-          "minItems": 1
+          "minItems": 0
         },
         "priority": {
           "type": "array",

--- a/scripts/lib/issueDiscovery.mjs
+++ b/scripts/lib/issueDiscovery.mjs
@@ -155,12 +155,16 @@ export const DECISION_TREE = Object.freeze({
   q3d: Object.freeze({
     id: "q3d",
     predecessors: Object.freeze(["q3c"]),
-    next: Object.freeze([{ target: "q3e-priority", when: "areaSelected" }]),
+    next: Object.freeze([
+      { target: "q3e-priority", when: "areaSelected" },
+      { target: "q3e-priority", when: "areaSkipped" },
+    ]),
     minOptions: 2,
     maxOptions: 4,
     canHalt: true,
     customEscape: true,
-    description: "Area label. Top-3 scored from intent + custom (halts on unknown area).",
+    description:
+      "Area label. When labels.area is non-empty: top-3 scored from intent + custom (halts on unknown area). When labels.area is empty: 2-option prompt offering to add a label inline or skip. Skip sets area to null and proceeds without an area label.",
   }),
   "q3e-priority": Object.freeze({
     id: "q3e-priority",

--- a/skills/issue-discovery/SKILL.md
+++ b/skills/issue-discovery/SKILL.md
@@ -82,9 +82,13 @@ Hard rule baked in: **the skill never calls a tracker API directly.** Every crea
       |
       v
 [Q3d. AREA LABEL]
-  agent scores user intent against area_keywords; presents top 3 plus custom
-  1..3: propose area
-  4. Something else (halt per ambiguity-halt with `/adapt-system` hint)
+  when labels.area is non-empty:
+    agent scores user intent against area_keywords; presents top 3 plus custom
+    1..3: propose area
+    4. Something else (halt per ambiguity-halt with `/adapt-system` hint)
+  when labels.area is empty:
+    1. Add an area label now (user provides name; skill creates via tracker-sync)
+    2. Skip area for this issue (sets area to null; proceeds to Q3e)
       |
       v
 [Q3e. PRIORITY + SIZE]
@@ -191,7 +195,7 @@ The session scratch file is ephemeral local state, not a durable artefact. Unlik
 - `trackers.dev[]` (at least one entry with depth != `read-only`).
 - `trackers.release` (optional; absent means the Q4 umbrella branch is skipped entirely per the PR 7 rule).
 - `workspace.members[]` (optional; present for multi-repo workspaces).
-- `labels.type`, `labels.area`, `labels.priority`, `labels.intent`, `labels.size` (every label set the interview offers as an option comes from here).
+- `labels.type`, `labels.area` (may be empty; Q3d gracefully skips or offers inline add), `labels.priority`, `labels.intent`, `labels.size` (every label set the interview offers as an option comes from here).
 - `workflow.issue_discovery.title_templates` (optional; when present, Q3b uses these as the proposal seeds instead of area-keyword matching).
 - `workflow.issue_discovery.stakeholders` (optional; surfaced as options at Q5.8).
 - `workflow.issue_discovery.domain_glossary` (optional; surfaces a one-line definition when an answer matches a glossary term).

--- a/skills/issue-discovery/runbook.md
+++ b/skills/issue-discovery/runbook.md
@@ -128,6 +128,8 @@ Option 4 hands off to `regression-handler` with `{title, intentText, memberName}
 
 ### Q3d. Area label
 
+**When `labels.area` is non-empty** (the typical case for projects with a seeded taxonomy):
+
 Score `session.intentText` against the keywords attached to each entry in `labels.area` (per the bundle-standard `area_keywords` shape). Surface the top 3 plus a custom option.
 
 ```text
@@ -144,6 +146,21 @@ When the user picks option 4 and types a free-form area, if that area is not in 
 ```text
 I see you want area "{{user_answer}}", which isn't in `labels.area`: {{configured_list}}. Adding a new area is an adapt-system change, not something I'll do silently. Pick an existing area, halt for `/adapt-system "add area <short desc>"` first, or re-route this issue to the closest existing area. How do you want me to proceed?
 ```
+
+**When `labels.area` is empty** (fresh solo repos, projects without a label taxonomy):
+
+The skill does not halt. Instead it offers a 2-option prompt:
+
+```text
+No area labels are configured for this project.
+
+1. Add an area label now (I will create it via tracker-sync).
+2. Skip area for this issue.
+```
+
+Option 1: the user provides a label name. The skill creates it via `tracker-sync.labels.create` and assigns it to the draft issue. The new label is not automatically added to `labels.area` in ops.config.json (that is an adapt-system change).
+
+Option 2: the skill sets area to null on the draft issue and proceeds to Q3e. The generated issue will have no `area:*` label.
 
 ### Q3e. Priority + size
 

--- a/skills/issue-discovery/runbook.md
+++ b/skills/issue-discovery/runbook.md
@@ -158,7 +158,7 @@ No area labels are configured for this project.
 2. Skip area for this issue.
 ```
 
-Option 1: the user provides a label name. The skill creates it via `tracker-sync.labels.create` and assigns it to the draft issue. The new label is not automatically added to `labels.area` in ops.config.json (that is an adapt-system change).
+Option 1: the user provides a label name. The skill creates and assigns it by calling `tracker-sync.labels.reconcileLabels` with `apply: true` and a one-entry taxonomy for the new `area:*` label. On backends that support label CRUD, this materializes the label; on Jira, label "creation" is effectively a no-op until the label is applied to an issue. The new label is not automatically added to `labels.area` in ops.config.json (that is an adapt-system change).
 
 Option 2: the skill sets area to null on the draft issue and proceeds to Q3e. The generated issue will have no `area:*` label.
 

--- a/tests/issue_discovery_decision_tree.test.mjs
+++ b/tests/issue_discovery_decision_tree.test.mjs
@@ -81,6 +81,19 @@ describe("DECISION_TREE: shape + invariants", () => {
     assert.deepEqual(proceedTargets, ["q6"]);
   });
 
+  it("q3d has an areaSkipped branch to q3e-priority for empty labels.area", () => {
+    const q3d = DECISION_TREE.q3d;
+    const skipBranch = q3d.next.find((b) => b.when === "areaSkipped");
+    assert.ok(skipBranch, "q3d must have an areaSkipped branch");
+    assert.equal(skipBranch.target, "q3e-priority");
+  });
+
+  it("q3e-priority predecessor is q3d (skip path still routes through q3d)", () => {
+    const q3e = DECISION_TREE["q3e-priority"];
+    assert.ok(q3e.predecessors.includes("q3d"), "q3e-priority must list q3d as a predecessor");
+    assert.equal(q3e.predecessors.length, 1, "q3e-priority has exactly one predecessor (q3d handles both normal and skip paths)");
+  });
+
   it("nodes with customEscape=true list `canHalt: true` (custom option must be able to halt per ambiguity rules)", () => {
     for (const node of nodes) {
       if (!node.customEscape) continue;
@@ -108,6 +121,11 @@ describe("scoreArea", () => {
     });
     assert.deepEqual(result.matchedKeywords.sort(), ["checkout", "payment"]);
     assert.equal(result.score, 2 / 4);
+  });
+
+  it("returns zero for an area with no name or missing object (graceful on empty labels.area)", () => {
+    assert.deepEqual(scoreArea("anything", undefined), { score: 0, matchedKeywords: [] });
+    assert.deepEqual(scoreArea("anything", {}), { score: 0, matchedKeywords: [] });
   });
 
   it("handles non-string inputs without throwing", () => {


### PR DESCRIPTION
## Summary

- When `labels.area = []` (typical for fresh solo repos), issue-discovery Q3d now offers a 2-option prompt (add a label inline or skip) instead of halting with no valid options
- Schema `labels.area.minItems` relaxed from `1` to `0`
- Decision tree gains `areaSkipped` branch; rule, SKILL.md, runbook updated
- 3 new tests; 849 existing tests pass with no regressions
- Lint ignores updated for local-only directories (.claude, .memory, .idea, daily)

Closes #24

## Test plan

- [x] `node --test tests/issue_discovery_decision_tree.test.mjs` — 18/18 pass (3 new)
- [x] `node --test tests/issue_discovery_state.test.mjs` — 14/14 pass
- [x] Full suite `node --test tests/*.test.mjs` — 849/849 pass, 0 failures
- [x] `npm run lint` — 0 errors
- [x] `npm run validate` — PASS
- [x] Code review via ctxr-skill-code-review — GO verdict, 0 critical, 0 important

🤖 Generated with [Claude Code](https://claude.com/claude-code)