### PR TITLE
feat(mcp): official-only integration layer (git, filesystem, sqlite + opt-in datadog)

### DIFF
--- a/bundle-index.md
+++ b/bundle-index.md
@@ -123,6 +123,11 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 - [memory-seeds/commit-style-conventional.md](memory-seeds/commit-style-conventional.md): conventional-commits convention.
 - [memory-seeds/dash-free-writing.md](memory-seeds/dash-free-writing.md): the no-em/en-dash rule as a memory.
 
+### MCP integration
+
+- [mcp/manifest.yaml](mcp/manifest.yaml): canonical MCP server list (git, filesystem, sqlite, datadog).
+- [rules/mcp-usage.md](rules/mcp-usage.md): governance rule (lazy registration, graceful degradation, rejected servers).
+
 ### Cache economy (prompt caching)
 
 - [rules/cache-economy.md](rules/cache-economy.md): the static/dynamic partitioning rule for SKILL.md files.
@@ -146,10 +151,11 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 - [skills/regression-handler/SKILL.md](skills/regression-handler/SKILL.md): bug triage + linked-issue proposal.
 - [skills/release-tracker/SKILL.md](skills/release-tracker/SKILL.md): Release umbrella status computation.
 
-### Rules (14)
+### Rules (15)
 
 - [rules/adaptation.md](rules/adaptation.md): when to invoke adapt-system.
 - [rules/cache-economy.md](rules/cache-economy.md): static/dynamic partitioning of SKILL.md for prompt cache economics.
+- [rules/mcp-usage.md](rules/mcp-usage.md): official-only MCP integration (lazy registration, graceful degradation, rejected servers).
 - [rules/agent-boot.md](rules/agent-boot.md): session-start checks; scans for pending PR iteration loops and surfaces a resume prompt.
 - [rules/ambiguity-halt.md](rules/ambiguity-halt.md): halt-and-ask when state is weird.
 - [rules/issue-discovery.md](rules/issue-discovery.md): the three-clause intake rule (never guess; 2-4 options plus custom; delegate writes).

--- a/mcp/manifest.yaml
+++ b/mcp/manifest.yaml
@@ -1,0 +1,44 @@
+# Canonical MCP server manifest for agent-staff-engineer.
+# Every server listed here is maintained by Anthropic or a first-party vendor,
+# has active commits, broad adoption, and known-safe auth posture.
+# Community MCPs are out of scope until the ecosystem matures.
+
+$schemaVersion: "0.1.0"
+
+servers:
+  git:
+    tier: core
+    package: "@modelcontextprotocol/server-git"
+    install: "npx -y @modelcontextprotocol/server-git"
+    maintainer: "Anthropic"
+    description: "Git operations (log, diff, blame, status) via MCP."
+
+  filesystem:
+    tier: core
+    package: "@modelcontextprotocol/server-filesystem"
+    install: "npx -y @modelcontextprotocol/server-filesystem"
+    maintainer: "Anthropic"
+    description: "Filesystem read/write via MCP."
+
+  sqlite:
+    tier: core
+    package: "@modelcontextprotocol/server-sqlite"
+    install: "npx -y @modelcontextprotocol/server-sqlite"
+    maintainer: "Anthropic"
+    description: "SQLite queries via MCP. Local index for the canonical knowledge store (#35)."
+
+  datadog:
+    tier: observability
+    package: "datadog-mcp"
+    install: "See https://docs.datadoghq.com/service_management/operations/mcp-server/"
+    maintainer: "Datadog"
+    description: "Live metrics, traces, and logs during incident intake."
+    condition: "DATADOG_API_KEY is set in environment"
+
+rejected:
+  - name: "@modelcontextprotocol/server-memory"
+    reason: "Not team-shareable (JSON blob on one laptop). Replaced by canonical knowledge store (#35)."
+  - name: "@github/mcp-server-github"
+    reason: "All reviewer tools call REST RequestReviewers internally, which silently no-ops for bot reviewers. No GraphQL requestReviews tool. Adopting it regresses Copilot review workflows."
+  - name: "code-graph-mcp, code-pathfinder, mcp-ripgrep, ts-refactoring-mcp"
+    reason: "Fail the widely-supported + famous bar. Skills use Claude Code native Grep/Glob/Bash in isolated subagents instead."

--- a/mcp/manifest.yaml
+++ b/mcp/manifest.yaml
@@ -2,6 +2,11 @@
 # Every server listed here is maintained by Anthropic or a first-party vendor,
 # has active commits, broad adoption, and known-safe auth posture.
 # Community MCPs are out of scope until the ecosystem matures.
+#
+# Version policy: "latest" means npx resolves the current version at install
+# time. These reference servers are not published to npm with semver tags;
+# npx fetches from the GitHub-based registry. Pin to a specific commit/tag
+# when a known regression is discovered.
 
 $schemaVersion: "0.1.0"
 

--- a/mcp/manifest.yaml
+++ b/mcp/manifest.yaml
@@ -9,6 +9,7 @@ servers:
   git:
     tier: core
     package: "@modelcontextprotocol/server-git"
+    version: "latest"
     install: "npx -y @modelcontextprotocol/server-git"
     maintainer: "Anthropic"
     description: "Git operations (log, diff, blame, status) via MCP."
@@ -16,6 +17,7 @@ servers:
   filesystem:
     tier: core
     package: "@modelcontextprotocol/server-filesystem"
+    version: "latest"
     install: "npx -y @modelcontextprotocol/server-filesystem"
     maintainer: "Anthropic"
     description: "Filesystem read/write via MCP."
@@ -23,6 +25,7 @@ servers:
   sqlite:
     tier: core
     package: "@modelcontextprotocol/server-sqlite"
+    version: "latest"
     install: "npx -y @modelcontextprotocol/server-sqlite"
     maintainer: "Anthropic"
     description: "SQLite queries via MCP. Local index for the canonical knowledge store (#35)."

--- a/mcp/manifest.yaml
+++ b/mcp/manifest.yaml
@@ -15,6 +15,7 @@ servers:
     tier: core
     package: "@modelcontextprotocol/server-git"
     version: "latest"
+    autoRegistrable: true
     install: "npx -y @modelcontextprotocol/server-git"
     maintainer: "Anthropic"
     description: "Git operations (log, diff, blame, status) via MCP."
@@ -23,6 +24,7 @@ servers:
     tier: core
     package: "@modelcontextprotocol/server-filesystem"
     version: "latest"
+    autoRegistrable: true
     install: "npx -y @modelcontextprotocol/server-filesystem"
     maintainer: "Anthropic"
     description: "Filesystem read/write via MCP."
@@ -31,6 +33,7 @@ servers:
     tier: core
     package: "@modelcontextprotocol/server-sqlite"
     version: "latest"
+    autoRegistrable: true
     install: "npx -y @modelcontextprotocol/server-sqlite"
     maintainer: "Anthropic"
     description: "SQLite queries via MCP. Local index for the canonical knowledge store (#35)."
@@ -38,6 +41,7 @@ servers:
   datadog:
     tier: observability
     package: "datadog-mcp"
+    autoRegistrable: false
     install: "See https://docs.datadoghq.com/service_management/operations/mcp-server/"
     maintainer: "Datadog"
     description: "Live metrics, traces, and logs during incident intake."

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "schemas/",
     "scripts/",
     "examples/",
-    "design/"
+    "design/",
+    "mcp/"
   ],
   "ctxr": {
     "type": "agent",

--- a/rules/mcp-usage.md
+++ b/rules/mcp-usage.md
@@ -1,0 +1,46 @@
+---
+name: mcp-usage
+description: Governance rule for MCP server registration. Official-only servers, lazy registration, token-budget discipline, graceful degradation, security guardrails, freshness policy.
+portable: true
+scope: every session and every skill that declares mcp_required or mcp_optional
+---
+
+# MCP usage
+
+## The rule
+
+The bundle ships a conservative, official-only MCP integration layer. Every server in `mcp/manifest.yaml` is maintained by Anthropic or a first-party vendor, has active commits, broad adoption, and known-safe auth posture. Community MCPs are out of scope.
+
+### Clause 1: lazy registration
+
+Skills declare `mcp_required:` and `mcp_optional:` in their SKILL.md frontmatter. Core-tier servers (git, filesystem, sqlite) are always registered when the project's `mcp.tier` is `"core"` or `"core+observability"`. Optional-tier servers (datadog) activate only when their preconditions pass AND the consuming skill declares them.
+
+### Clause 2: token-budget discipline
+
+Each SKILL.md that declares an MCP must state expected schema overhead in a comment. The cache-control pass (#22) places server schemas inside the static cached block so they are not re-sent on every invocation.
+
+### Clause 3: graceful degradation
+
+Every skill that uses an MCP MUST have a fallback path using existing tools (`Bash`, `gh`, `Grep`, `Glob`, `Read`). No hard dependencies on MCP availability. When an MCP server is unavailable, the skill falls back silently and logs the fallback in its report.
+
+### Clause 4: security and correctness guardrails
+
+Any MCP requiring a secret loads it from the environment (e.g. `DATADOG_API_KEY`), never from `ops.config.json`. Official or first-party-vendor origin is necessary but not sufficient. Every first-party MCP is audited against the bundle's own requirements before inclusion.
+
+### Clause 5: freshness policy
+
+Server versions are pinned in `mcp/manifest.yaml`. Bumped via adapt-system cascade (`mcp:bump-versions`). Stale versions are flagged on session start (future: via remote-sync drift detection, #18).
+
+## Rejected servers
+
+| Server | Status | Reason |
+|--------|--------|--------|
+| `@modelcontextprotocol/server-memory` | rejected | Not team-shareable (JSON blob on one laptop). Replaced by the canonical knowledge store (#35): LLM Wiki as source of truth + SQLite MCP as local index. |
+| `@github/mcp-server-github` | rejected (first-party) | All three reviewer tools (`update_pull_request`, `request_pull_request_reviewers`, `request_copilot_review`) call REST `RequestReviewers` internally. The REST endpoint silently no-ops for bot reviewers. No GraphQL `requestReviews` tool, no `call_graphql` escape hatch. Adopting it regresses every Copilot-review workflow. Our `gh` CLI path uses the working GraphQL `requestReviews` mutation with `botIds`. Revisit if upstream adds GraphQL reviewer support. |
+| Community MCPs (code-graph-mcp, code-pathfinder, mcp-ripgrep, ts-refactoring-mcp) | rejected | Fail the "widely-supported + famous" bar. Skills like code-search and refactor-choreography use Claude Code native `Grep` / `Glob` / `Bash` in isolated subagents. Same ripgrep underneath, no fragile dependency. |
+
+## Related
+
+- [mcp/manifest.yaml](../mcp/manifest.yaml): the canonical server list with tiers and install commands.
+- [rules/cache-economy.md](cache-economy.md): MCP server schemas live inside the cached static block.
+- [rules/pr-iteration.md](pr-iteration.md): the `gh` CLI path that replaces the rejected GitHub MCP.

--- a/rules/mcp-usage.md
+++ b/rules/mcp-usage.md
@@ -29,7 +29,7 @@ Any MCP requiring a secret loads it from the environment (e.g. `DATADOG_API_KEY`
 
 ### Clause 5: freshness policy
 
-Server versions are pinned in `mcp/manifest.yaml`. Bumped via adapt-system cascade (`mcp:bump-versions`). Stale versions are flagged on session start (future: via remote-sync drift detection, #18).
+Server versions are tracked in `mcp/manifest.yaml`. Core servers use "latest" (npx resolves at install time from the GitHub-based registry; these reference servers are not published to npm with semver tags). Pin to a specific commit or tag when a known regression is discovered. Stale versions are flagged on session start (future: via remote-sync drift detection, #18).
 
 ## Rejected servers
 

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -552,7 +552,7 @@
           "type": "string",
           "enum": ["core", "core+observability", "none"],
           "default": "core",
-          "description": "core: git + filesystem + sqlite. core+observability: adds Datadog when DATADOG_API_KEY is set. none: no MCP servers."
+          "description": "core: git + filesystem + sqlite (auto-registered via npx). core+observability: core servers + Datadog marker in config (Datadog requires manual setup per vendor docs). none: no MCP servers."
         },
         "overrides": {
           "type": "object",

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -543,6 +543,25 @@
       }
     },
 
+    "mcp": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "MCP integration layer. Controls which official MCP servers are registered. See rules/mcp-usage.md and mcp/manifest.yaml.",
+      "properties": {
+        "tier": {
+          "type": "string",
+          "enum": ["core", "core+observability", "none"],
+          "default": "core",
+          "description": "core: git + filesystem + sqlite. core+observability: adds Datadog when DATADOG_API_KEY is set. none: no MCP servers."
+        },
+        "overrides": {
+          "type": "object",
+          "additionalProperties": { "type": "string", "enum": ["enabled", "disabled"] },
+          "description": "Per-server overrides. Keys are server names from mcp/manifest.yaml."
+        }
+      }
+    },
+
     "paths": {
       "type": "object",
       "required": ["plans_root", "plan_states", "dev_working_dir", "templates", "agent_bundle_dir", "wrappers"],

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -557,7 +557,7 @@
         "overrides": {
           "type": "object",
           "additionalProperties": { "type": "string", "enum": ["enabled", "disabled"] },
-          "description": "Per-server overrides. Keys are server names from mcp/manifest.yaml."
+          "description": "Per-server overrides. Keys are server names from mcp/manifest.yaml. Reserved for future use; not enforced by the current registration flow."
         }
       }
     },

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1538,7 +1538,7 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
       runbooks: ".development/shared/runbooks",
     },
     mcp: {
-      tier: (a.bootstrapMode ?? a.teamSize) === "solo" ? "core" : "core",
+      tier: (a.bootstrapMode ?? a.teamSize) === "solo" ? "core" : "core+observability",
     },
     wiki: {
       provider: "@ctxr/skill-llm-wiki",

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1537,6 +1537,9 @@ export function compose(d, a, bundleRef = ".claude/agents/agent-staff-engineer")
       reports: ".development/shared/reports",
       runbooks: ".development/shared/runbooks",
     },
+    mcp: {
+      tier: (a.bootstrapMode ?? a.teamSize) === "solo" ? "core" : "core",
+    },
     wiki: {
       provider: "@ctxr/skill-llm-wiki",
       mode: "in-place",

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -979,9 +979,12 @@ if (MODE === "apply" || MODE === "update") {
   const mcpTier = opsConfig.mcp?.tier ?? "core";
   if (mcpTier !== "none") {
     const { registerMcpServers } = await import("./lib/mcp/register.mjs");
-    const { tier, servers, mcpJsonPath } = await registerMcpServers(TARGET, mcpTier);
+    const { tier, servers, skipped } = await registerMcpServers(TARGET, mcpTier);
     if (servers.length > 0) {
       process.stdout.write(`mcp: registered ${servers.join(", ")} (tier: ${tier})\n`);
+    }
+    if (skipped && skipped.length > 0) {
+      process.stdout.write(`mcp: skipped ${skipped.join(", ")} (requires manual setup)\n`);
     }
   }
 }

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -978,13 +978,17 @@ for (const w of writes) {
 if (MODE === "apply" || MODE === "update") {
   const mcpTier = opsConfig.mcp?.tier ?? "core";
   if (mcpTier !== "none") {
-    const { registerMcpServers } = await import("./lib/mcp/register.mjs");
-    const { tier, servers, skipped } = await registerMcpServers(TARGET, mcpTier);
-    if (servers.length > 0) {
-      process.stdout.write(`mcp: registered ${servers.join(", ")} (tier: ${tier})\n`);
-    }
-    if (skipped && skipped.length > 0) {
-      process.stdout.write(`mcp: skipped ${skipped.join(", ")} (requires manual setup)\n`);
+    try {
+      const { registerMcpServers } = await import("./lib/mcp/register.mjs");
+      const { tier, servers, skipped } = await registerMcpServers(TARGET, mcpTier);
+      if (servers.length > 0) {
+        process.stdout.write(`mcp: registered ${servers.join(", ")} (tier: ${tier})\n`);
+      }
+      if (skipped && skipped.length > 0) {
+        process.stdout.write(`mcp: skipped ${skipped.join(", ")} (requires manual setup)\n`);
+      }
+    } catch (e) {
+      process.stderr.write(`mcp: registration failed (non-fatal): ${e.message}\n`);
     }
   }
 }

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -988,7 +988,7 @@ if (MODE === "apply" || MODE === "update") {
         process.stdout.write(`mcp: skipped ${skipped.join(", ")} (requires manual setup)\n`);
       }
     } catch (e) {
-      process.stderr.write(`mcp: registration failed (non-fatal): ${e.message}\n`);
+      process.stderr.write(`mcp: registration failed (non-fatal): ${e?.message ?? e}\n`);
     }
   }
 }

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -974,6 +974,18 @@ for (const w of writes) {
   }
 }
 
+// MCP server registration.
+if (MODE === "apply" || MODE === "update") {
+  const mcpTier = opsConfig.mcp?.tier ?? "core";
+  if (mcpTier !== "none") {
+    const { registerMcpServers } = await import("./lib/mcp/register.mjs");
+    const { tier, servers, mcpJsonPath } = await registerMcpServers(TARGET, mcpTier);
+    if (servers.length > 0) {
+      process.stdout.write(`mcp: registered ${servers.join(", ")} (tier: ${tier})\n`);
+    }
+  }
+}
+
 // Manifest.
 // Deferred config write: if the code-review probe changed the provider
 // in memory, persist it now — after all preflights, wrapper writes, and

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -990,6 +990,30 @@ if (MODE === "apply" || MODE === "update") {
     } catch (e) {
       process.stderr.write(`mcp: registration failed (non-fatal): ${e?.message ?? e}\n`);
     }
+  } else {
+    // tier=none: remove managed MCP entries from .mcp.json if present.
+    try {
+      const { loadManifest } = await import("./lib/mcp/register.mjs");
+      const mcpJsonPath = join(TARGET, ".mcp.json");
+      const existing = JSON.parse(await readFile(mcpJsonPath, "utf8").catch(() => "{}"));
+      if (existing.mcpServers && typeof existing.mcpServers === "object") {
+        const manifest = await loadManifest();
+        const managedNames = Object.keys(manifest.servers ?? {});
+        let removed = 0;
+        for (const name of managedNames) {
+          if (name in existing.mcpServers) {
+            delete existing.mcpServers[name];
+            removed++;
+          }
+        }
+        if (removed > 0) {
+          await atomicWriteJson(mcpJsonPath, existing);
+          process.stdout.write(`mcp: removed ${removed} managed server(s) from .mcp.json (tier: none)\n`);
+        }
+      }
+    } catch {
+      // No .mcp.json or parse error; nothing to clean up.
+    }
   }
 }
 

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -996,7 +996,7 @@ if (MODE === "apply" || MODE === "update") {
       const { loadManifest } = await import("./lib/mcp/register.mjs");
       const mcpJsonPath = join(TARGET, ".mcp.json");
       const existing = JSON.parse(await readFile(mcpJsonPath, "utf8").catch(() => "{}"));
-      if (existing.mcpServers && typeof existing.mcpServers === "object") {
+      if (existing.mcpServers && typeof existing.mcpServers === "object" && !Array.isArray(existing.mcpServers)) {
         const manifest = await loadManifest();
         const managedNames = Object.keys(manifest.servers ?? {});
         let removed = 0;

--- a/scripts/lib/mcp/probe.mjs
+++ b/scripts/lib/mcp/probe.mjs
@@ -7,9 +7,9 @@
  * Returns { datadogAvailable: boolean }.
  */
 export function probeEnvironment() {
-  const ddKey = process.env.DATADOG_API_KEY;
+  const ddKey = (process.env.DATADOG_API_KEY ?? "").trim();
   return {
-    datadogAvailable: typeof ddKey === "string" && ddKey.length > 0,
+    datadogAvailable: ddKey.length > 0,
   };
 }
 

--- a/scripts/lib/mcp/probe.mjs
+++ b/scripts/lib/mcp/probe.mjs
@@ -1,0 +1,28 @@
+// lib/mcp/probe.mjs
+// Detect MCP preconditions from the environment.
+// Never persists secrets to disk.
+
+/**
+ * Probe the environment for MCP preconditions.
+ * Returns { datadogAvailable: boolean }.
+ */
+export function probeEnvironment() {
+  const ddKey = process.env.DATADOG_API_KEY;
+  return {
+    datadogAvailable: typeof ddKey === "string" && ddKey.length > 0,
+  };
+}
+
+/**
+ * Determine the effective MCP tier based on config + environment.
+ * @param {string} configuredTier - from ops.config.json mcp.tier ("core" | "core+observability" | "none")
+ * @param {object} env - result of probeEnvironment()
+ * @returns {string} effective tier
+ */
+export function resolveEffectiveTier(configuredTier, env) {
+  if (configuredTier === "none") return "none";
+  if (configuredTier === "core+observability") {
+    return env.datadogAvailable ? "core+observability" : "core";
+  }
+  return "core";
+}

--- a/scripts/lib/mcp/register.mjs
+++ b/scripts/lib/mcp/register.mjs
@@ -75,10 +75,13 @@ export async function writeMcpJson(targetDir, mcpConfig) {
     // No existing .mcp.json or parse error; start fresh.
   }
 
+  const existingServers = (existing.mcpServers && typeof existing.mcpServers === "object" && !Array.isArray(existing.mcpServers))
+    ? existing.mcpServers
+    : {};
   const merged = {
     ...existing,
     mcpServers: {
-      ...(existing.mcpServers ?? {}),
+      ...existingServers,
       ...mcpConfig.mcpServers,
     },
   };

--- a/scripts/lib/mcp/register.mjs
+++ b/scripts/lib/mcp/register.mjs
@@ -20,7 +20,7 @@ const MANIFEST_PATH = join(__dirname, "..", "..", "..", "mcp", "manifest.yaml");
 export async function loadManifest(manifestPath = MANIFEST_PATH) {
   const content = await readFile(manifestPath, "utf8");
   const doc = yamlLoad(content);
-  if (!doc || typeof doc.servers !== "object") {
+  if (!doc || !doc.servers || typeof doc.servers !== "object" || Array.isArray(doc.servers)) {
     throw new TypeError("MCP manifest must have a top-level 'servers' object");
   }
   return doc;

--- a/scripts/lib/mcp/register.mjs
+++ b/scripts/lib/mcp/register.mjs
@@ -102,7 +102,13 @@ export async function registerMcpServers(targetDir, configuredTier = "core", man
   }
 
   const mcpConfig = buildMcpConfig(servers, targetDir);
-  const mcpJsonPath = await writeMcpJson(targetDir, mcpConfig);
+  const registeredNames = Object.keys(mcpConfig.mcpServers);
+  const skippedNames = servers.filter((s) => !registeredNames.includes(s.name)).map((s) => s.name);
 
-  return { tier, servers: servers.map((s) => s.name), mcpJsonPath };
+  if (registeredNames.length === 0) {
+    return { tier, servers: [], skipped: skippedNames, mcpJsonPath: null };
+  }
+
+  const mcpJsonPath = await writeMcpJson(targetDir, mcpConfig);
+  return { tier, servers: registeredNames, skipped: skippedNames, mcpJsonPath };
 }

--- a/scripts/lib/mcp/register.mjs
+++ b/scripts/lib/mcp/register.mjs
@@ -52,9 +52,11 @@ export function selectServers(manifest, effectiveTier) {
 export function buildMcpConfig(servers, targetDir) {
   const mcpServers = {};
   for (const server of servers) {
-    // Only auto-register servers with scoped npm packages (@org/pkg).
-    // Vendor-specific servers (datadog) require manual setup per their docs
-    // and are reported as "skipped" in the install output.
+    // Only auto-register servers with scoped npm packages (@org/pkg)
+    // that can be launched via npx. Vendor-specific servers (datadog)
+    // require manual setup per their docs and are reported as "skipped"
+    // in the install output. The tier config records the INTENT
+    // (core+observability); actual datadog activation is manual.
     if (!server.package || !server.package.startsWith("@")) continue;
     mcpServers[server.name] = {
       command: "npx",

--- a/scripts/lib/mcp/register.mjs
+++ b/scripts/lib/mcp/register.mjs
@@ -15,11 +15,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const MANIFEST_PATH = join(__dirname, "..", "..", "..", "mcp", "manifest.yaml");
 
 /**
- * Load and parse the MCP manifest.
+ * Load and parse the MCP manifest. Validates the required top-level keys.
  */
 export async function loadManifest(manifestPath = MANIFEST_PATH) {
   const content = await readFile(manifestPath, "utf8");
-  return yamlLoad(content);
+  const doc = yamlLoad(content);
+  if (!doc || typeof doc.servers !== "object") {
+    throw new TypeError("MCP manifest must have a top-level 'servers' object");
+  }
+  return doc;
 }
 
 /**
@@ -47,6 +51,9 @@ export function selectServers(manifest, effectiveTier) {
 export function buildMcpConfig(servers, targetDir) {
   const mcpServers = {};
   for (const server of servers) {
+    // Only register servers with npx-compatible packages (starts with @).
+    // Vendor-specific servers (datadog) require manual setup per their docs.
+    if (!server.package || !server.package.startsWith("@")) continue;
     mcpServers[server.name] = {
       command: "npx",
       args: ["-y", server.package, ...(server.name === "filesystem" ? [targetDir] : [])],

--- a/scripts/lib/mcp/register.mjs
+++ b/scripts/lib/mcp/register.mjs
@@ -51,8 +51,9 @@ export function selectServers(manifest, effectiveTier) {
 export function buildMcpConfig(servers, targetDir) {
   const mcpServers = {};
   for (const server of servers) {
-    // Only register servers with npx-compatible packages (starts with @).
-    // Vendor-specific servers (datadog) require manual setup per their docs.
+    // Only auto-register servers with scoped npm packages (@org/pkg).
+    // Vendor-specific servers (datadog) require manual setup per their docs
+    // and are reported as "skipped" in the install output.
     if (!server.package || !server.package.startsWith("@")) continue;
     mcpServers[server.name] = {
       command: "npx",

--- a/scripts/lib/mcp/register.mjs
+++ b/scripts/lib/mcp/register.mjs
@@ -52,12 +52,10 @@ export function selectServers(manifest, effectiveTier) {
 export function buildMcpConfig(servers, targetDir) {
   const mcpServers = {};
   for (const server of servers) {
-    // Only auto-register servers with scoped npm packages (@org/pkg)
-    // that can be launched via npx. Vendor-specific servers (datadog)
-    // require manual setup per their docs and are reported as "skipped"
-    // in the install output. The tier config records the INTENT
-    // (core+observability); actual datadog activation is manual.
-    if (!server.package || !server.package.startsWith("@")) continue;
+    // Only auto-register servers marked autoRegistrable in the manifest.
+    // Vendor-specific servers (datadog) require manual setup per their
+    // docs and are reported as "skipped" in the install output.
+    if (!server.autoRegistrable) continue;
     mcpServers[server.name] = {
       command: "npx",
       args: ["-y", server.package, ...(server.name === "filesystem" ? [targetDir] : [])],

--- a/scripts/lib/mcp/register.mjs
+++ b/scripts/lib/mcp/register.mjs
@@ -2,7 +2,8 @@
 // Reads mcp/manifest.yaml and writes a project-level .mcp.json
 // with the servers appropriate for the configured tier.
 
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { atomicWriteJson } from "../fsx.mjs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
@@ -87,7 +88,7 @@ export async function writeMcpJson(targetDir, mcpConfig) {
     },
   };
 
-  await writeFile(mcpJsonPath, JSON.stringify(merged, null, 2) + "\n");
+  await atomicWriteJson(mcpJsonPath, merged);
   return mcpJsonPath;
 }
 

--- a/scripts/lib/mcp/register.mjs
+++ b/scripts/lib/mcp/register.mjs
@@ -1,0 +1,101 @@
+// lib/mcp/register.mjs
+// Reads mcp/manifest.yaml and writes a project-level .mcp.json
+// with the servers appropriate for the configured tier.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { probeEnvironment, resolveEffectiveTier } from "./probe.mjs";
+
+const require = createRequire(import.meta.url);
+const { load: yamlLoad } = require("js-yaml");
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = join(__dirname, "..", "..", "..", "mcp", "manifest.yaml");
+
+/**
+ * Load and parse the MCP manifest.
+ */
+export async function loadManifest(manifestPath = MANIFEST_PATH) {
+  const content = await readFile(manifestPath, "utf8");
+  return yamlLoad(content);
+}
+
+/**
+ * Build the list of servers to register based on the effective tier.
+ * Returns array of { name, server config }.
+ */
+export function selectServers(manifest, effectiveTier) {
+  if (effectiveTier === "none") return [];
+
+  const servers = [];
+  for (const [name, def] of Object.entries(manifest.servers ?? {})) {
+    if (def.tier === "core") {
+      servers.push({ name, ...def });
+    } else if (def.tier === "observability" && effectiveTier === "core+observability") {
+      servers.push({ name, ...def });
+    }
+  }
+  return servers;
+}
+
+/**
+ * Build the .mcp.json content for the selected servers.
+ * Format follows Claude Code's MCP configuration schema.
+ */
+export function buildMcpConfig(servers, targetDir) {
+  const mcpServers = {};
+  for (const server of servers) {
+    mcpServers[server.name] = {
+      command: "npx",
+      args: ["-y", server.package, ...(server.name === "filesystem" ? [targetDir] : [])],
+    };
+  }
+  return { mcpServers };
+}
+
+/**
+ * Write .mcp.json to the target project.
+ * Merges with existing entries (preserves user-added servers).
+ */
+export async function writeMcpJson(targetDir, mcpConfig) {
+  const mcpJsonPath = join(targetDir, ".mcp.json");
+  let existing = {};
+  try {
+    existing = JSON.parse(await readFile(mcpJsonPath, "utf8"));
+  } catch {
+    // No existing .mcp.json or parse error; start fresh.
+  }
+
+  const merged = {
+    ...existing,
+    mcpServers: {
+      ...(existing.mcpServers ?? {}),
+      ...mcpConfig.mcpServers,
+    },
+  };
+
+  await writeFile(mcpJsonPath, JSON.stringify(merged, null, 2) + "\n");
+  return mcpJsonPath;
+}
+
+/**
+ * Full registration flow: load manifest, probe env, select servers, write config.
+ * Returns { tier, servers, mcpJsonPath }.
+ */
+export async function registerMcpServers(targetDir, configuredTier = "core", manifestPath = MANIFEST_PATH) {
+  const manifest = await loadManifest(manifestPath);
+  const env = probeEnvironment();
+  const tier = resolveEffectiveTier(configuredTier, env);
+  const servers = selectServers(manifest, tier);
+
+  if (servers.length === 0) {
+    return { tier, servers: [], mcpJsonPath: null };
+  }
+
+  const mcpConfig = buildMcpConfig(servers, targetDir);
+  const mcpJsonPath = await writeMcpJson(targetDir, mcpConfig);
+
+  return { tier, servers: servers.map((s) => s.name), mcpJsonPath };
+}

--- a/tests/mcp/mcp.test.mjs
+++ b/tests/mcp/mcp.test.mjs
@@ -67,6 +67,14 @@ describe("mcp/register", () => {
     assert.deepEqual(selectServers(manifest, "none"), []);
   });
 
+  it("buildMcpConfig skips non-scoped packages (datadog)", async () => {
+    const manifest = await loadManifest(MANIFEST_PATH);
+    const servers = selectServers(manifest, "core+observability");
+    const config = buildMcpConfig(servers, "/tmp/test");
+    assert.ok(!config.mcpServers.datadog, "datadog should be skipped (not an @-scoped package)");
+    assert.ok(config.mcpServers.git, "core servers should be present");
+  });
+
   it("buildMcpConfig produces Claude Code MCP format", async () => {
     const manifest = await loadManifest(MANIFEST_PATH);
     const servers = selectServers(manifest, "core");

--- a/tests/mcp/mcp.test.mjs
+++ b/tests/mcp/mcp.test.mjs
@@ -1,6 +1,5 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { probeEnvironment, resolveEffectiveTier } from "../../scripts/lib/mcp/probe.mjs";

--- a/tests/mcp/mcp.test.mjs
+++ b/tests/mcp/mcp.test.mjs
@@ -67,11 +67,11 @@ describe("mcp/register", () => {
     assert.deepEqual(selectServers(manifest, "none"), []);
   });
 
-  it("buildMcpConfig skips non-scoped packages (datadog)", async () => {
+  it("buildMcpConfig skips non-autoRegistrable servers (datadog)", async () => {
     const manifest = await loadManifest(MANIFEST_PATH);
     const servers = selectServers(manifest, "core+observability");
     const config = buildMcpConfig(servers, "/tmp/test");
-    assert.ok(!config.mcpServers.datadog, "datadog should be skipped (not an @-scoped package)");
+    assert.ok(!config.mcpServers.datadog, "datadog should be skipped (autoRegistrable: false)");
     assert.ok(config.mcpServers.git, "core servers should be present");
   });
 

--- a/tests/mcp/mcp.test.mjs
+++ b/tests/mcp/mcp.test.mjs
@@ -1,0 +1,80 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { probeEnvironment, resolveEffectiveTier } from "../../scripts/lib/mcp/probe.mjs";
+import { loadManifest, selectServers, buildMcpConfig } from "../../scripts/lib/mcp/register.mjs";
+
+const BUNDLE = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const MANIFEST_PATH = join(BUNDLE, "mcp", "manifest.yaml");
+
+describe("mcp/probe", () => {
+  it("probeEnvironment returns datadogAvailable based on env var", () => {
+    const original = process.env.DATADOG_API_KEY;
+    try {
+      process.env.DATADOG_API_KEY = "test-key";
+      assert.equal(probeEnvironment().datadogAvailable, true);
+      delete process.env.DATADOG_API_KEY;
+      assert.equal(probeEnvironment().datadogAvailable, false);
+      process.env.DATADOG_API_KEY = "";
+      assert.equal(probeEnvironment().datadogAvailable, false);
+    } finally {
+      if (original !== undefined) process.env.DATADOG_API_KEY = original;
+      else delete process.env.DATADOG_API_KEY;
+    }
+  });
+
+  it("resolveEffectiveTier downgrades observability when datadog unavailable", () => {
+    assert.equal(resolveEffectiveTier("core+observability", { datadogAvailable: false }), "core");
+    assert.equal(resolveEffectiveTier("core+observability", { datadogAvailable: true }), "core+observability");
+  });
+
+  it("resolveEffectiveTier passes through core and none", () => {
+    assert.equal(resolveEffectiveTier("core", { datadogAvailable: true }), "core");
+    assert.equal(resolveEffectiveTier("none", { datadogAvailable: true }), "none");
+  });
+});
+
+describe("mcp/register", () => {
+  it("loads the bundled manifest", async () => {
+    const manifest = await loadManifest(MANIFEST_PATH);
+    assert.ok(manifest.servers.git);
+    assert.ok(manifest.servers.filesystem);
+    assert.ok(manifest.servers.sqlite);
+    assert.ok(manifest.servers.datadog);
+    assert.ok(Array.isArray(manifest.rejected));
+  });
+
+  it("selectServers returns core servers for core tier", async () => {
+    const manifest = await loadManifest(MANIFEST_PATH);
+    const servers = selectServers(manifest, "core");
+    const names = servers.map((s) => s.name);
+    assert.ok(names.includes("git"));
+    assert.ok(names.includes("filesystem"));
+    assert.ok(names.includes("sqlite"));
+    assert.ok(!names.includes("datadog"));
+  });
+
+  it("selectServers includes datadog for core+observability tier", async () => {
+    const manifest = await loadManifest(MANIFEST_PATH);
+    const servers = selectServers(manifest, "core+observability");
+    const names = servers.map((s) => s.name);
+    assert.ok(names.includes("datadog"));
+  });
+
+  it("selectServers returns empty for none tier", async () => {
+    const manifest = await loadManifest(MANIFEST_PATH);
+    assert.deepEqual(selectServers(manifest, "none"), []);
+  });
+
+  it("buildMcpConfig produces Claude Code MCP format", async () => {
+    const manifest = await loadManifest(MANIFEST_PATH);
+    const servers = selectServers(manifest, "core");
+    const config = buildMcpConfig(servers, "/tmp/test");
+    assert.ok(config.mcpServers.git);
+    assert.equal(config.mcpServers.git.command, "npx");
+    assert.ok(config.mcpServers.filesystem);
+    assert.ok(config.mcpServers.sqlite);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `mcp/manifest.yaml`: canonical server list (3 core Anthropic official + 1 opt-in Datadog)
- Add `rules/mcp-usage.md`: 5-clause governance rule + rejected servers table (Memory MCP, GitHub MCP, community MCPs)
- Add `scripts/lib/mcp/register.mjs`: writes `.mcp.json` with tier-appropriate servers
- Add `scripts/lib/mcp/probe.mjs`: detects `DATADOG_API_KEY` in env (never persists)
- Schema gains `mcp.tier` ("core", "core+observability", "none") + `mcp.overrides`
- Install.mjs calls register.mjs after install. Bootstrap compose emits mcp.tier.
- 8 new tests (probe + register + manifest parsing)

Closes #34

## Test plan

- [x] `node --test tests/mcp/mcp.test.mjs` — 8/8 pass
- [x] Full suite — 888/888 pass
- [x] `npm run validate` — PASS
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)