### PR TITLE
feat(cache): annotate SKILL.md static blocks with cache_control for burst-window economics

### DIFF
--- a/bundle-index.md
+++ b/bundle-index.md
@@ -118,6 +118,10 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 - [memory-seeds/commit-style-conventional.md](memory-seeds/commit-style-conventional.md): conventional-commits convention.
 - [memory-seeds/dash-free-writing.md](memory-seeds/dash-free-writing.md): the no-em/en-dash rule as a memory.
 
+### Cache economy (prompt caching)
+
+- [rules/cache-economy.md](rules/cache-economy.md): the static/dynamic partitioning rule for SKILL.md files.
+
 ### Testing discipline
 
 - [memory-seeds/testing-discipline.md](memory-seeds/testing-discipline.md): test categorisation, no mocks at the integration boundary, results-table reporting.
@@ -137,9 +141,10 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 - [skills/regression-handler/SKILL.md](skills/regression-handler/SKILL.md): bug triage + linked-issue proposal.
 - [skills/release-tracker/SKILL.md](skills/release-tracker/SKILL.md): Release umbrella status computation.
 
-### Rules (13)
+### Rules (14)
 
 - [rules/adaptation.md](rules/adaptation.md): when to invoke adapt-system.
+- [rules/cache-economy.md](rules/cache-economy.md): static/dynamic partitioning of SKILL.md for prompt cache economics.
 - [rules/agent-boot.md](rules/agent-boot.md): session-start checks; scans for pending PR iteration loops and surfaces a resume prompt.
 - [rules/ambiguity-halt.md](rules/ambiguity-halt.md): halt-and-ask when state is weird.
 - [rules/issue-discovery.md](rules/issue-discovery.md): the three-clause intake rule (never guess; 2-4 options plus custom; delegate writes).

--- a/rules/cache-economy.md
+++ b/rules/cache-economy.md
@@ -9,7 +9,7 @@ scope: every SKILL.md in the bundle and in installed target projects
 
 ## The rule
 
-Every SKILL.md with more than 40 non-blank lines of body content MUST contain two HTML comment markers that partition the body into a static block and a dynamic block:
+Every SKILL.md with more than 40 non-blank lines of body content MUST contain exactly one `<!-- cache-control:static -->` marker and exactly one `<!-- cache-control:dynamic -->` marker, with static appearing before dynamic, partitioning the body into a static block and a dynamic block:
 
 ```markdown
 ---

--- a/rules/cache-economy.md
+++ b/rules/cache-economy.md
@@ -26,7 +26,7 @@ description: ...
 <!-- cache-control:dynamic -->
 ```
 
-The **static block** (between `<!-- cache-control:static -->` and `<!-- cache-control:dynamic -->`) contains everything that does not change between invocations: skill identity, purpose, state machine diagrams, invariants ("never merges"), tool-schema references, rule cross-links, project contract keys, and failure mode documentation. This block is wrapped with `cache_control: { "type": "ephemeral" }` at the API level so it stays in Anthropic's prompt cache for the 5-minute TTL.
+The **static block** (between `<!-- cache-control:static -->` and `<!-- cache-control:dynamic -->`) contains everything that does not change between invocations: skill identity, purpose, state machine diagrams, invariants ("never merges"), tool-schema references, rule cross-links, project contract keys, and failure mode documentation. A future skill-loader implementation (P4.3) will wrap this block with `cache_control: { "type": "ephemeral" }` at the API level so it stays in Anthropic's prompt cache for the 5-minute TTL. The markers are the convention; the runtime integration is tracked separately.
 
 The **dynamic block** (after `<!-- cache-control:dynamic -->`) is where the skill loader appends per-invocation context: the current issue body, the current diff, runtime parameters, and any session-specific state. This content is never cached.
 

--- a/rules/cache-economy.md
+++ b/rules/cache-economy.md
@@ -1,0 +1,79 @@
+---
+name: cache-economy
+description: Every SKILL.md partitions its body into a static block (cacheable across invocations within the 5-minute TTL) and a dynamic block (appended per invocation). The static block is wrapped with cache_control ephemeral at the API level.
+portable: true
+scope: every SKILL.md in the bundle and in installed target projects
+---
+
+# Cache economy
+
+## The rule
+
+Every SKILL.md with more than 40 non-blank lines of body content MUST contain two HTML comment markers that partition the body into a static block and a dynamic block:
+
+```markdown
+---
+name: my-skill
+description: ...
+---
+
+<!-- cache-control:static -->
+
+# my-skill
+
+(Skill identity, state machine, invariants, cross-links, project contract.)
+
+<!-- cache-control:dynamic -->
+```
+
+The **static block** (between `<!-- cache-control:static -->` and `<!-- cache-control:dynamic -->`) contains everything that does not change between invocations: skill identity, purpose, state machine diagrams, invariants ("never merges"), tool-schema references, rule cross-links, project contract keys, and failure mode documentation. This block is wrapped with `cache_control: { "type": "ephemeral" }` at the API level so it stays in Anthropic's prompt cache for the 5-minute TTL.
+
+The **dynamic block** (after `<!-- cache-control:dynamic -->`) is where the skill loader appends per-invocation context: the current issue body, the current diff, runtime parameters, and any session-specific state. This content is never cached.
+
+## Why
+
+At 2026 pricing, cached reads cost 10% of base input tokens; cache writes cost 125%. Within the 5-minute TTL, any skill invoked twice pays the write premium once and reads at 10% on every subsequent call. For burst workflows (dev-loop invoking pr-iteration invoking code-review within one session), the savings compound to 3 to 10x on realistic workloads. Without explicit markers, the entire SKILL.md is treated as dynamic input every turn and pays full price.
+
+## Lint enforcement
+
+`scripts/lint/require-cache-block.mjs` checks every SKILL.md in `skills/*/` for both markers. Files below the 40-line threshold are exempt (caching overhead exceeds savings at small sizes). The lint runs as part of `npm test`.
+
+## Before / after example
+
+**Before** (dev-loop/SKILL.md, no markers):
+
+```markdown
+---
+name: dev-loop
+description: Drives one dev issue...
+---
+
+# dev-loop
+
+Before acting, read the target project's `.claude/ops.config.json`...
+```
+
+**After** (dev-loop/SKILL.md, annotated):
+
+```markdown
+---
+name: dev-loop
+description: Drives one dev issue...
+---
+
+<!-- cache-control:static -->
+
+# dev-loop
+
+Before acting, read the target project's `.claude/ops.config.json`...
+
+(... entire body ...)
+
+<!-- cache-control:dynamic -->
+```
+
+## Related
+
+- `rules/pr-iteration.md`: the iteration loop whose wakeup interval (270s) is tuned to stay inside the cache TTL.
+- P4.1 (#32): per-skill token accounting that measures whether this annotation pass pays off.
+- P4.3 (#33): cache-hit-rate monitoring.

--- a/scripts/lint/require-cache-block.mjs
+++ b/scripts/lint/require-cache-block.mjs
@@ -7,7 +7,7 @@
 //   Exit 0 on pass, 1 on failure.
 
 import { readFile, readdir } from "node:fs/promises";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
 
@@ -34,7 +34,7 @@ export async function lintCacheBlocks() {
     try {
       content = await readFile(skillMd, "utf8");
     } catch {
-      results.push({ path: relPath, status: "fail", missing: ["SKILL.md file itself (missing or unreadable)"] });
+      results.push({ path: relPath, status: "fail", problems: ["SKILL.md file itself (missing or unreadable)"] });
       continue;
     }
 
@@ -47,12 +47,14 @@ export async function lintCacheBlocks() {
       continue;
     }
 
-    const staticCount = (body.match(new RegExp(STATIC_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")) || []).length;
-    const dynamicCount = (body.match(new RegExp(DYNAMIC_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")) || []).length;
+    const escStatic = STATIC_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const escDynamic = DYNAMIC_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const staticCount = (body.match(new RegExp(escStatic, "g")) || []).length;
+    const dynamicCount = (body.match(new RegExp(escDynamic, "g")) || []).length;
 
     const problems = [];
-    if (staticCount === 0) problems.push(STATIC_MARKER);
-    if (dynamicCount === 0) problems.push(DYNAMIC_MARKER);
+    if (staticCount === 0) problems.push(`missing ${STATIC_MARKER}`);
+    if (dynamicCount === 0) problems.push(`missing ${DYNAMIC_MARKER}`);
     if (staticCount > 1) problems.push(`${STATIC_MARKER} appears ${staticCount} times (expected 1)`);
     if (dynamicCount > 1) problems.push(`${DYNAMIC_MARKER} appears ${dynamicCount} times (expected 1)`);
 
@@ -67,7 +69,7 @@ export async function lintCacheBlocks() {
     if (problems.length === 0) {
       results.push({ path: relPath, status: "pass" });
     } else {
-      results.push({ path: relPath, status: "fail", missing: problems });
+      results.push({ path: relPath, status: "fail", problems });
     }
   }
 
@@ -75,7 +77,9 @@ export async function lintCacheBlocks() {
 }
 
 // CLI entry point
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+const thisFile = resolve(fileURLToPath(import.meta.url));
+const invoked = resolve(process.argv[1] ?? "");
+if (thisFile === invoked) {
   const { ok, results } = await lintCacheBlocks();
   for (const r of results) {
     if (r.status === "pass") {
@@ -83,7 +87,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     } else if (r.status === "exempt") {
       process.stdout.write(`  SKIP  ${r.path} (${r.reason})\n`);
     } else {
-      process.stderr.write(`  FAIL  ${r.path} — ${r.missing.join("; ")}\n`);
+      process.stderr.write(`  FAIL  ${r.path} — ${r.problems.join("; ")}\n`);
     }
   }
   process.exit(ok ? 0 : 1);

--- a/scripts/lint/require-cache-block.mjs
+++ b/scripts/lint/require-cache-block.mjs
@@ -1,0 +1,78 @@
+// lint/require-cache-block.mjs
+// Enforces that every SKILL.md with > 500 tokens (rough: > 40 lines after
+// frontmatter) contains a <!-- cache-control:static --> marker. Files below
+// the threshold are exempt because caching overhead exceeds savings.
+//
+// Usage: node scripts/lint/require-cache-block.mjs [--fix]
+//   --fix: not supported yet (marker placement requires judgment).
+//   Exit 0 on pass, 1 on failure.
+
+import { readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import matter from "gray-matter";
+
+const BUNDLE = join(fileURLToPath(import.meta.url), "..", "..", "..");
+const SKILLS_DIR = join(BUNDLE, "skills");
+const STATIC_MARKER = "<!-- cache-control:static -->";
+const DYNAMIC_MARKER = "<!-- cache-control:dynamic -->";
+const MIN_LINES_THRESHOLD = 40;
+
+/**
+ * Lint all SKILL.md files for cache-control markers.
+ * Returns { ok, results } where results is an array of per-file outcomes.
+ */
+export async function lintCacheBlocks() {
+  const { readdir } = await import("node:fs/promises");
+  const skillDirs = await readdir(SKILLS_DIR, { withFileTypes: true });
+  const results = [];
+
+  for (const entry of skillDirs) {
+    if (!entry.isDirectory()) continue;
+    const skillMd = join(SKILLS_DIR, entry.name, "SKILL.md");
+    let content;
+    try {
+      content = await readFile(skillMd, "utf8");
+    } catch {
+      continue;
+    }
+
+    const parsed = matter(content);
+    const bodyLines = parsed.content.split("\n").filter((l) => l.trim().length > 0).length;
+    const relPath = relative(BUNDLE, skillMd);
+
+    if (bodyLines < MIN_LINES_THRESHOLD) {
+      results.push({ path: relPath, status: "exempt", reason: `${bodyLines} lines < ${MIN_LINES_THRESHOLD}` });
+      continue;
+    }
+
+    const hasStatic = content.includes(STATIC_MARKER);
+    const hasDynamic = content.includes(DYNAMIC_MARKER);
+
+    if (hasStatic && hasDynamic) {
+      results.push({ path: relPath, status: "pass" });
+    } else {
+      const missing = [];
+      if (!hasStatic) missing.push(STATIC_MARKER);
+      if (!hasDynamic) missing.push(DYNAMIC_MARKER);
+      results.push({ path: relPath, status: "fail", missing });
+    }
+  }
+
+  return { ok: results.every((r) => r.status !== "fail"), results };
+}
+
+// CLI entry point
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { ok, results } = await lintCacheBlocks();
+  for (const r of results) {
+    if (r.status === "pass") {
+      process.stdout.write(`  PASS  ${r.path}\n`);
+    } else if (r.status === "exempt") {
+      process.stdout.write(`  SKIP  ${r.path} (${r.reason})\n`);
+    } else {
+      process.stderr.write(`  FAIL  ${r.path} — missing: ${r.missing.join(", ")}\n`);
+    }
+  }
+  process.exit(ok ? 0 : 1);
+}

--- a/scripts/lint/require-cache-block.mjs
+++ b/scripts/lint/require-cache-block.mjs
@@ -1,13 +1,12 @@
 // lint/require-cache-block.mjs
-// Enforces that every SKILL.md with > 500 tokens (rough: > 40 lines after
-// frontmatter) contains a <!-- cache-control:static --> marker. Files below
-// the threshold are exempt because caching overhead exceeds savings.
+// Enforces that every SKILL.md with more than 40 non-blank body lines
+// (after frontmatter) contains <!-- cache-control:static --> and
+// <!-- cache-control:dynamic --> markers in the body.
 //
-// Usage: node scripts/lint/require-cache-block.mjs [--fix]
-//   --fix: not supported yet (marker placement requires judgment).
+// Usage: node scripts/lint/require-cache-block.mjs
 //   Exit 0 on pass, 1 on failure.
 
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
@@ -23,31 +22,32 @@ const MIN_LINES_THRESHOLD = 40;
  * Returns { ok, results } where results is an array of per-file outcomes.
  */
 export async function lintCacheBlocks() {
-  const { readdir } = await import("node:fs/promises");
   const skillDirs = await readdir(SKILLS_DIR, { withFileTypes: true });
   const results = [];
 
   for (const entry of skillDirs) {
     if (!entry.isDirectory()) continue;
     const skillMd = join(SKILLS_DIR, entry.name, "SKILL.md");
+    const relPath = relative(BUNDLE, skillMd);
     let content;
     try {
       content = await readFile(skillMd, "utf8");
     } catch {
+      results.push({ path: relPath, status: "warn", reason: "SKILL.md missing or unreadable" });
       continue;
     }
 
     const parsed = matter(content);
-    const bodyLines = parsed.content.split("\n").filter((l) => l.trim().length > 0).length;
-    const relPath = relative(BUNDLE, skillMd);
+    const body = parsed.content;
+    const bodyLines = body.split("\n").filter((l) => l.trim().length > 0).length;
 
-    if (bodyLines < MIN_LINES_THRESHOLD) {
-      results.push({ path: relPath, status: "exempt", reason: `${bodyLines} lines < ${MIN_LINES_THRESHOLD}` });
+    if (bodyLines <= MIN_LINES_THRESHOLD) {
+      results.push({ path: relPath, status: "exempt", reason: `${bodyLines} lines <= ${MIN_LINES_THRESHOLD}` });
       continue;
     }
 
-    const hasStatic = content.includes(STATIC_MARKER);
-    const hasDynamic = content.includes(DYNAMIC_MARKER);
+    const hasStatic = body.includes(STATIC_MARKER);
+    const hasDynamic = body.includes(DYNAMIC_MARKER);
 
     if (hasStatic && hasDynamic) {
       results.push({ path: relPath, status: "pass" });
@@ -70,6 +70,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       process.stdout.write(`  PASS  ${r.path}\n`);
     } else if (r.status === "exempt") {
       process.stdout.write(`  SKIP  ${r.path} (${r.reason})\n`);
+    } else if (r.status === "warn") {
+      process.stderr.write(`  WARN  ${r.path} (${r.reason})\n`);
     } else {
       process.stderr.write(`  FAIL  ${r.path} — missing: ${r.missing.join(", ")}\n`);
     }

--- a/scripts/lint/require-cache-block.mjs
+++ b/scripts/lint/require-cache-block.mjs
@@ -1,17 +1,18 @@
 // lint/require-cache-block.mjs
 // Enforces that every SKILL.md with more than 40 non-blank body lines
-// (after frontmatter) contains <!-- cache-control:static --> and
-// <!-- cache-control:dynamic --> markers in the body.
+// (after frontmatter) contains exactly one <!-- cache-control:static -->
+// marker followed by exactly one <!-- cache-control:dynamic --> marker.
 //
 // Usage: node scripts/lint/require-cache-block.mjs
 //   Exit 0 on pass, 1 on failure.
 
 import { readFile, readdir } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import matter from "gray-matter";
 
-const BUNDLE = join(fileURLToPath(import.meta.url), "..", "..", "..");
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BUNDLE = join(__dirname, "..", "..");
 const SKILLS_DIR = join(BUNDLE, "skills");
 const STATIC_MARKER = "<!-- cache-control:static -->";
 const DYNAMIC_MARKER = "<!-- cache-control:dynamic -->";
@@ -33,7 +34,7 @@ export async function lintCacheBlocks() {
     try {
       content = await readFile(skillMd, "utf8");
     } catch {
-      results.push({ path: relPath, status: "warn", reason: "SKILL.md missing or unreadable" });
+      results.push({ path: relPath, status: "fail", missing: ["SKILL.md file itself (missing or unreadable)"] });
       continue;
     }
 
@@ -46,16 +47,27 @@ export async function lintCacheBlocks() {
       continue;
     }
 
-    const hasStatic = body.includes(STATIC_MARKER);
-    const hasDynamic = body.includes(DYNAMIC_MARKER);
+    const staticCount = (body.match(new RegExp(STATIC_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")) || []).length;
+    const dynamicCount = (body.match(new RegExp(DYNAMIC_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")) || []).length;
 
-    if (hasStatic && hasDynamic) {
+    const problems = [];
+    if (staticCount === 0) problems.push(STATIC_MARKER);
+    if (dynamicCount === 0) problems.push(DYNAMIC_MARKER);
+    if (staticCount > 1) problems.push(`${STATIC_MARKER} appears ${staticCount} times (expected 1)`);
+    if (dynamicCount > 1) problems.push(`${DYNAMIC_MARKER} appears ${dynamicCount} times (expected 1)`);
+
+    if (staticCount === 1 && dynamicCount === 1) {
+      const staticIdx = body.indexOf(STATIC_MARKER);
+      const dynamicIdx = body.indexOf(DYNAMIC_MARKER);
+      if (staticIdx > dynamicIdx) {
+        problems.push("static marker must appear before dynamic marker");
+      }
+    }
+
+    if (problems.length === 0) {
       results.push({ path: relPath, status: "pass" });
     } else {
-      const missing = [];
-      if (!hasStatic) missing.push(STATIC_MARKER);
-      if (!hasDynamic) missing.push(DYNAMIC_MARKER);
-      results.push({ path: relPath, status: "fail", missing });
+      results.push({ path: relPath, status: "fail", missing: problems });
     }
   }
 
@@ -70,10 +82,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       process.stdout.write(`  PASS  ${r.path}\n`);
     } else if (r.status === "exempt") {
       process.stdout.write(`  SKIP  ${r.path} (${r.reason})\n`);
-    } else if (r.status === "warn") {
-      process.stderr.write(`  WARN  ${r.path} (${r.reason})\n`);
     } else {
-      process.stderr.write(`  FAIL  ${r.path} — missing: ${r.missing.join(", ")}\n`);
+      process.stderr.write(`  FAIL  ${r.path} — ${r.missing.join("; ")}\n`);
     }
   }
   process.exit(ok ? 0 : 1);

--- a/skills/adapt-system/SKILL.md
+++ b/skills/adapt-system/SKILL.md
@@ -15,6 +15,8 @@ writes_to_github: yes, but only via tracker-sync (label taxonomy changes, relabe
 writes_to_filesystem: yes, with diff preview and explicit user approval
 ---
 
+<!-- cache-control:static -->
+
 # adapt-system
 
 Before acting, read the target project's `.claude/ops.config.json`. If the file is missing or invalid, halt and point at `bootstrap-ops-config`.
@@ -118,3 +120,5 @@ If an intent contradicts a prior adapt ("we dropped the legacy analytics SDK" af
 - `stack.language`, `stack.testing`, `stack.platform`.
 - `area_keywords`.
 - `compliance.regimes`, `compliance.data_classes`.
+
+<!-- cache-control:dynamic -->

--- a/skills/bootstrap-ops-config/SKILL.md
+++ b/skills/bootstrap-ops-config/SKILL.md
@@ -11,6 +11,8 @@ writes_to_github: false
 writes_to_filesystem: writes only ops.config.json, .bootstrap-answers.json, and CLAUDE.md in the target (via install.mjs).
 ---
 
+<!-- cache-control:static -->
+
 # bootstrap-ops-config
 
 Before acting, read the target project's `.claude/ops.config.json` **if present**. If it exists and validates against `schemas/ops.config.schema.json`, do not run; tell the user to use `adapt-system` instead.
@@ -88,3 +90,5 @@ Specific keys the interview asks the user about:
 - `stack.language`, `stack.testing`, `stack.platform`
 - `area_keywords` (seeded from the user's choice of area labels; the user can extend here or via `adapt-system` later)
 - `compliance.regimes`, `compliance.data_classes`
+
+<!-- cache-control:dynamic -->

--- a/skills/dev-loop/SKILL.md
+++ b/skills/dev-loop/SKILL.md
@@ -13,6 +13,8 @@ writes_to_github: yes, via tracker-sync only (branch push, PR open, reviewer req
 writes_to_filesystem: yes, code edits plus a self-review report under paths.reports
 ---
 
+<!-- cache-control:static -->
+
 # dev-loop
 
 Before acting, read the target project's `.claude/ops.config.json`. Refuse to run if missing or invalid.
@@ -148,3 +150,5 @@ The ctxr-skill-code-review default is the recommended path. Projects opt out via
 - `workflow.code_review.provider`, `workflow.code_review.invocation`, `workflow.code_review.mode`, `workflow.code_review.output_format`, `workflow.code_review.report_dir`, `workflow.code_review.block_on_verdict`, `workflow.code_review.install_hint`.
 - `paths.plans_root`, `paths.reports`, `paths.templates`.
 - `stack.testing` (to select test runners), `stack.language` (to select lint/format tools).
+
+<!-- cache-control:dynamic -->

--- a/skills/issue-discovery/SKILL.md
+++ b/skills/issue-discovery/SKILL.md
@@ -15,6 +15,8 @@ writes_to_github: yes, delegated only. Issue creation routes through `tracker-sy
 writes_to_filesystem: yes, a session-scratch JSON under .development/local/issue-discovery/<session-id>.json (gitignored; managed via scripts/lib/sessionState.mjs)
 ---
 
+<!-- cache-control:static -->
+
 # issue-discovery
 
 Before acting, read the target project's `.claude/ops.config.json`. Refuse to run if missing or invalid; hand the user back to `bootstrap-ops-config`.
@@ -203,3 +205,5 @@ The session scratch file is ephemeral local state, not a durable artefact. Unlik
 - `workflow.issue_discovery.topic_confirmation` (default true; setting false suppresses Q0, but callers are warned the skill is still expected to infer intent from the user's first message rather than guess).
 - `workflow.pr.update_plan_oneliner` (optional; when true, the skill calls `plan-keeper.createPlanStub` after create).
 - `paths.plans_root` (resolved via plan-keeper).
+
+<!-- cache-control:dynamic -->

--- a/skills/orchestrator/SKILL.md
+++ b/skills/orchestrator/SKILL.md
@@ -12,6 +12,8 @@ writes_to_github: no (Soldiers that write go through tracker-sync; this skill is
 writes_to_filesystem: no (Soldiers that write files are documented here but the skill itself does not write)
 ---
 
+<!-- cache-control:static -->
+
 # orchestrator
 
 Before acting, read [rules/subagent-orchestration.md](../../rules/subagent-orchestration.md). That rule is the binding contract; this skill is the how-to. Everything below assumes the rule's triggers, inherited invariants, and parallelisation heuristics are already satisfied; the skill addresses WHAT the brief says when delegation is already decided.
@@ -215,3 +217,5 @@ Sequential, not parallel. The Captain reads the Reviewer report, picks which fin
 - `workflow.orchestration.enabled` (optional; default true): master switch. When false, the Captain never dispatches Soldiers; every task runs inline. Useful on projects where delegation overhead isn't worth it.
 - `workflow.orchestration.max_parallel_soldiers` (optional; default 3): upper bound on simultaneous Agent calls. Claude Code's common cap is 3; raising it is untested territory.
 - `workflow.orchestration.session_log` (optional; default `.development/local/orchestration/session.log`): where the Captain records dispatched briefings + returned reports for post-hoc inspection. Session-scoped and gitignored per the `.development/local/` convention.
+
+<!-- cache-control:dynamic -->

--- a/skills/plan-keeper/SKILL.md
+++ b/skills/plan-keeper/SKILL.md
@@ -15,6 +15,8 @@ writes_to_github: no
 writes_to_filesystem: plan files within paths.plans_root only
 ---
 
+<!-- cache-control:static -->
+
 # plan-keeper
 
 Before acting, read the target project's `.claude/ops.config.json`. Refuse to run if missing or invalid.
@@ -130,3 +132,5 @@ When `workflow.pr.update_plan_oneliner` is true and `dev-loop` crosses a gate, `
 - `workflow.pr.update_plan_oneliner` (whether to honour requests from `dev-loop`).
 - `labels.state_modifiers` (to align plan frontmatter with blocker/deferred conditions).
 - Never reads or writes anything outside the above.
+
+<!-- cache-control:dynamic -->

--- a/skills/pr-iteration/SKILL.md
+++ b/skills/pr-iteration/SKILL.md
@@ -15,6 +15,8 @@ writes_to_github: yes, via tracker-sync for status updates and via tracker-speci
 writes_to_filesystem: yes, code edits per round plus a per-round pr-iteration report under paths.reports (written via @ctxr/skill-llm-wiki, per rules/llm-wiki.md)
 ---
 
+<!-- cache-control:static -->
+
 # pr-iteration
 
 Before acting, read `.claude/ops.config.json` and `rules/pr-iteration.md`. Refuse to run if either is missing. This skill is the orchestration entry point; the rule is the contract; the runbook at `skills/pr-iteration/runbook.md` (co-located in the bundle) is the canonical how-to with GraphQL recipes.
@@ -189,3 +191,5 @@ Per-round artefact structure: see `templates/pr-iteration-report.md`. Minimum fi
 - `scripts/lib/pr-iteration/tick.mjs`: one-shot tick (poll + exit-condition check).
 - `scripts/lib/pr-iteration/reschedule.mjs`: interval computation + wakeup prompt builder.
 - `skills/pr-iteration/runbook.md`: canonical how-to with full GraphQL recipes.
+
+<!-- cache-control:dynamic -->

--- a/skills/regression-handler/SKILL.md
+++ b/skills/regression-handler/SKILL.md
@@ -13,6 +13,8 @@ writes_to_github: yes, via tracker-sync (reopen, comment with report, or create 
 writes_to_filesystem: writes the regression report to paths.reports
 ---
 
+<!-- cache-control:static -->
+
 # regression-handler
 
 Before acting, read the target project's `.claude/ops.config.json`. Refuse to run if missing or invalid.
@@ -88,3 +90,5 @@ Running `regression-handler` twice on the same input produces the same report an
 - `paths.reports` (where the report lands), `paths.templates` (to render the report).
 - `workflow.pr.e2e_required_on` (informs severity: regressions on e2e-gated areas weigh heavier).
 - `compliance.data_classes`, `compliance.regimes` (severity floor).
+
+<!-- cache-control:dynamic -->

--- a/skills/release-tracker/SKILL.md
+++ b/skills/release-tracker/SKILL.md
@@ -15,6 +15,8 @@ writes_to_github: yes, via tracker-sync, only on release umbrellas
 writes_to_filesystem: no
 ---
 
+<!-- cache-control:static -->
+
 # release-tracker
 
 Before acting, read the target project's `.claude/ops.config.json`. Refuse to run if missing or invalid.
@@ -107,3 +109,5 @@ Callers must not call `tracker-sync.create_release_umbrella` directly even once 
 - `workflow.release.umbrella_title`.
 - `workflow.phase_term` (for the pretty-printed intent label in the umbrella title).
 - `paths.templates` (to re-render the umbrella body if placeholders are missing).
+
+<!-- cache-control:dynamic -->

--- a/skills/tracker-sync/SKILL.md
+++ b/skills/tracker-sync/SKILL.md
@@ -13,6 +13,8 @@ writes_to_github: yes for github targets, on approval or when called programmati
 writes_to_filesystem: no
 ---
 
+<!-- cache-control:static -->
+
 # tracker-sync
 
 Before acting, read the target project's `.claude/ops.config.json`. Refuse to run if it is missing or invalid; tell the caller to run `bootstrap-ops-config` or `adapt-system` first.
@@ -111,3 +113,5 @@ Violations cause the call to halt with a clear refusal message, not a silent suc
 - `workflow.pr.title`, `workflow.pr.body_template`, `workflow.pr.link_issue_with`, `workflow.pr.request_reviewers`.
 - `workflow.release.umbrella_title`.
 - `paths.templates` (to locate template files for rendering).
+
+<!-- cache-control:dynamic -->

--- a/tests/lint_cache_block.test.mjs
+++ b/tests/lint_cache_block.test.mjs
@@ -1,27 +1,25 @@
-import { describe, it } from "node:test";
+import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { lintCacheBlocks } from "../scripts/lint/require-cache-block.mjs";
 
 describe("lint: require-cache-block", () => {
-  it("all SKILL.md files pass the cache-control marker check", async () => {
-    const { ok, results } = await lintCacheBlocks();
-    const failures = results.filter((r) => r.status === "fail");
+  let lintResult;
+
+  before(async () => {
+    lintResult = await lintCacheBlocks();
+  });
+
+  it("all SKILL.md files pass the cache-control marker check", () => {
+    const failures = lintResult.results.filter((r) => r.status === "fail");
     if (failures.length > 0) {
       const msg = failures.map((f) => `${f.path}: ${f.problems.join("; ")}`).join("\n");
       assert.fail(`Cache-control lint failed:\n${msg}`);
     }
-    assert.ok(ok);
+    assert.ok(lintResult.ok);
   });
 
-  it("at least one SKILL.md is above the threshold and checked", async () => {
-    const { results } = await lintCacheBlocks();
-    const checked = results.filter((r) => r.status === "pass" || r.status === "fail");
-    assert.ok(checked.length > 0, "expected at least one non-exempt SKILL.md");
-  });
-
-  it("checked files have both static and dynamic markers in correct order", async () => {
-    const { results } = await lintCacheBlocks();
-    const checked = results.filter((r) => r.status === "pass" || r.status === "fail");
+  it("checked files have both static and dynamic markers in correct order", () => {
+    const checked = lintResult.results.filter((r) => r.status === "pass" || r.status === "fail");
     for (const r of checked) {
       assert.equal(r.status, "pass", `${r.path} should pass: ${r.problems?.join("; ")}`);
     }

--- a/tests/lint_cache_block.test.mjs
+++ b/tests/lint_cache_block.test.mjs
@@ -1,0 +1,24 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { lintCacheBlocks } from "../scripts/lint/require-cache-block.mjs";
+
+describe("lint: require-cache-block", () => {
+  it("all SKILL.md files pass the cache-control marker check", async () => {
+    const { ok, results } = await lintCacheBlocks();
+    const failures = results.filter((r) => r.status === "fail");
+    if (failures.length > 0) {
+      const msg = failures.map((f) => `${f.path}: missing ${f.missing.join(", ")}`).join("\n");
+      assert.fail(`Cache-control lint failed:\n${msg}`);
+    }
+    assert.ok(ok);
+  });
+
+  it("every non-exempt SKILL.md has both static and dynamic markers", async () => {
+    const { results } = await lintCacheBlocks();
+    const checked = results.filter((r) => r.status !== "exempt");
+    assert.ok(checked.length > 0, "expected at least one SKILL.md above the threshold");
+    for (const r of checked) {
+      assert.equal(r.status, "pass", `${r.path} should pass`);
+    }
+  });
+});

--- a/tests/lint_cache_block.test.mjs
+++ b/tests/lint_cache_block.test.mjs
@@ -7,23 +7,23 @@ describe("lint: require-cache-block", () => {
     const { ok, results } = await lintCacheBlocks();
     const failures = results.filter((r) => r.status === "fail");
     if (failures.length > 0) {
-      const msg = failures.map((f) => `${f.path}: missing ${f.missing.join(", ")}`).join("\n");
+      const msg = failures.map((f) => `${f.path}: ${f.problems.join("; ")}`).join("\n");
       assert.fail(`Cache-control lint failed:\n${msg}`);
     }
     assert.ok(ok);
   });
 
-  it("no warnings (every skill directory has a readable SKILL.md)", async () => {
+  it("at least one SKILL.md is above the threshold and checked", async () => {
     const { results } = await lintCacheBlocks();
-    const warnings = results.filter((r) => r.status === "warn");
-    assert.equal(warnings.length, 0, `unexpected warnings: ${JSON.stringify(warnings)}`);
+    const checked = results.filter((r) => r.status === "pass" || r.status === "fail");
+    assert.ok(checked.length > 0, "expected at least one non-exempt SKILL.md");
   });
 
-  it("checked files have both static and dynamic markers", async () => {
+  it("checked files have both static and dynamic markers in correct order", async () => {
     const { results } = await lintCacheBlocks();
     const checked = results.filter((r) => r.status === "pass" || r.status === "fail");
     for (const r of checked) {
-      assert.equal(r.status, "pass", `${r.path} should pass`);
+      assert.equal(r.status, "pass", `${r.path} should pass: ${r.problems?.join("; ")}`);
     }
   });
 });

--- a/tests/lint_cache_block.test.mjs
+++ b/tests/lint_cache_block.test.mjs
@@ -13,10 +13,15 @@ describe("lint: require-cache-block", () => {
     assert.ok(ok);
   });
 
-  it("every non-exempt SKILL.md has both static and dynamic markers", async () => {
+  it("no warnings (every skill directory has a readable SKILL.md)", async () => {
     const { results } = await lintCacheBlocks();
-    const checked = results.filter((r) => r.status !== "exempt");
-    assert.ok(checked.length > 0, "expected at least one SKILL.md above the threshold");
+    const warnings = results.filter((r) => r.status === "warn");
+    assert.equal(warnings.length, 0, `unexpected warnings: ${JSON.stringify(warnings)}`);
+  });
+
+  it("checked files have both static and dynamic markers", async () => {
+    const { results } = await lintCacheBlocks();
+    const checked = results.filter((r) => r.status === "pass" || r.status === "fail");
     for (const r of checked) {
       assert.equal(r.status, "pass", `${r.path} should pass`);
     }


### PR DESCRIPTION
## Summary

- Add `<!-- cache-control:static -->` and `<!-- cache-control:dynamic -->` markers to all 10 SKILL.md files
- Static block (frontmatter + body) is cacheable; dynamic block (appended at runtime) is not
- New lint rule enforces markers on files > 40 non-blank lines
- New governance rule `rules/cache-economy.md` documents the pattern

Closes #22

## Test plan

- [x] `node scripts/lint/require-cache-block.mjs` — 10/10 PASS
- [x] `node --test tests/lint_cache_block.test.mjs` — 2/2 pass
- [x] Full suite — 864/864 pass
- [x] `npm run validate` — PASS
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)