### PR TITLE
feat(bootstrap)!: --solo / --team / --interactive preset modes

### DIFF
--- a/examples/ops.config.example.json
+++ b/examples/ops.config.example.json
@@ -98,6 +98,7 @@
   },
 
   "workflow": {
+    "mode": "team",
     "phase_term": "wave",
     "branch_patterns": {
       "feature":  "feat/{issue}-{slug}",

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -245,6 +245,12 @@
       "required": ["phase_term", "branch_patterns", "commits", "pr"],
       "additionalProperties": false,
       "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["solo", "team"],
+          "description": "Bootstrap mode. solo: minimal config, no external review, empty area labels. team: full interview, all features enabled.",
+          "default": "solo"
+        },
         "phase_term": {
           "type": "string",
           "description": "The word used in label scope intent/* and in release umbrella titles. Default: wave.",

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -175,9 +175,9 @@
         },
         "priority": {
           "type": "array",
-          "description": "Scope priority/*. Example values: p0-blocker, p1-high, p2-medium, p3-low.",
+          "description": "Scope priority/*. Example values: p0-blocker, p1-high, p2-medium, p3-low. When empty (solo mode), issue-discovery skips the priority step.",
           "items": { "type": "string", "minLength": 1 },
-          "minItems": 1
+          "minItems": 0
         },
         "intent": {
           "type": "array",

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -76,7 +76,7 @@ async function main() {
 
   process.stdout.write(`\nbootstrap-ops-config\n`);
   process.stdout.write(`target: ${TARGET}\n`);
-  process.stdout.write(`mode:   ${DRY_RUN ? "dry-run (no writes)" : "apply"}\n\n`);
+  process.stdout.write(`write:  ${DRY_RUN ? "dry-run (no writes)" : "apply"}\n\n`);
 
   // Check mode flag conflicts before creating readline (early exit without cleanup issues).
   const MODE_SOLO = boolFlag(flags, "solo", false);

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -130,9 +130,17 @@ async function main() {
     if (bootstrapMode === "yes") {
       answers = pickDefaults(detection);
     } else if (bootstrapMode === "solo") {
-      answers = await interviewSolo(rl, detection);
+      if (!process.stdin.isTTY) {
+        // Non-TTY solo: use auto-detected defaults, no prompts.
+        const defaults = pickDefaults(detection);
+        defaults.bootstrapMode = "solo";
+        answers = defaults;
+      } else {
+        answers = await interviewSolo(rl, detection);
+      }
     } else {
       answers = await interview(rl, detection, BUNDLE_REF);
+      answers.bootstrapMode = "team";
     }
   } finally {
     rl.close();
@@ -186,6 +194,13 @@ async function main() {
 function printHelp() {
   const text = `
 bootstrap.mjs  interactive cold-start of ops.config.json
+
+Modes:
+  --solo            3 questions (repo, language, test runner). No external review.
+  --team            full 10-question interview. All features enabled.
+  --interactive     alias for --team.
+  (no flag + TTY)   prompts for mode.
+  (no flag + no TTY) defaults to --solo.
 
 Options:
   --target <path>   target project root (default: cwd)
@@ -1458,7 +1473,6 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
       },
       ...((a.bootstrapMode ?? a.teamSize) === "solo" ? {
         external_review: {
-          enabled: true,
           provider: "none",
         },
       } : {}),
@@ -1509,8 +1523,12 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
       required: true,
     },
     stack: {
-      language: d.stack.language.length ? d.stack.language : ["other"],
-      testing: d.stack.testing,
+      language: a.soloOverrides?.language
+        ? [a.soloOverrides.language, ...d.stack.language.filter((l) => l !== a.soloOverrides.language)]
+        : (d.stack.language.length ? d.stack.language : ["other"]),
+      testing: a.soloOverrides?.testRunner && a.soloOverrides.testRunner !== "none"
+        ? [a.soloOverrides.testRunner, ...d.stack.testing.filter((t) => t !== a.soloOverrides.testRunner)]
+        : d.stack.testing,
       platform: d.stack.platform,
     },
     area_keywords: {},

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -132,8 +132,10 @@ async function main() {
     } else if (bootstrapMode === "solo") {
       if (!process.stdin.isTTY) {
         // Non-TTY solo: use auto-detected defaults, no prompts.
+        // Override team-specific defaults for solo semantics.
         const defaults = pickDefaults(detection);
         defaults.bootstrapMode = "solo";
+        defaults.releaseTracker = undefined;
         answers = defaults;
       } else {
         answers = await interviewSolo(rl, detection);
@@ -507,7 +509,13 @@ async function interviewSolo(rl, d) {
 
   // Q1: Repo coordinate (auto-detect from git remote)
   const detectedRepo = d.git.ownerRepo ?? "";
-  const repo = await ask("1. GitHub repo (owner/name)", detectedRepo);
+  let repo = "";
+  while (!repo || !repo.includes("/") || repo.split("/").length !== 2 || repo.split("/").some((s) => !s)) {
+    repo = await ask("1. GitHub repo (owner/name)", detectedRepo);
+    if (!repo || !repo.includes("/") || repo.split("/").length !== 2 || repo.split("/").some((s) => !s)) {
+      process.stdout.write("   Expected format: owner/name (e.g. acme/my-app)\n");
+    }
+  }
 
   // Q2: Primary language
   const detectedLang = d.stack.language[0] ?? "";
@@ -519,7 +527,7 @@ async function interviewSolo(rl, d) {
 
   // Build answers with solo defaults
   const kind = "github";
-  const [owner, repoName] = repo.includes("/") ? repo.split("/") : ["unknown", repo];
+  const [owner, repoName] = repo.split("/");
   const devTracker = {
     kind,
     owner,

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -46,7 +46,7 @@ async function main() {
   await preflight();
 
   const { flags } = parseArgv(process.argv.slice(2), {
-    booleans: new Set(["dry-run", "apply", "yes", "update", "help", "auto-install-node"]),
+    booleans: new Set(["dry-run", "apply", "yes", "update", "help", "auto-install-node", "solo", "team", "interactive"]),
   });
 
   if (flags.help) {
@@ -98,9 +98,42 @@ async function main() {
   process.on("SIGINT", onSigint);
   rl.on("close", () => {});
 
+  // Resolve bootstrap mode: --solo, --team, --interactive flag, or prompt.
+  const MODE_SOLO = boolFlag(flags, "solo", false);
+  const MODE_TEAM = boolFlag(flags, "team", false);
+  const MODE_INTERACTIVE = boolFlag(flags, "interactive", false);
+  const modeCount = [MODE_SOLO, MODE_TEAM, MODE_INTERACTIVE].filter(Boolean).length;
+  if (modeCount > 1) {
+    process.stderr.write("bootstrap: specify at most one of --solo, --team, --interactive\n");
+    process.exit(1);
+  }
+
+  let bootstrapMode;
+  if (AUTO_YES) {
+    bootstrapMode = "yes";
+  } else if (MODE_SOLO) {
+    bootstrapMode = "solo";
+  } else if (MODE_TEAM) {
+    bootstrapMode = "team";
+  } else if (MODE_INTERACTIVE) {
+    bootstrapMode = "interactive";
+  } else if (!process.stdin.isTTY) {
+    bootstrapMode = "solo";
+  } else {
+    const modeAnswer = await rl.question("Bootstrap mode: solo (3 questions) / team (full interview) [solo]: ");
+    bootstrapMode = modeAnswer.trim().toLowerCase().startsWith("t") ? "team" : "solo";
+  }
+  process.stdout.write(`mode: ${bootstrapMode}\n\n`);
+
   let answers;
   try {
-    answers = AUTO_YES ? pickDefaults(detection) : await interview(rl, detection, BUNDLE_REF);
+    if (bootstrapMode === "yes") {
+      answers = pickDefaults(detection);
+    } else if (bootstrapMode === "solo") {
+      answers = await interviewSolo(rl, detection);
+    } else {
+      answers = await interview(rl, detection, BUNDLE_REF);
+    }
   } finally {
     rl.close();
     process.off("SIGINT", onSigint);
@@ -442,6 +475,66 @@ export function inferTrackerKind(detection) {
   if (t.gitlab?.hasToken || t.gitlab?.glab) credentialed.push("gitlab");
   if (credentialed.length === 1) return credentialed[0];
   return null;
+}
+
+/**
+ * Solo interview: 3 questions maximum. Auto-detects as much as possible.
+ * Sets solo-appropriate defaults (no external review, no release tracker,
+ * empty area labels, no workspace members).
+ */
+async function interviewSolo(rl, d) {
+  const ask = async (q, def = "") => {
+    const s = await rl.question(`${q}${def ? ` [${def}]` : ""}: `);
+    return s.trim() || def;
+  };
+
+  process.stdout.write("solo mode (3 questions). Enter accepts the default shown in brackets.\n\n");
+
+  // Q1: Repo coordinate (auto-detect from git remote)
+  const detectedRepo = d.git.ownerRepo ?? "";
+  const repo = await ask("1. GitHub repo (owner/name)", detectedRepo);
+
+  // Q2: Primary language
+  const detectedLang = d.stack.language[0] ?? "";
+  const language = await ask("2. Primary language", detectedLang);
+
+  // Q3: Test runner
+  const detectedTest = d.stack.testing[0] ?? "none";
+  const testRunner = await ask("3. Test runner", detectedTest);
+
+  // Build answers with solo defaults
+  const kind = "github";
+  const [owner, repoName] = repo.includes("/") ? repo.split("/") : ["unknown", repo];
+  const devTracker = {
+    kind,
+    owner,
+    repo: repoName,
+    depth: "full",
+    projects: [],
+  };
+  const pushAllowed = [d.gh.login, "claude"].filter(Boolean);
+
+  return {
+    cadence: "per-wave",
+    teamSize: "solo",
+    bootstrapMode: "solo",
+    pushAllowed,
+    reviewers: [d.gh.login].filter(Boolean),
+    e2eSetup: testRunner,
+    e2ePath: "",
+    devTracker,
+    releaseTracker: undefined,
+    branchPatterns: { ...DEFAULT_BRANCH_PATTERNS },
+    workspace: undefined,
+    observed: [],
+    regimes: ["none"],
+    dataClasses: ["none"],
+    seedProductRules: false,
+    soloOverrides: {
+      language,
+      testRunner,
+    },
+  };
 }
 
 async function interview(rl, d, _bundleRef) {
@@ -1111,6 +1204,7 @@ export function pickDefaults(d) {
   return {
     cadence: "per-wave",
     teamSize: "solo",
+    bootstrapMode: "team",
     pushAllowed,
     reviewers,
     e2eSetup: d.stack.testing[0] ?? "none",
@@ -1299,25 +1393,19 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
     ...(a.workspace === undefined ? {} : { workspace: a.workspace }),
     labels: {
       type: ["feature", "bug", "task", "refactor", "docs", "chore"],
-      area: [
-        "frontend",
-        "backend",
-        "data",
-        "security",
-        "performance",
-        "compliance",
-        "ux",
-        "devx",
-        "testing",
-        "docs",
-      ],
-      priority: ["p0-blocker", "p1-high", "p2-medium", "p3-low"],
+      area: (a.bootstrapMode ?? a.teamSize) === "solo"
+        ? []
+        : ["frontend", "backend", "data", "security", "performance", "compliance", "ux", "devx", "testing", "docs"],
+      priority: (a.bootstrapMode ?? a.teamSize) === "solo"
+        ? []
+        : ["p0-blocker", "p1-high", "p2-medium", "p3-low"],
       intent: cadenceToIntent(a.cadence),
       size: ["xs", "s", "m", "l", "xl"],
       automation: ["auto-regression", "auto-release-tracked"],
       state_modifiers: ["blocked", "deferred", "cancelled"],
     },
     workflow: {
+      mode: a.bootstrapMode ?? (a.teamSize === "solo" ? "solo" : "team"),
       phase_term: a.cadence === "per-wave" ? "wave" : a.cadence === "per-version" ? "version" : "track",
       // Merge DEFAULT_BRANCH_PATTERNS under a.branchPatterns so:
       //   (a) the composed object is always a fresh mutable copy,
@@ -1368,6 +1456,12 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
       release: {
         umbrella_title: "{intent_label_pretty} Release",
       },
+      ...((a.bootstrapMode ?? a.teamSize) === "solo" ? {
+        external_review: {
+          enabled: true,
+          provider: "none",
+        },
+      } : {}),
       code_review: {
         provider: CODE_REVIEW_SKILL,
         provider_url: "https://github.com/ctxr-dev/skill-code-review",

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -116,7 +116,7 @@ async function main() {
   } else if (MODE_TEAM) {
     bootstrapMode = "team";
   } else if (MODE_INTERACTIVE) {
-    bootstrapMode = "interactive";
+    bootstrapMode = "team";
   } else if (!process.stdin.isTTY) {
     bootstrapMode = "solo";
   } else {

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1395,13 +1395,18 @@ export function defaultTrackerTarget(kind, role, d) {
 }
 
 export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer") {
-  const [owner, repo] = (d.git.ownerRepo ?? "unknown/unknown").split("/");
+  // Prefer the tracker's owner/repo (set by the interview, including solo)
+  // over detection (which may be absent or stale).
+  const repoCoord = (a.devTracker?.owner && a.devTracker?.repo)
+    ? `${a.devTracker.owner}/${a.devTracker.repo}`
+    : (d.git.ownerRepo ?? "unknown/unknown");
+  const [owner, repo] = repoCoord.split("/");
   return {
     $schemaVersion: "0.1.0",
     project: {
       name: repo,
       org: owner,
-      repo: d.git.ownerRepo ?? "unknown/unknown",
+      repo: repoCoord,
       default_branch: d.git.defaultBranch,
       principals: {
         push_allowed: a.pushAllowed.length ? a.pushAllowed : ["claude"],

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -147,6 +147,7 @@ async function main() {
         }
         defaults.bootstrapMode = "solo";
         defaults.releaseTracker = undefined;
+        defaults.reviewers = [d.gh.login].filter(Boolean);
         answers = defaults;
       } else {
         answers = await interviewSolo(rl, detection);

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -120,8 +120,9 @@ async function main() {
   } else if (!process.stdin.isTTY) {
     bootstrapMode = "solo";
   } else {
-    const modeAnswer = await rl.question("Bootstrap mode: solo (3 questions) / team (full interview) [solo]: ");
-    bootstrapMode = modeAnswer.trim().toLowerCase().startsWith("t") ? "team" : "solo";
+    const modeAnswer = await rl.question("Bootstrap mode: solo (3 questions) / team (full interview) / interactive [solo]: ");
+    const m = modeAnswer.trim().toLowerCase();
+    bootstrapMode = (m.startsWith("t") || m.startsWith("i")) ? "team" : "solo";
   }
   process.stdout.write(`mode: ${bootstrapMode}\n\n`);
 
@@ -133,7 +134,17 @@ async function main() {
       if (!process.stdin.isTTY) {
         // Non-TTY solo: use auto-detected defaults, no prompts.
         // Override team-specific defaults for solo semantics.
-        const defaults = pickDefaults(detection);
+        let defaults;
+        try {
+          defaults = pickDefaults(detection);
+        } catch (e) {
+          // pickDefaults error message references --yes; rephrase for solo context.
+          throw new Error(
+            "bootstrap --solo (non-TTY): no git remote with owner/repo was detected. " +
+            "Re-run in a TTY so the solo interview can prompt for repo coordinates, " +
+            "or set up a git remote first.",
+          );
+        }
         defaults.bootstrapMode = "solo";
         defaults.releaseTracker = undefined;
         answers = defaults;

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -78,6 +78,16 @@ async function main() {
   process.stdout.write(`target: ${TARGET}\n`);
   process.stdout.write(`mode:   ${DRY_RUN ? "dry-run (no writes)" : "apply"}\n\n`);
 
+  // Check mode flag conflicts before creating readline (early exit without cleanup issues).
+  const MODE_SOLO = boolFlag(flags, "solo", false);
+  const MODE_TEAM = boolFlag(flags, "team", false);
+  const MODE_INTERACTIVE = boolFlag(flags, "interactive", false);
+  const modeCount = [MODE_SOLO, MODE_TEAM, MODE_INTERACTIVE].filter(Boolean).length;
+  if (modeCount > 1) {
+    process.stderr.write("bootstrap: specify at most one of --solo, --team, --interactive\n");
+    process.exit(1);
+  }
+
   const detection = {
     git: detectGit(TARGET),
     gh: await detectGh(),
@@ -98,16 +108,7 @@ async function main() {
   process.on("SIGINT", onSigint);
   rl.on("close", () => {});
 
-  // Resolve bootstrap mode: --solo, --team, --interactive flag, or prompt.
-  const MODE_SOLO = boolFlag(flags, "solo", false);
-  const MODE_TEAM = boolFlag(flags, "team", false);
-  const MODE_INTERACTIVE = boolFlag(flags, "interactive", false);
-  const modeCount = [MODE_SOLO, MODE_TEAM, MODE_INTERACTIVE].filter(Boolean).length;
-  if (modeCount > 1) {
-    process.stderr.write("bootstrap: specify at most one of --solo, --team, --interactive\n");
-    process.exit(1);
-  }
-
+  // Resolve bootstrap mode.
   let bootstrapMode;
   if (AUTO_YES) {
     bootstrapMode = "yes";

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -147,7 +147,7 @@ async function main() {
         }
         defaults.bootstrapMode = "solo";
         defaults.releaseTracker = undefined;
-        defaults.reviewers = [d.gh.login].filter(Boolean);
+        defaults.reviewers = [detection.gh.login].filter(Boolean);
         answers = defaults;
       } else {
         answers = await interviewSolo(rl, detection);

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -1072,6 +1072,9 @@ function printHelp() {
       "  --uninstall       remove wrappers per manifest; preserve user-populated",
       "                    below-marker content",
       "  --yes             accept prompt defaults non-interactively",
+      "  --solo            bootstrap in solo mode (3 questions, no external review)",
+      "  --team            bootstrap in team mode (full 10-question interview)",
+      "  --interactive     alias for --team",
       "",
     ].join("\n")
   );

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -70,7 +70,7 @@ const CLAUDE_MD_END_MARKER =
 // Parse args BEFORE preflight so --help runs even when Node is too old (it
 // otherwise fails silently for a user who cannot yet install Node).
 const { flags } = parseArgv(process.argv.slice(2), {
-  booleans: new Set(["dry-run", "apply", "update", "uninstall", "yes", "help", "auto-install-node"]),
+  booleans: new Set(["dry-run", "apply", "update", "uninstall", "yes", "help", "auto-install-node", "solo", "team", "interactive"]),
 });
 if (flags.help) {
   printHelp();
@@ -183,6 +183,9 @@ if (!opsConfig) {
   if (MODE === "apply" || MODE === "update") args.push("--apply");
   if (YES) args.push("--yes");
   if (boolFlag(flags, "auto-install-node", false)) args.push("--auto-install-node");
+  if (boolFlag(flags, "solo", false)) args.push("--solo");
+  if (boolFlag(flags, "team", false)) args.push("--team");
+  if (boolFlag(flags, "interactive", false)) args.push("--interactive");
   const res = spawnSync(process.execPath, args, {
     stdio: "inherit",
     cwd: TARGET,


### PR DESCRIPTION
## Summary

- Add `--solo` (3 questions), `--team` (full interview), `--interactive` (alias) bootstrap modes
- No flag + TTY: prompts for mode. No flag + non-TTY: defaults to solo
- Solo mode: `workflow.mode = "solo"`, `external_review.provider = "none"`, empty area/priority labels
- `--yes` preserves existing behavior (backward compat for CI pipelines)
- Schema gains `workflow.mode: "solo" | "team"`

BREAKING CHANGE: non-TTY installs without `--yes` default to solo mode.

Closes #19

## Test plan

- [x] Full suite — 880/880 pass (existing bootstrap tests unchanged)
- [x] `npm run validate` — PASS
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)