### PR TITLE
feat(observability): per-skill token accounting + weekly metrics report (#32)

### DIFF
--- a/bundle-index.md
+++ b/bundle-index.md
@@ -125,8 +125,18 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 
 ### Per-skill metrics + weekly rollup
 
+**Status: library-only in this PR.** The recorder, aggregator, and
+weekly-report CLI all ship here, but the per-skill dispatch sites that
+would call `record()` on every invocation are NOT yet wired up — the
+bundle has no centralised dispatch layer today. As a result, until the
+follow-up wiring lands, no JSONL records are produced automatically;
+the helpers can be invoked manually or through tests, and the CLI
+runs against any pre-existing JSONL the user (or a future version)
+deposits under `.claude/state/metrics/`. The schema field
+`observability.metrics_enabled` is reserved for that follow-up.
+
 - [scripts/lib/metrics/record.mjs](scripts/lib/metrics/record.mjs): per-invocation recorder. Builds + writes one JSONL line per skill invocation under `.claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl`. Cost computed from token counts + a per-model rate table.
-- [scripts/lib/metrics/aggregate.mjs](scripts/lib/metrics/aggregate.mjs): daily JSONL -> ISO-week rollup. Sub-invocations fold into the parent's skill row; thresholds drive red-flag annotations; output is deterministic across re-runs.
+- [scripts/lib/metrics/aggregate.mjs](scripts/lib/metrics/aggregate.mjs): daily JSONL -> ISO-week rollup. Sub-invocations fold into the parent's skill row when the parent is in-window; orphan subs are dropped from the rollup. Thresholds drive red-flag annotations; output is deterministic across re-runs.
 - [scripts/report_metrics.mjs](scripts/report_metrics.mjs): CLI entrypoint (`node scripts/report_metrics.mjs --weekly`). Writes JSON + markdown to `.claude/state/metrics-weekly/<yyyy>-Www.{json,md}` — under `.claude/state/`, NOT under `.development/**`, since the latter is wiki-governed (rules/llm-wiki.md) and requires a nested-scalable layout that flat per-week leaves do not fit. Echoes the markdown to stdout.
 - [schemas/metrics-record.schema.json](schemas/metrics-record.schema.json): per-invocation record shape (additionalProperties: false; no PII).
 - [schemas/metrics-weekly.schema.json](schemas/metrics-weekly.schema.json): rollup shape.

--- a/bundle-index.md
+++ b/bundle-index.md
@@ -127,7 +127,7 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 
 - [scripts/lib/metrics/record.mjs](scripts/lib/metrics/record.mjs): per-invocation recorder. Builds + writes one JSONL line per skill invocation under `.claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl`. Cost computed from token counts + a per-model rate table.
 - [scripts/lib/metrics/aggregate.mjs](scripts/lib/metrics/aggregate.mjs): daily JSONL -> ISO-week rollup. Sub-invocations fold into the parent's skill row; thresholds drive red-flag annotations; output is deterministic across re-runs.
-- [scripts/report_metrics.mjs](scripts/report_metrics.mjs): CLI entrypoint (`node scripts/report_metrics.mjs --weekly`). Writes JSON + markdown to `.development/local/metrics/<yyyy>-Www.{json,md}` (local because flat per-week leaves don't fit the wiki's nested-scalable layout; promoting curated rollups to `.development/shared/` is a project's choice). Echoes the markdown to stdout.
+- [scripts/report_metrics.mjs](scripts/report_metrics.mjs): CLI entrypoint (`node scripts/report_metrics.mjs --weekly`). Writes JSON + markdown to `.claude/state/metrics-weekly/<yyyy>-Www.{json,md}` — under `.claude/state/`, NOT under `.development/**`, since the latter is wiki-governed (rules/llm-wiki.md) and requires a nested-scalable layout that flat per-week leaves do not fit. Echoes the markdown to stdout.
 - [schemas/metrics-record.schema.json](schemas/metrics-record.schema.json): per-invocation record shape (additionalProperties: false; no PII).
 - [schemas/metrics-weekly.schema.json](schemas/metrics-weekly.schema.json): rollup shape.
 

--- a/bundle-index.md
+++ b/bundle-index.md
@@ -123,6 +123,14 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 - [memory-seeds/commit-style-conventional.md](memory-seeds/commit-style-conventional.md): conventional-commits convention.
 - [memory-seeds/dash-free-writing.md](memory-seeds/dash-free-writing.md): the no-em/en-dash rule as a memory.
 
+### Per-skill metrics + weekly rollup
+
+- [scripts/lib/metrics/record.mjs](scripts/lib/metrics/record.mjs): per-invocation recorder. Builds + writes one JSONL line per skill invocation under `.claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl`. Cost computed from token counts + a per-model rate table.
+- [scripts/lib/metrics/aggregate.mjs](scripts/lib/metrics/aggregate.mjs): daily JSONL -> ISO-week rollup. Sub-invocations fold into the parent's skill row; thresholds drive red-flag annotations; output is deterministic across re-runs.
+- [scripts/report_metrics.mjs](scripts/report_metrics.mjs): CLI entrypoint (`node scripts/report_metrics.mjs --weekly`). Writes JSON + markdown to `.development/shared/reports/metrics/<yyyy>-Www.{json,md}` and echoes the markdown to stdout.
+- [schemas/metrics-record.schema.json](schemas/metrics-record.schema.json): per-invocation record shape (additionalProperties: false; no PII).
+- [schemas/metrics-weekly.schema.json](schemas/metrics-weekly.schema.json): rollup shape.
+
 ### MCP integration
 
 - [mcp/manifest.yaml](mcp/manifest.yaml): canonical MCP server list (git, filesystem, sqlite, datadog).

--- a/bundle-index.md
+++ b/bundle-index.md
@@ -127,7 +127,7 @@ Most skills are triggered by a concrete intent. Map the user's ask to the minima
 
 - [scripts/lib/metrics/record.mjs](scripts/lib/metrics/record.mjs): per-invocation recorder. Builds + writes one JSONL line per skill invocation under `.claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl`. Cost computed from token counts + a per-model rate table.
 - [scripts/lib/metrics/aggregate.mjs](scripts/lib/metrics/aggregate.mjs): daily JSONL -> ISO-week rollup. Sub-invocations fold into the parent's skill row; thresholds drive red-flag annotations; output is deterministic across re-runs.
-- [scripts/report_metrics.mjs](scripts/report_metrics.mjs): CLI entrypoint (`node scripts/report_metrics.mjs --weekly`). Writes JSON + markdown to `.development/shared/reports/metrics/<yyyy>-Www.{json,md}` and echoes the markdown to stdout.
+- [scripts/report_metrics.mjs](scripts/report_metrics.mjs): CLI entrypoint (`node scripts/report_metrics.mjs --weekly`). Writes JSON + markdown to `.development/local/metrics/<yyyy>-Www.{json,md}` (local because flat per-week leaves don't fit the wiki's nested-scalable layout; promoting curated rollups to `.development/shared/` is a project's choice). Echoes the markdown to stdout.
 - [schemas/metrics-record.schema.json](schemas/metrics-record.schema.json): per-invocation record shape (additionalProperties: false; no PII).
 - [schemas/metrics-weekly.schema.json](schemas/metrics-weekly.schema.json): rollup shape.
 

--- a/schemas/metrics-record.schema.json
+++ b/schemas/metrics-record.schema.json
@@ -35,12 +35,12 @@
     "started_at": {
       "type": "string",
       "format": "date-time",
-      "description": "ISO 8601 UTC timestamp at invocation start."
+      "description": "ISO 8601 timestamp at invocation start. Both Z-form (e.g. `2026-04-28T10:00:00Z`) and explicit-offset form (e.g. `2026-04-28T05:00:00-05:00`) are accepted; the writer normalises offset timestamps to the corresponding UTC calendar day for the per-day JSONL filename."
     },
     "ended_at": {
       "type": "string",
       "format": "date-time",
-      "description": "ISO 8601 UTC timestamp at invocation end."
+      "description": "ISO 8601 timestamp at invocation end. Same shape rules as started_at (Z-form or explicit-offset)."
     },
     "model": {
       "type": "string",

--- a/schemas/metrics-record.schema.json
+++ b/schemas/metrics-record.schema.json
@@ -28,7 +28,8 @@
     "skill": {
       "type": "string",
       "minLength": 1,
-      "description": "Skill name (e.g. dev-loop, pr-iteration, incident-intake)."
+      "pattern": "^[a-z0-9][a-z0-9_-]*$",
+      "description": "Skill name (e.g. dev-loop, pr-iteration, incident-intake). Lowercase alphanumeric + underscore + dash only; the writer (scripts/lib/metrics/record.mjs::writeRecord) enforces the same pattern at write time. The pattern is also a path-traversal guard since the per-day JSONL filename is derived from the started_at date, not the skill, but the skill name still appears in error messages and aggregator output where we want a stable shape."
     },
     "started_at": {
       "type": "string",

--- a/schemas/metrics-record.schema.json
+++ b/schemas/metrics-record.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ctxr.dev/schemas/metrics-record.schema.json",
+  "title": "Per-skill invocation metrics record",
+  "description": "One JSONL line per skill invocation under .claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl. additionalProperties is false at every layer so no PII or unintended fields can leak in.",
+  "type": "object",
+  "required": [
+    "trace_id",
+    "skill",
+    "started_at",
+    "ended_at",
+    "tokens",
+    "cost_usd",
+    "exit"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "trace_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier for this invocation. Sub-invocations carry the parent's trace_id in parent_trace_id."
+    },
+    "parent_trace_id": {
+      "type": ["string", "null"],
+      "description": "Set on sub-invocations (subagent or pre-hydrate); null for top-level invocations.",
+      "default": null
+    },
+    "skill": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Skill name (e.g. dev-loop, pr-iteration, incident-intake)."
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp at invocation start."
+    },
+    "ended_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp at invocation end."
+    },
+    "model": {
+      "type": "string",
+      "description": "Public model identifier (e.g. claude-opus-4-7); optional but recommended for cost-rate lookups."
+    },
+    "tokens": {
+      "type": "object",
+      "required": ["input", "output", "cache_read", "cache_write"],
+      "additionalProperties": false,
+      "properties": {
+        "input": { "type": "integer", "minimum": 0 },
+        "output": { "type": "integer", "minimum": 0 },
+        "cache_read": { "type": "integer", "minimum": 0 },
+        "cache_write": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "cost_usd": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Total cost computed from documented per-model rates. 6 decimal places of precision is plenty."
+    },
+    "subagents": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "count": { "type": "integer", "minimum": 0 },
+        "total_tokens": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "mcp_servers_used": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true,
+      "description": "MCP server names touched during this invocation. Names only; no payloads."
+    },
+    "exit": {
+      "type": "string",
+      "enum": ["success", "halt", "fault", "error", "cancelled"],
+      "description": "Terminal status. 'halt' is a documented soft-stop (e.g. ambiguity-halt); 'fault' is in-flow; 'error' is environment / pre-condition."
+    }
+  }
+}

--- a/schemas/metrics-record.schema.json
+++ b/schemas/metrics-record.schema.json
@@ -17,12 +17,13 @@
   "properties": {
     "trace_id": {
       "type": "string",
-      "minLength": 1,
-      "description": "Stable identifier for this invocation. Sub-invocations carry the parent's trace_id in parent_trace_id."
+      "pattern": "^t-[0-9a-f]{16}$",
+      "description": "Stable identifier for this invocation. Format: `t-` prefix + 16 lowercase hex chars (matches scripts/lib/metrics/record.mjs::newTraceId). Sub-invocations carry the parent's trace_id in parent_trace_id; the writer enforces the same pattern at write time."
     },
     "parent_trace_id": {
       "type": ["string", "null"],
-      "description": "Set on sub-invocations (subagent or pre-hydrate); null for top-level invocations.",
+      "pattern": "^t-[0-9a-f]{16}$",
+      "description": "Set on sub-invocations (subagent or pre-hydrate); null for top-level invocations. Same shape as trace_id when present.",
       "default": null
     },
     "skill": {

--- a/schemas/metrics-record.schema.json
+++ b/schemas/metrics-record.schema.json
@@ -65,6 +65,8 @@
     "subagents": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["count", "total_tokens"],
+      "description": "When present, BOTH count and total_tokens are required. The writer (scripts/lib/metrics/record.mjs::writeRecord) enforces the same rule at write time.",
       "properties": {
         "count": { "type": "integer", "minimum": 0 },
         "total_tokens": { "type": "integer", "minimum": 0 }

--- a/schemas/metrics-weekly.schema.json
+++ b/schemas/metrics-weekly.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ctxr.dev/schemas/metrics-weekly.schema.json",
   "title": "Weekly metrics rollup",
-  "description": "Aggregator output. One object per ISO week. By default scripts/report_metrics.mjs writes under .development/local/metrics/<yyyy>-Www.json (the markdown report at <yyyy>-Www.md is rendered from this). Local rather than shared because flat per-week leaves don't fit the wiki's nested-scalable layout (rules/llm-wiki.md); promoting a curated subset to .development/shared/ for git is a project's choice, not the script's default.",
+  "description": "Aggregator output. One object per ISO week. By default scripts/report_metrics.mjs writes under .claude/state/metrics-weekly/<yyyy>-Www.json (the markdown report at <yyyy>-Www.md is rendered from this). The output lives under .claude/state/, NOT under .development/**, because .development/* roots are wiki-governed (rules/llm-wiki.md) and require a nested-scalable layout that flat per-week leaves do not fit. A project that wants the rollup published in its team wiki can copy it from here and route the publish through the wiki skill manually.",
   "type": "object",
   "required": [
     "iso_week",

--- a/schemas/metrics-weekly.schema.json
+++ b/schemas/metrics-weekly.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://ctxr.dev/schemas/metrics-weekly.schema.json",
   "title": "Weekly metrics rollup",
-  "description": "Aggregator output. One object per ISO week. Written under .development/shared/reports/metrics/<yyyy>-Www.json (the markdown report at <yyyy>-Www.md is rendered from this).",
+  "description": "Aggregator output. One object per ISO week. By default scripts/report_metrics.mjs writes under .development/local/metrics/<yyyy>-Www.json (the markdown report at <yyyy>-Www.md is rendered from this). Local rather than shared because flat per-week leaves don't fit the wiki's nested-scalable layout (rules/llm-wiki.md); promoting a curated subset to .development/shared/ for git is a project's choice, not the script's default.",
   "type": "object",
   "required": [
     "iso_week",

--- a/schemas/metrics-weekly.schema.json
+++ b/schemas/metrics-weekly.schema.json
@@ -15,8 +15,8 @@
   "properties": {
     "iso_week": {
       "type": "string",
-      "pattern": "^[0-9]{4}-W[0-9]{2}$",
-      "description": "ISO 8601 week designation, e.g. 2026-W17."
+      "pattern": "^[0-9]{4}-W(0[1-9]|[1-4][0-9]|5[0-3])$",
+      "description": "ISO 8601 week designation, e.g. 2026-W17. Week digits are constrained to the valid 01..53 range so impossible designations (W00, W54..W99) are rejected at schema validation."
     },
     "window": {
       "type": "object",

--- a/schemas/metrics-weekly.schema.json
+++ b/schemas/metrics-weekly.schema.json
@@ -67,7 +67,7 @@
           "avg_cost": { "type": "number", "minimum": 0 },
           "delta_vs_prev": {
             "type": ["number", "null"],
-            "description": "Fractional change in avg_cost vs the previous week's value for the same skill. null for newly seen skills."
+            "description": "Fractional change in avg_cost vs the previous week's value for the same skill. null when the delta is undefined: the skill was not in the previous-week rollup (newly seen), OR the previous-week avg_cost was 0 with this week non-zero (relative change is infinite). When BOTH weeks were 0, the delta is 0 (no change)."
           }
         }
       }

--- a/schemas/metrics-weekly.schema.json
+++ b/schemas/metrics-weekly.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ctxr.dev/schemas/metrics-weekly.schema.json",
+  "title": "Weekly metrics rollup",
+  "description": "Aggregator output. One object per ISO week. Written under .development/shared/reports/metrics/<yyyy>-Www.json (the markdown report at <yyyy>-Www.md is rendered from this).",
+  "type": "object",
+  "required": [
+    "iso_week",
+    "totals",
+    "per_skill",
+    "thresholds",
+    "red_flags"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "iso_week": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-W[0-9]{2}$",
+      "description": "ISO 8601 week designation, e.g. 2026-W17."
+    },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "type": "string", "format": "date-time" },
+        "end": { "type": "string", "format": "date-time" }
+      }
+    },
+    "totals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["invocations", "cost_usd", "tokens", "cache_hit_rate"],
+      "properties": {
+        "invocations": { "type": "integer", "minimum": 0 },
+        "cost_usd": { "type": "number", "minimum": 0 },
+        "tokens": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["input", "output", "cache_read", "cache_write"],
+          "properties": {
+            "input": { "type": "integer", "minimum": 0 },
+            "output": { "type": "integer", "minimum": 0 },
+            "cache_read": { "type": "integer", "minimum": 0 },
+            "cache_write": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "cache_hit_rate": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "cache_read / (input + cache_read). 0 when no inputs were processed."
+        }
+      }
+    },
+    "per_skill": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["skill", "invocations", "avg_tokens", "cache_hit_rate", "avg_cost"],
+        "properties": {
+          "skill": { "type": "string", "minLength": 1 },
+          "invocations": { "type": "integer", "minimum": 0 },
+          "avg_tokens": { "type": "integer", "minimum": 0 },
+          "cache_hit_rate": { "type": "number", "minimum": 0, "maximum": 1 },
+          "avg_cost": { "type": "number", "minimum": 0 },
+          "delta_vs_prev": {
+            "type": ["number", "null"],
+            "description": "Fractional change in avg_cost vs the previous week's value for the same skill. null for newly seen skills."
+          }
+        }
+      }
+    },
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cache_hit_rate_min": { "type": "number", "minimum": 0, "maximum": 1 },
+        "per_skill_token_ceiling": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "red_flags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["skill", "kind", "message"],
+        "properties": {
+          "skill": { "type": "string" },
+          "kind": {
+            "type": "string",
+            "enum": ["cache_hit_rate_below_min", "avg_tokens_above_ceiling"]
+          },
+          "message": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -565,7 +565,7 @@
     "observability": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Per-skill token accounting and weekly metrics report. The recorder writes one JSONL line per invocation under .claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl; report_metrics.mjs --weekly rolls daily files into ISO-week summaries under .development/local/metrics/<yyyy>-Www.json (local/, not shared/, because flat per-week leaves do not fit the wiki nested-scalable layout the project's wiki enforces). See scripts/lib/metrics/. Note: this PR ships the recorder, aggregator, and CLI; the per-skill dispatch sites that read `metrics_enabled` and emit records land in a follow-up wiring PR (the bundle has no centralised dispatch layer today).",
+      "description": "Per-skill token accounting and weekly metrics report. The recorder writes one JSONL line per invocation under .claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl; report_metrics.mjs --weekly rolls daily files into ISO-week summaries under .claude/state/metrics-weekly/<yyyy>-Www.json. Both live under .claude/state/, NOT under .development/**: the .development/* roots are wiki-governed (rules/llm-wiki.md) and require a nested-scalable layout that flat per-week leaves do not fit. See scripts/lib/metrics/. Note: this PR ships the recorder, aggregator, and CLI; the per-skill dispatch sites that read `metrics_enabled` and emit records land in a follow-up wiring PR (the bundle has no centralised dispatch layer today).",
       "properties": {
         "metrics_enabled": {
           "type": "boolean",

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -565,7 +565,7 @@
     "observability": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Per-skill token accounting and weekly metrics report. The recorder writes one JSONL line per invocation under .claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl; aggregate.mjs rolls daily files into ISO-week summaries under .development/shared/reports/metrics/<yyyy>-Www.json. See scripts/lib/metrics/. Note: this PR ships the recorder, aggregator, and CLI; the per-skill dispatch sites that read `metrics_enabled` and emit records land in a follow-up wiring PR (the bundle has no centralised dispatch layer today).",
+      "description": "Per-skill token accounting and weekly metrics report. The recorder writes one JSONL line per invocation under .claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl; report_metrics.mjs --weekly rolls daily files into ISO-week summaries under .development/local/metrics/<yyyy>-Www.json (local/, not shared/, because flat per-week leaves do not fit the wiki nested-scalable layout the project's wiki enforces). See scripts/lib/metrics/. Note: this PR ships the recorder, aggregator, and CLI; the per-skill dispatch sites that read `metrics_enabled` and emit records land in a follow-up wiring PR (the bundle has no centralised dispatch layer today).",
       "properties": {
         "metrics_enabled": {
           "type": "boolean",

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -565,17 +565,17 @@
     "observability": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Per-skill token accounting and weekly metrics report. The recorder writes one JSONL line per invocation under .claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl; aggregate.mjs rolls daily files into ISO-week summaries under .development/shared/reports/metrics/<yyyy>-Www.json. See scripts/lib/metrics/.",
+      "description": "Per-skill token accounting and weekly metrics report. The recorder writes one JSONL line per invocation under .claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl; aggregate.mjs rolls daily files into ISO-week summaries under .development/shared/reports/metrics/<yyyy>-Www.json. See scripts/lib/metrics/. Note: this PR ships the recorder, aggregator, and CLI; the per-skill dispatch sites that read `metrics_enabled` and emit records land in a follow-up wiring PR (the bundle has no centralised dispatch layer today).",
       "properties": {
         "metrics_enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Master switch for the recorder. When false, callers of scripts/lib/metrics/record.mjs become no-ops."
+          "description": "Master switch for the recorder. Reserved field: the dispatch wiring lands in a follow-up. When the per-skill emitters are wired up, callers of scripts/lib/metrics/record.mjs will check this flag and become no-ops when false."
         },
         "weekly_report": {
           "type": "boolean",
           "default": true,
-          "description": "Whether scripts/report_metrics.mjs --weekly is wired into the project's reminder / cron path."
+          "description": "Whether scripts/report_metrics.mjs --weekly is wired into the project's reminder / cron path. Reserved until the cron wiring follow-up; for now the script is invokable manually."
         },
         "alert_thresholds": {
           "type": "object",

--- a/schemas/ops.config.schema.json
+++ b/schemas/ops.config.schema.json
@@ -562,6 +562,43 @@
       }
     },
 
+    "observability": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Per-skill token accounting and weekly metrics report. The recorder writes one JSONL line per invocation under .claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl; aggregate.mjs rolls daily files into ISO-week summaries under .development/shared/reports/metrics/<yyyy>-Www.json. See scripts/lib/metrics/.",
+      "properties": {
+        "metrics_enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Master switch for the recorder. When false, callers of scripts/lib/metrics/record.mjs become no-ops."
+        },
+        "weekly_report": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether scripts/report_metrics.mjs --weekly is wired into the project's reminder / cron path."
+        },
+        "alert_thresholds": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "cache_hit_rate_min": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "default": 0.7,
+              "description": "Per-skill cache hit rate below this triggers a red flag in the weekly rollup."
+            },
+            "per_skill_token_ceiling": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 50000,
+              "description": "Per-skill avg_tokens above this triggers a red flag in the weekly rollup."
+            }
+          }
+        }
+      }
+    },
+
     "paths": {
       "type": "object",
       "required": ["plans_root", "plan_states", "dev_working_dir", "templates", "agent_bundle_dir", "wrappers"],

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -911,6 +911,11 @@ if (opsConfig.paths.gitignore_dev_working_dir !== false) {
   await ensureGitignore(TARGET, [
     `${opsConfig.paths.dev_working_dir}/${localSub}`,
     `${opsConfig.paths.dev_working_dir}/${cacheSub}`,
+    // Per-skill metrics records (JSONL, per-day) live under .claude/state/metrics/.
+    // They contain no PII (skill names + counts only) but they are local
+    // artefacts, not code. Aggregator output lands under .development/shared/
+    // and that directory is ALREADY committed by convention.
+    ".claude/state/metrics/",
   ]);
 }
 for (const w of writes) {

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -927,6 +927,7 @@ if (opsConfig.paths.gitignore_dev_working_dir !== false) {
     // rollup published to its team wiki can copy from here and run it
     // through the wiki skill manually.
     ".claude/state/metrics/",
+    ".claude/state/metrics-weekly/",
   ]);
 }
 for (const w of writes) {

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -912,9 +912,14 @@ if (opsConfig.paths.gitignore_dev_working_dir !== false) {
     `${opsConfig.paths.dev_working_dir}/${localSub}`,
     `${opsConfig.paths.dev_working_dir}/${cacheSub}`,
     // Per-skill metrics records (JSONL, per-day) live under .claude/state/metrics/.
-    // They contain no PII (skill names + counts only) but they are local
-    // artefacts, not code. Aggregator output lands under .development/shared/
-    // and that directory is ALREADY committed by convention.
+    // The recorder writes: trace_id (random hex), parent_trace_id, skill name,
+    // started_at / ended_at (ISO timestamps), model id, token counts
+    // (input/output/cache_read/cache_write), cost_usd, subagent counts,
+    // mcp_servers_used (server names only), and the exit status.
+    // No PII; no payloads; no diffs. They are local artefacts (not code),
+    // so they stay out of git. Aggregator output lands under
+    // .development/shared/reports/metrics/ and that directory is ALREADY
+    // committed by convention.
     ".claude/state/metrics/",
   ]);
 }

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -917,9 +917,11 @@ if (opsConfig.paths.gitignore_dev_working_dir !== false) {
     // (input/output/cache_read/cache_write), cost_usd, subagent counts,
     // mcp_servers_used (server names only), and the exit status.
     // No PII; no payloads; no diffs. They are local artefacts (not code),
-    // so they stay out of git. Aggregator output lands under
-    // .development/shared/reports/metrics/ and that directory is ALREADY
-    // committed by convention.
+    // so they stay out of git. Aggregator output (the weekly rollup) also
+    // lands under .development/local/ by default — flat per-week leaves
+    // don't fit the wiki's nested-scalable layout, so the script writes
+    // local; promoting a curated subset into .development/shared/ for
+    // git is a project's choice, not the script's default.
     ".claude/state/metrics/",
   ]);
 }

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -917,11 +917,15 @@ if (opsConfig.paths.gitignore_dev_working_dir !== false) {
     // (input/output/cache_read/cache_write), cost_usd, subagent counts,
     // mcp_servers_used (server names only), and the exit status.
     // No PII; no payloads; no diffs. They are local artefacts (not code),
-    // so they stay out of git. Aggregator output (the weekly rollup) also
-    // lands under .development/local/ by default — flat per-week leaves
-    // don't fit the wiki's nested-scalable layout, so the script writes
-    // local; promoting a curated subset into .development/shared/ for
-    // git is a project's choice, not the script's default.
+    // so they stay out of git. Weekly rollup output (`scripts/report_metrics.mjs`)
+    // lands under `.claude/state/metrics-weekly/` by default, NOT under
+    // `.development/**`: the .development/* roots are wiki-governed
+    // (rules/llm-wiki.md) and demand a nested-scalable layout, while
+    // weekly rollups are flat `<yyyy>-Www.json` per-week leaves. Keeping
+    // both daily and weekly metrics state under .claude/state/ keeps the
+    // wiki layout invariant intact; a project that wants a curated
+    // rollup published to its team wiki can copy from here and run it
+    // through the wiki skill manually.
     ".claude/state/metrics/",
   ]);
 }

--- a/scripts/install.mjs
+++ b/scripts/install.mjs
@@ -911,25 +911,38 @@ if (opsConfig.paths.gitignore_dev_working_dir !== false) {
   await ensureGitignore(TARGET, [
     `${opsConfig.paths.dev_working_dir}/${localSub}`,
     `${opsConfig.paths.dev_working_dir}/${cacheSub}`,
-    // Per-skill metrics records (JSONL, per-day) live under .claude/state/metrics/.
-    // The recorder writes: trace_id (random hex), parent_trace_id, skill name,
-    // started_at / ended_at (ISO timestamps), model id, token counts
-    // (input/output/cache_read/cache_write), cost_usd, subagent counts,
-    // mcp_servers_used (server names only), and the exit status.
-    // No PII; no payloads; no diffs. They are local artefacts (not code),
-    // so they stay out of git. Weekly rollup output (`scripts/report_metrics.mjs`)
-    // lands under `.claude/state/metrics-weekly/` by default, NOT under
-    // `.development/**`: the .development/* roots are wiki-governed
-    // (rules/llm-wiki.md) and demand a nested-scalable layout, while
-    // weekly rollups are flat `<yyyy>-Www.json` per-week leaves. Keeping
-    // both daily and weekly metrics state under .claude/state/ keeps the
-    // wiki layout invariant intact; a project that wants a curated
-    // rollup published to its team wiki can copy from here and run it
-    // through the wiki skill manually.
-    ".claude/state/metrics/",
-    ".claude/state/metrics-weekly/",
   ]);
 }
+
+// Metrics state ALWAYS gets gitignored, regardless of the
+// gitignore_dev_working_dir flag: that flag is specifically about whether
+// `${dev_working_dir}/local` and `${dev_working_dir}/cache` should be
+// ignored. The metrics state lives under `.claude/state/`, an entirely
+// different surface that nobody wants in git: the JSONL records contain
+// trace_ids, started_at / ended_at timestamps, token counts, and
+// cost_usd; the weekly rollup files contain the same data aggregated.
+// Both are local artefacts (not code), and would clutter the diff if
+// committed accidentally. Keeping the gitignore here outside the
+// dev_working_dir flag means a project that turns off the .development
+// gitignore (e.g. because it wants to commit shared/) does not silently
+// lose the metrics-state ignore at the same time.
+await ensureGitignore(TARGET, [
+  // Per-skill metrics records (JSONL, per-day) under .claude/state/metrics/.
+  // The recorder writes: trace_id (random hex), parent_trace_id, skill name,
+  // started_at / ended_at (ISO timestamps), model id, token counts
+  // (input/output/cache_read/cache_write), cost_usd, subagent counts,
+  // mcp_servers_used (server names only), and the exit status. No PII;
+  // no payloads; no diffs.
+  ".claude/state/metrics/",
+  // Weekly rollup output from scripts/report_metrics.mjs. Lands under
+  // .claude/state/metrics-weekly/, NOT under .development/**, because
+  // the .development/* roots are wiki-governed (rules/llm-wiki.md) and
+  // demand a nested-scalable layout that flat <yyyy>-Www.json per-week
+  // leaves do not fit. A project that wants a curated rollup published
+  // to its team wiki can copy from here and route the publish through
+  // the wiki skill manually.
+  ".claude/state/metrics-weekly/",
+]);
 for (const w of writes) {
   if (w.content == null) continue;
   await ensureDir(dirname(w.path));

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -251,7 +251,15 @@ export function aggregate(records, opts) {
     const avgCost = round6(acc.cost_usd / inv);
     const cacheHit = computeCacheHitRate(acc.tokens_input, acc.tokens_cache_read);
     const prev = previousAvgCostBySkill.get(skill);
-    const delta = prev == null ? null : prev === 0 ? null : round4((avgCost - prev) / prev);
+    // delta_vs_prev is null when the relative change is undefined:
+    //   - skill missing from the prev-week map (newly seen)
+    //   - prev was 0 AND avgCost is non-zero (infinite relative change)
+    // When BOTH weeks were 0, return 0 (literally no change in cost).
+    // Schema description on `delta_vs_prev` records the same union.
+    let delta;
+    if (prev == null) delta = null;
+    else if (prev === 0) delta = avgCost === 0 ? 0 : null;
+    else delta = round4((avgCost - prev) / prev);
     const row = {
       skill,
       invocations: acc.invocations,

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -23,7 +23,10 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /**
  * Compute the start (Mon 00:00:00 UTC) and end (next Mon 00:00:00 UTC)
- * of the ISO week containing `date`. Returns ISO 8601 strings.
+ * of the ISO week containing `date`. `start` and `end` are returned as
+ * Date objects (UTC midnight); `isoWeek` is the ISO 8601 week
+ * designation (e.g. "2026-W17"). Callers that need a string boundary
+ * should call `.toISOString()` on the Date themselves.
  *
  * @param {Date} date
  * @returns {{start: Date, end: Date, isoWeek: string}}
@@ -119,12 +122,16 @@ export function aggregate(records, opts) {
   const thresholds = opts.thresholds ?? {};
   const previousAvgCostBySkill = opts.previousAvgCostBySkill ?? new Map();
 
-  // Per-skill accumulators. Sub-invocations are folded into their
-  // parent's totals (parent_trace_id != null counts toward the parent's
-  // skill, not its own row), since the issue's per-skill table is
-  // top-level invocations only. We attribute under parent's skill if
-  // we can find the parent record; otherwise we skip the sub-record so
-  // it never shows up as a phantom skill row.
+  // Per-skill accumulators. Sub-invocations whose parent chain RESOLVES
+  // inside the aggregation window are folded into the root parent's
+  // totals (parent_trace_id != null contributes cost/tokens to the
+  // parent's row, not its own). Sub-invocations whose parent record is
+  // NOT present in this batch ("orphan subs") cannot be folded; we land
+  // them under the sub's own skill AND count them as invocations so the
+  // per-skill avg_cost / avg_tokens math stays meaningful (the
+  // alternative — invocations=0 with non-zero totals — mis-reports a
+  // total as an average). See the isOrphanSub branch below; the
+  // top-level totals reflect this same accounting.
   const recordsByTraceId = new Map();
   for (const r of records) {
     if (r && typeof r.trace_id === "string") {

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -132,7 +132,14 @@ export function readRecordsInWindow(metricsDir, start, end) {
     } catch {
       continue;
     }
-    for (const line of lines) {
+    for (const rawLine of lines) {
+      // Strip a trailing `\r` so a JSONL file produced or edited under
+      // CRLF (Windows checkout, certain editors, gitattributes
+      // text=auto) round-trips cleanly. Without the strip, every
+      // valid-looking record from a CRLF file would JSON.parse-throw
+      // (the trailing `\r` is not legal whitespace inside JSON tokens)
+      // and the entire week's data would silently disappear.
+      const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
       if (line.length === 0) continue;
       let parsed;
       try {

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -126,12 +126,13 @@ export function aggregate(records, opts) {
   // inside the aggregation window are folded into the root parent's
   // totals (parent_trace_id != null contributes cost/tokens to the
   // parent's row, not its own). Sub-invocations whose parent record is
-  // NOT present in this batch ("orphan subs") cannot be folded; we land
-  // them under the sub's own skill AND count them as invocations so the
-  // per-skill avg_cost / avg_tokens math stays meaningful (the
-  // alternative — invocations=0 with non-zero totals — mis-reports a
-  // total as an average). See the isOrphanSub branch below; the
-  // top-level totals reflect this same accounting.
+  // NOT present in this batch ("orphan subs") are dropped from the
+  // rollup entirely — they neither surface as their own per_skill row
+  // nor fold into a phantom parent. Promoting orphans to top-level
+  // rows would make per_skill invocation counts unstable at week
+  // boundaries (a sub run on Sunday whose parent ran on Monday would
+  // flip between "folded" and "phantom" depending on the aggregation
+  // window). When cross-week accuracy matters, widen the window.
   const recordsByTraceId = new Map();
   for (const r of records) {
     if (r && typeof r.trace_id === "string") {

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -101,7 +101,18 @@ export function readRecordsInWindow(metricsDir, start, end) {
   if (!st.isDirectory()) return [];
   const startKey = ymdKey(start);
   const endKey = ymdKey(end);
-  const files = readdirSync(metricsDir)
+  // Even though the statSync above proved the directory existed at
+  // T0, readdirSync can still throw at T1 if the dir is removed,
+  // permissions change, or the volume goes offline between the two
+  // calls. The aggregator's contract is "stay resilient on FS
+  // issues"; treat any failure here as an empty window.
+  let entries;
+  try {
+    entries = readdirSync(metricsDir);
+  } catch {
+    return [];
+  }
+  const files = entries
     .filter((f) => /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(f))
     .filter((f) => {
       const k = f.slice(0, 10);
@@ -111,7 +122,16 @@ export function readRecordsInWindow(metricsDir, start, end) {
     .sort();
   const records = [];
   for (const f of files) {
-    const lines = readFileSync(join(metricsDir, f), "utf8").split("\n");
+    // Same TOCTOU window for the per-file read: the file might have
+    // been rotated / removed between readdirSync above and this
+    // readFileSync. Skip the file on any read error so the rollup
+    // stays computable instead of crashing the whole CLI.
+    let lines;
+    try {
+      lines = readFileSync(join(metricsDir, f), "utf8").split("\n");
+    } catch {
+      continue;
+    }
     for (const line of lines) {
       if (line.length === 0) continue;
       let parsed;

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -424,7 +424,15 @@ function newSkillAcc() {
 }
 
 function isPlainRecord(r) {
-  return r && typeof r === "object" && typeof r.skill === "string" && r.tokens && typeof r.tokens === "object";
+  // Reject arrays at every layer. `typeof [] === "object"` is true,
+  // so a corrupted JSONL line shaped as `{"skill":"x","tokens":[]}`
+  // would otherwise pass and count as an invocation with 0 tokens
+  // and 0 cost, skewing the rollup. Require both `r` itself and
+  // `r.tokens` to be plain (non-array) objects.
+  if (r == null || typeof r !== "object" || Array.isArray(r)) return false;
+  if (typeof r.skill !== "string") return false;
+  if (r.tokens == null || typeof r.tokens !== "object" || Array.isArray(r.tokens)) return false;
+  return true;
 }
 
 function num(v) {

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -142,10 +142,21 @@ export function aggregate(records, opts) {
   for (const r of records) {
     if (!isPlainRecord(r)) continue;
     const isSub = r.parent_trace_id != null;
-    const skill = isSub
-      ? (recordsByTraceId.get(r.parent_trace_id)?.skill ?? null)
-      : r.skill;
-    if (!skill) continue; // orphan sub-record: skip (no parent in this window)
+    // Walk the parent chain to the root skill, not just the immediate
+    // parent. A sub-invocation can itself fan out to nested subagents;
+    // each level carries its own parent_trace_id. Resolve to the
+    // top-most ancestor's skill so the per-skill row counts every
+    // descendant against the work that originated it. Handles cycles
+    // defensively via a visited set (records should never form a cycle
+    // but we don't trust adversarial input).
+    const rootSkill = isSub ? resolveRootSkill(r, recordsByTraceId) : r.skill;
+    // Sub-invocations whose parent chain leaves the aggregation window
+    // (parent record not present in this batch) are folded under the
+    // sub's OWN skill rather than dropped entirely. This costs a row
+    // for orphans, but it's correct: the cost / tokens are real and
+    // need to land somewhere; dropping them under-reports the totals.
+    const skill = rootSkill ?? (typeof r.skill === "string" ? r.skill : null);
+    if (!skill) continue; // truly malformed; nothing else to do
     const acc = skillStats.get(skill) ?? newSkillAcc();
     acc.invocations += isSub ? 0 : 1; // count top-level invocations only
     acc.cost_usd += num(r.cost_usd);
@@ -277,6 +288,31 @@ export function renderMarkdown(weekly) {
 }
 
 // ---------- internals ----------
+
+/**
+ * Walk the parent_trace_id chain back to the top-level record and
+ * return its skill. Returns null if the chain leaves the supplied
+ * record map (parent not in this aggregation window) so the caller
+ * can decide how to handle the orphan.
+ *
+ * Defends against cycles via a visited set; the chain length cap of
+ * 16 is generous (real-world subagent depth is 1 or 2) and prevents
+ * an adversarial JSONL from spinning the aggregator.
+ */
+function resolveRootSkill(record, recordsByTraceId) {
+  let cur = record;
+  const visited = new Set();
+  let depth = 0;
+  while (cur && cur.parent_trace_id != null && depth < 16) {
+    if (visited.has(cur.trace_id)) return null; // cycle
+    visited.add(cur.trace_id);
+    const parent = recordsByTraceId.get(cur.parent_trace_id);
+    if (!parent) return null; // parent not in window
+    cur = parent;
+    depth++;
+  }
+  return typeof cur?.skill === "string" ? cur.skill : null;
+}
 
 function newSkillAcc() {
   return {

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -344,8 +344,16 @@ function isPlainRecord(r) {
 }
 
 function num(v) {
+  // Clamp negative values to 0. The recorder validates non-negative
+  // counts at write time, but a corrupted / hand-edited JSONL line
+  // could land a negative, and weekly rollups have `minimum: 0` on
+  // every cost / token field (schemas/metrics-weekly.schema.json).
+  // Coercing here keeps the rollup schema-conformant even when the
+  // input file is damaged; we'd rather under-count a row than emit
+  // a JSON object the consumer's validator will reject outright.
   const n = Number(v ?? 0);
-  return Number.isFinite(n) ? n : 0;
+  if (!Number.isFinite(n)) return 0;
+  return n < 0 ? 0 : n;
 }
 
 function computeCacheHitRate(input, cacheRead) {

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -342,6 +342,15 @@ function resolveRootSkill(record, recordsByTraceId) {
   // Return null so the caller drops the record the same way it drops
   // a parent-not-in-window orphan.
   if (cur == null || cur.parent_trace_id != null) return null;
+  // Also reject roots that fail isPlainRecord. The main loop skips
+  // malformed records via isPlainRecord, so the parent's own
+  // invocations counter never increments — but if a sub-invocation
+  // resolves to that malformed parent's skill, it would fold cost
+  // and tokens into a per_skill row whose invocations stayed at 0.
+  // That over-counts the rollup and produces an "invocations=0,
+  // cost>0" combination the schema technically allows but no
+  // downstream consumer wants to see. Drop the chain instead.
+  if (!isPlainRecord(cur)) return null;
   return typeof cur.skill === "string" ? cur.skill : null;
 }
 

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -155,10 +155,16 @@ export function aggregate(records, opts) {
     acc.tokens_cache_write += num(r.tokens?.cache_write);
     skillStats.set(skill, acc);
 
+    // Cost AND tokens both include sub-invocations: a top-level
+    // dev-loop run that fans out to three Explorer subagents should
+    // surface the full bill in totals.cost_usd, not just the parent's
+    // share. Invocation count, however, is top-level only — sub
+    // entries are folded into the parent's per-skill row above and
+    // would inflate the count if also added here.
     if (!isSub) {
       totals.invocations += 1;
-      totals.cost_usd += num(r.cost_usd);
     }
+    totals.cost_usd += num(r.cost_usd);
     totals.tokens.input += num(r.tokens?.input);
     totals.tokens.output += num(r.tokens?.output);
     totals.tokens.cache_read += num(r.tokens?.cache_read);

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -135,10 +135,14 @@ export function readRecordsInWindow(metricsDir, start, end) {
     for (const rawLine of lines) {
       // Strip a trailing `\r` so a JSONL file produced or edited under
       // CRLF (Windows checkout, certain editors, gitattributes
-      // text=auto) round-trips cleanly. Without the strip, every
-      // valid-looking record from a CRLF file would JSON.parse-throw
-      // (the trailing `\r` is not legal whitespace inside JSON tokens)
-      // and the entire week's data would silently disappear.
+      // text=auto) is normalised before we treat it as a record line.
+      // JSON.parse accepts `\r` as insignificant whitespace, so the
+      // strip is not strictly required for parsing — but `split("\n")`
+      // leaves a bare `\r` as a "line" of its own when a file ends
+      // with `\r\n`, and downstream consumers that re-serialise the
+      // record back are sensitive to the orphan `\r` glued to the
+      // trailing brace. Normalising here keeps the read path
+      // predictable across EOL flavours.
       const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
       if (line.length === 0) continue;
       let parsed;

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -325,7 +325,14 @@ function resolveRootSkill(record, recordsByTraceId) {
     cur = parent;
     depth++;
   }
-  return typeof cur?.skill === "string" ? cur.skill : null;
+  // After the loop, `cur` is a root only when its parent_trace_id is
+  // null. Hitting the depth cap with parent_trace_id still set means
+  // the chain is corrupted (deeper than any real workflow ever
+  // produces); folding that into a phantom row would over-count.
+  // Return null so the caller drops the record the same way it drops
+  // a parent-not-in-window orphan.
+  if (cur == null || cur.parent_trace_id != null) return null;
+  return typeof cur.skill === "string" ? cur.skill : null;
 }
 
 function newSkillAcc() {

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -347,8 +347,14 @@ export function renderMarkdown(weekly) {
   lines.push("| skill | invocations | avg_tokens | cache_hit | avg_cost | delta_vs_prev |");
   lines.push("|---|---|---|---|---|---|");
   for (const row of weekly.per_skill) {
+    // Render null as "n/a" rather than "new". delta_vs_prev is null
+    // for two distinct structural reasons (newly seen skill OR
+    // previous-week avg_cost was 0 with this week non-zero, i.e.
+    // infinite relative change); the rollup field is the same null
+    // for both, so the renderer cannot honestly label one case as
+    // "new". "n/a" is accurate for either union member.
     const delta = row.delta_vs_prev == null
-      ? "new"
+      ? "n/a"
       : `${row.delta_vs_prev >= 0 ? "+" : ""}${(row.delta_vs_prev * 100).toFixed(0)} %`;
     lines.push(`| ${row.skill} | ${row.invocations} | ${row.avg_tokens} | ${pct(row.cache_hit_rate)} | $${row.avg_cost.toFixed(2)} | ${delta} |`);
   }
@@ -461,7 +467,14 @@ function round6(n) {
 }
 
 function pct(n) {
-  return `${(n * 100).toFixed(0)} %`;
+  // 1-decimal precision so a `cache_hit_rate < cache_hit_rate_min`
+  // MISS is not visually identical to the threshold itself
+  // (e.g. 69.5 % vs 70 %). The rendered table previously printed
+  // both as "70 %", which made it hard for a human skimming the
+  // markdown to see why a row landed in the red-flag list. The
+  // raw fraction stays in the JSON rollup at full round4
+  // precision; this helper is only for human-facing markdown.
+  return `${(n * 100).toFixed(1)} %`;
 }
 
 function ymdKey(d) {

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -147,18 +147,24 @@ export function aggregate(records, opts) {
     // each level carries its own parent_trace_id. Resolve to the
     // top-most ancestor's skill so the per-skill row counts every
     // descendant against the work that originated it. Handles cycles
-    // defensively via a visited set (records should never form a cycle
-    // but we don't trust adversarial input).
+    // defensively via resolveRootSkill().
     const rootSkill = isSub ? resolveRootSkill(r, recordsByTraceId) : r.skill;
     // Sub-invocations whose parent chain leaves the aggregation window
-    // (parent record not present in this batch) are folded under the
-    // sub's OWN skill rather than dropped entirely. This costs a row
-    // for orphans, but it's correct: the cost / tokens are real and
-    // need to land somewhere; dropping them under-reports the totals.
-    const skill = rootSkill ?? (typeof r.skill === "string" ? r.skill : null);
-    if (!skill) continue; // truly malformed; nothing else to do
+    // (parent record not present in this batch) are "orphans". We fold
+    // them under the sub's OWN skill rather than dropping them: their
+    // cost / tokens are real and need to land somewhere. We treat them
+    // as a top-level invocation FOR THE PURPOSES OF AVERAGING so the
+    // per-skill row's avg_cost / avg_tokens stay meaningful (otherwise
+    // a skill that only appears as orphan sub-records ends up with
+    // invocations=0 and avg = total / 1, which mis-reports a total
+    // as an average).
+    const isOrphanSub = isSub && rootSkill == null;
+    const skill = rootSkill ?? (isSub ? r.skill : null);
+    if (!skill) continue; // truly malformed; nothing to do
+    const countsAsInvocation = !isSub || isOrphanSub;
+
     const acc = skillStats.get(skill) ?? newSkillAcc();
-    acc.invocations += isSub ? 0 : 1; // count top-level invocations only
+    if (countsAsInvocation) acc.invocations += 1;
     acc.cost_usd += num(r.cost_usd);
     acc.tokens_input += num(r.tokens?.input);
     acc.tokens_output += num(r.tokens?.output);
@@ -166,15 +172,15 @@ export function aggregate(records, opts) {
     acc.tokens_cache_write += num(r.tokens?.cache_write);
     skillStats.set(skill, acc);
 
-    // Cost AND tokens both include sub-invocations: a top-level
-    // dev-loop run that fans out to three Explorer subagents should
-    // surface the full bill in totals.cost_usd, not just the parent's
-    // share. Invocation count, however, is top-level only — sub
-    // entries are folded into the parent's per-skill row above and
-    // would inflate the count if also added here.
-    if (!isSub) {
-      totals.invocations += 1;
-    }
+    // Cost AND tokens both include sub-invocations (and orphan subs):
+    // a top-level dev-loop run that fans out to three Explorer
+    // subagents should surface the full bill in totals.cost_usd, not
+    // just the parent's share. Invocation count tracks distinct
+    // user-visible work units — top-level invocations PLUS orphan
+    // subs that look like top-levels in this window — so an
+    // aggregation containing only orphan subs reports a non-zero
+    // invocations count consistent with non-zero cost.
+    if (countsAsInvocation) totals.invocations += 1;
     totals.cost_usd += num(r.cost_usd);
     totals.tokens.input += num(r.tokens?.input);
     totals.tokens.output += num(r.tokens?.output);

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -356,13 +356,13 @@ export function renderMarkdown(weekly) {
     const delta = row.delta_vs_prev == null
       ? "n/a"
       : `${row.delta_vs_prev >= 0 ? "+" : ""}${(row.delta_vs_prev * 100).toFixed(0)} %`;
-    lines.push(`| ${row.skill} | ${row.invocations} | ${row.avg_tokens} | ${pct(row.cache_hit_rate)} | $${row.avg_cost.toFixed(2)} | ${delta} |`);
+    lines.push(`| ${escapeCell(row.skill)} | ${row.invocations} | ${row.avg_tokens} | ${pct(row.cache_hit_rate)} | $${row.avg_cost.toFixed(2)} | ${delta} |`);
   }
   if (weekly.red_flags.length > 0) {
     lines.push("");
     lines.push("Red flags:");
     for (const flag of weekly.red_flags) {
-      lines.push(`- ${flag.skill}: ${flag.message}`);
+      lines.push(`- ${escapeCell(flag.skill)}: ${escapeCell(flag.message)}`);
     }
   }
   lines.push("");
@@ -464,6 +464,24 @@ function round4(n) {
 
 function round6(n) {
   return Number(n.toFixed(6));
+}
+
+function escapeCell(s) {
+  // The aggregator's read path is intentionally loose (no ajv on
+  // every JSONL line; see readRecordsInWindow JSDoc). A corrupted /
+  // hand-edited record could land a skill name containing markdown-
+  // table-breaking characters like `|`, a CR/LF, or a backslash, and
+  // the rendered weekly report would either break the table layout
+  // or inject unintended markdown into the output. Escape the four
+  // characters that actually break a markdown row: `|` becomes `\|`
+  // (escaped pipe), CR/LF become an HTML line break (the markdown
+  // table cell can't carry a real newline), and `\` is escaped so
+  // the escapes themselves cannot collide. Other characters pass
+  // through verbatim.
+  return String(s)
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/[\r\n]+/g, "<br>");
 }
 
 function pct(n) {

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -1,0 +1,336 @@
+// scripts/lib/metrics/aggregate.mjs
+//
+// Daily JSONL -> weekly rollup aggregator. Reads
+// .claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl files inside the ISO week
+// window and produces a single object conforming to
+// schemas/metrics-weekly.schema.json.
+//
+// Determinism: the rollup key set is stable (skills sorted lex); numeric
+// fields are rounded so two aggregator runs over the same JSONL produce
+// byte-identical JSON. red_flags rendering is sorted by skill name then
+// kind so diff noise stays low across re-runs.
+//
+// Threshold logic mirrors the issue body: cache_hit_rate < min OR
+// avg_tokens > ceiling raises a red flag. Both thresholds are
+// project-configurable via observability.alert_thresholds in
+// ops.config.json; the aggregator accepts them as plain options so it
+// stays pure (no config-loading inside this module).
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Compute the start (Mon 00:00:00 UTC) and end (next Mon 00:00:00 UTC)
+ * of the ISO week containing `date`. Returns ISO 8601 strings.
+ *
+ * @param {Date} date
+ * @returns {{start: Date, end: Date, isoWeek: string}}
+ */
+export function isoWeekWindow(date) {
+  // Convert any Date to UTC midnight; ISO weeks are defined in UTC for
+  // our purposes (cross-team aggregation must not skew by host TZ).
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  // ISO weekday: Mon=1, Sun=7. JS getUTCDay: Sun=0, Mon=1.
+  const dow = d.getUTCDay() || 7;
+  // Move back to the Monday of this week.
+  const monday = new Date(d.getTime() - (dow - 1) * MS_PER_DAY);
+  const nextMonday = new Date(monday.getTime() + 7 * MS_PER_DAY);
+  return { start: monday, end: nextMonday, isoWeek: isoWeekDesignation(monday) };
+}
+
+/**
+ * Return the ISO 8601 week designation (e.g. 2026-W17) for a Monday
+ * (the start of an ISO week).
+ *
+ * @param {Date} monday
+ * @returns {string}
+ */
+export function isoWeekDesignation(monday) {
+  // ISO 8601 week-numbering year may differ from the Gregorian year for
+  // the first / last days of the year. Standard algorithm: Thursday of
+  // the week determines the year.
+  const d = new Date(Date.UTC(monday.getUTCFullYear(), monday.getUTCMonth(), monday.getUTCDate()));
+  const thursday = new Date(d.getTime() + 3 * MS_PER_DAY);
+  const year = thursday.getUTCFullYear();
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Dow = jan4.getUTCDay() || 7;
+  const week1Monday = new Date(jan4.getTime() - (jan4Dow - 1) * MS_PER_DAY);
+  const weekIndex = Math.round((d.getTime() - week1Monday.getTime()) / (7 * MS_PER_DAY)) + 1;
+  return `${year}-W${String(weekIndex).padStart(2, "0")}`;
+}
+
+/**
+ * Iterate the JSONL files inside the metrics directory whose YYYY-MM-DD
+ * filename falls within [start, end). Returns a flat array of record
+ * objects. Malformed lines are skipped with no throw — the recorder is
+ * the contract gate; the aggregator stays resilient.
+ *
+ * @param {string} metricsDir
+ * @param {Date} start
+ * @param {Date} end
+ */
+export function readRecordsInWindow(metricsDir, start, end) {
+  if (!existsSync(metricsDir)) return [];
+  const startKey = ymdKey(start);
+  const endKey = ymdKey(end);
+  const files = readdirSync(metricsDir)
+    .filter((f) => /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(f))
+    .filter((f) => {
+      const k = f.slice(0, 10);
+      // [start, end): inclusive lower, exclusive upper.
+      return k >= startKey && k < endKey;
+    })
+    .sort();
+  const records = [];
+  for (const f of files) {
+    const lines = readFileSync(join(metricsDir, f), "utf8").split("\n");
+    for (const line of lines) {
+      if (line.length === 0) continue;
+      let parsed;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!parsed || typeof parsed !== "object") continue;
+      records.push(parsed);
+    }
+  }
+  return records;
+}
+
+/**
+ * Aggregate records into the weekly rollup shape.
+ *
+ * @param {object[]} records  output of readRecordsInWindow
+ * @param {object} opts
+ * @param {string} opts.isoWeek
+ * @param {{start: Date, end: Date}} [opts.window]
+ * @param {{cache_hit_rate_min?: number, per_skill_token_ceiling?: number}} [opts.thresholds]
+ * @param {Map<string, number>} [opts.previousAvgCostBySkill] previous-week avg_cost by skill, used for delta_vs_prev
+ * @returns {object} conforming to schemas/metrics-weekly.schema.json
+ */
+export function aggregate(records, opts) {
+  if (!opts || typeof opts.isoWeek !== "string") {
+    throw new Error("metrics.aggregate: opts.isoWeek is required");
+  }
+  const thresholds = opts.thresholds ?? {};
+  const previousAvgCostBySkill = opts.previousAvgCostBySkill ?? new Map();
+
+  // Per-skill accumulators. Sub-invocations are folded into their
+  // parent's totals (parent_trace_id != null counts toward the parent's
+  // skill, not its own row), since the issue's per-skill table is
+  // top-level invocations only. We attribute under parent's skill if
+  // we can find the parent record; otherwise we skip the sub-record so
+  // it never shows up as a phantom skill row.
+  const recordsByTraceId = new Map();
+  for (const r of records) {
+    if (r && typeof r.trace_id === "string") {
+      recordsByTraceId.set(r.trace_id, r);
+    }
+  }
+
+  const skillStats = new Map(); // skill -> accumulator
+  const totals = {
+    invocations: 0,
+    cost_usd: 0,
+    tokens: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+  };
+
+  for (const r of records) {
+    if (!isPlainRecord(r)) continue;
+    const isSub = r.parent_trace_id != null;
+    const skill = isSub
+      ? (recordsByTraceId.get(r.parent_trace_id)?.skill ?? null)
+      : r.skill;
+    if (!skill) continue; // orphan sub-record: skip (no parent in this window)
+    const acc = skillStats.get(skill) ?? newSkillAcc();
+    acc.invocations += isSub ? 0 : 1; // count top-level invocations only
+    acc.cost_usd += num(r.cost_usd);
+    acc.tokens_input += num(r.tokens?.input);
+    acc.tokens_output += num(r.tokens?.output);
+    acc.tokens_cache_read += num(r.tokens?.cache_read);
+    acc.tokens_cache_write += num(r.tokens?.cache_write);
+    skillStats.set(skill, acc);
+
+    if (!isSub) {
+      totals.invocations += 1;
+      totals.cost_usd += num(r.cost_usd);
+    }
+    totals.tokens.input += num(r.tokens?.input);
+    totals.tokens.output += num(r.tokens?.output);
+    totals.tokens.cache_read += num(r.tokens?.cache_read);
+    totals.tokens.cache_write += num(r.tokens?.cache_write);
+  }
+
+  const perSkill = [];
+  const redFlags = [];
+  // Deterministic order: lex by skill name.
+  const skillNames = [...skillStats.keys()].sort();
+  for (const skill of skillNames) {
+    const acc = skillStats.get(skill);
+    const totalTokens = acc.tokens_input + acc.tokens_output + acc.tokens_cache_read + acc.tokens_cache_write;
+    const inv = Math.max(acc.invocations, 1); // avoid /0 for sub-only rows (which we already filter, but defensive)
+    const avgTokens = Math.round(totalTokens / inv);
+    const avgCost = round6(acc.cost_usd / inv);
+    const cacheHit = computeCacheHitRate(acc.tokens_input, acc.tokens_cache_read);
+    const prev = previousAvgCostBySkill.get(skill);
+    const delta = prev == null ? null : prev === 0 ? null : round4((avgCost - prev) / prev);
+    const row = {
+      skill,
+      invocations: acc.invocations,
+      avg_tokens: avgTokens,
+      cache_hit_rate: cacheHit,
+      avg_cost: avgCost,
+      delta_vs_prev: delta,
+    };
+    perSkill.push(row);
+
+    if (typeof thresholds.cache_hit_rate_min === "number" && cacheHit < thresholds.cache_hit_rate_min) {
+      redFlags.push({
+        skill,
+        kind: "cache_hit_rate_below_min",
+        message: `cache_hit_rate ${pct(cacheHit)} < ${pct(thresholds.cache_hit_rate_min)}`,
+      });
+    }
+    if (typeof thresholds.per_skill_token_ceiling === "number" && avgTokens > thresholds.per_skill_token_ceiling) {
+      redFlags.push({
+        skill,
+        kind: "avg_tokens_above_ceiling",
+        message: `avg_tokens ${avgTokens} > ${thresholds.per_skill_token_ceiling}`,
+      });
+    }
+  }
+
+  redFlags.sort((a, b) => (a.skill === b.skill ? a.kind.localeCompare(b.kind) : a.skill.localeCompare(b.skill)));
+
+  const out = {
+    iso_week: opts.isoWeek,
+    totals: {
+      invocations: totals.invocations,
+      cost_usd: round6(totals.cost_usd),
+      tokens: totals.tokens,
+      cache_hit_rate: computeCacheHitRate(totals.tokens.input, totals.tokens.cache_read),
+    },
+    per_skill: perSkill,
+    thresholds: pickThresholds(thresholds),
+    red_flags: redFlags,
+  };
+  if (opts.window) {
+    out.window = {
+      start: opts.window.start.toISOString(),
+      end: opts.window.end.toISOString(),
+    };
+  }
+  return out;
+}
+
+/**
+ * Render a markdown report from the aggregator's output. The shape
+ * matches the worked example in the issue body: a header line, an
+ * overall cache-hit summary, the per-skill table, and a red-flags
+ * section.
+ *
+ * @param {object} weekly  output of aggregate()
+ * @returns {string}
+ */
+export function renderMarkdown(weekly) {
+  const lines = [];
+  lines.push(`# Week ${weekly.iso_week}`);
+  lines.push("");
+  const t = weekly.totals;
+  const avg = t.invocations > 0 ? round4(t.cost_usd / t.invocations) : 0;
+  lines.push(`Total cost: $${t.cost_usd.toFixed(2)} across ${t.invocations} skill invocations (avg $${avg.toFixed(2)})`);
+  const cacheStr = pct(t.cache_hit_rate);
+  const minStr = typeof weekly.thresholds.cache_hit_rate_min === "number"
+    ? ` (target >= ${pct(weekly.thresholds.cache_hit_rate_min)} ${t.cache_hit_rate >= weekly.thresholds.cache_hit_rate_min ? "OK" : "MISS"})`
+    : "";
+  lines.push(`Cache hit rate: ${cacheStr} overall${minStr}`);
+  lines.push("");
+  lines.push("Per-skill table:");
+  lines.push("");
+  lines.push("| skill | invocations | avg_tokens | cache_hit | avg_cost | delta_vs_prev |");
+  lines.push("|---|---|---|---|---|---|");
+  for (const row of weekly.per_skill) {
+    const delta = row.delta_vs_prev == null
+      ? "new"
+      : `${row.delta_vs_prev >= 0 ? "+" : ""}${(row.delta_vs_prev * 100).toFixed(0)} %`;
+    lines.push(`| ${row.skill} | ${row.invocations} | ${row.avg_tokens} | ${pct(row.cache_hit_rate)} | $${row.avg_cost.toFixed(2)} | ${delta} |`);
+  }
+  if (weekly.red_flags.length > 0) {
+    lines.push("");
+    lines.push("Red flags:");
+    for (const flag of weekly.red_flags) {
+      lines.push(`- ${flag.skill}: ${flag.message}`);
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+// ---------- internals ----------
+
+function newSkillAcc() {
+  return {
+    invocations: 0,
+    cost_usd: 0,
+    tokens_input: 0,
+    tokens_output: 0,
+    tokens_cache_read: 0,
+    tokens_cache_write: 0,
+  };
+}
+
+function isPlainRecord(r) {
+  return r && typeof r === "object" && typeof r.skill === "string" && r.tokens && typeof r.tokens === "object";
+}
+
+function num(v) {
+  const n = Number(v ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function computeCacheHitRate(input, cacheRead) {
+  const denom = num(input) + num(cacheRead);
+  if (denom === 0) return 0;
+  return round4(num(cacheRead) / denom);
+}
+
+function round4(n) {
+  return Number(n.toFixed(4));
+}
+
+function round6(n) {
+  return Number(n.toFixed(6));
+}
+
+function pct(n) {
+  return `${(n * 100).toFixed(0)} %`;
+}
+
+function ymdKey(d) {
+  return [
+    d.getUTCFullYear(),
+    String(d.getUTCMonth() + 1).padStart(2, "0"),
+    String(d.getUTCDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function pickThresholds(thresholds) {
+  const out = {};
+  if (typeof thresholds.cache_hit_rate_min === "number") out.cache_hit_rate_min = thresholds.cache_hit_rate_min;
+  if (typeof thresholds.per_skill_token_ceiling === "number") out.per_skill_token_ceiling = thresholds.per_skill_token_ceiling;
+  return out;
+}
+
+// Exported for tests; kept small.
+export const _internals = {
+  ymdKey,
+  computeCacheHitRate,
+  round4,
+  round6,
+  pct,
+  resolve,
+};

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -156,19 +156,21 @@ export function aggregate(records, opts) {
     // descendant against the work that originated it. Handles cycles
     // defensively via resolveRootSkill().
     const rootSkill = isSub ? resolveRootSkill(r, recordsByTraceId) : r.skill;
-    // Sub-invocations whose parent chain leaves the aggregation window
-    // (parent record not present in this batch) are "orphans". We fold
-    // them under the sub's OWN skill rather than dropping them: their
-    // cost / tokens are real and need to land somewhere. We treat them
-    // as a top-level invocation FOR THE PURPOSES OF AVERAGING so the
-    // per-skill row's avg_cost / avg_tokens stay meaningful (otherwise
-    // a skill that only appears as orphan sub-records ends up with
-    // invocations=0 and avg = total / 1, which mis-reports a total
-    // as an average).
-    const isOrphanSub = isSub && rootSkill == null;
-    const skill = rootSkill ?? (isSub ? r.skill : null);
+    // Sub-invocations whose parent record is NOT present in this batch
+    // ("orphan subs") are dropped from the rollup entirely. Per the
+    // contract in the issue body and the PR description, sub-invocations
+    // never surface as their own per_skill row — they fold into the
+    // parent's row when the parent is in-window, and otherwise are
+    // omitted. Promoting an orphan to a phantom top-level row would
+    // make `per_skill` invocation counts unstable at week boundaries
+    // (a sub run on Sunday whose parent ran on Monday flips between
+    // "folded" and "phantom" depending on the aggregation window).
+    // The cost/tokens are lost from the rollup; widening the window is
+    // the supported fix when cross-week accuracy matters.
+    if (isSub && rootSkill == null) continue;
+    const skill = rootSkill;
     if (!skill) continue; // truly malformed; nothing to do
-    const countsAsInvocation = !isSub || isOrphanSub;
+    const countsAsInvocation = !isSub;
 
     const acc = skillStats.get(skill) ?? newSkillAcc();
     if (countsAsInvocation) acc.invocations += 1;
@@ -179,14 +181,12 @@ export function aggregate(records, opts) {
     acc.tokens_cache_write += num(r.tokens?.cache_write);
     skillStats.set(skill, acc);
 
-    // Cost AND tokens both include sub-invocations (and orphan subs):
-    // a top-level dev-loop run that fans out to three Explorer
-    // subagents should surface the full bill in totals.cost_usd, not
-    // just the parent's share. Invocation count tracks distinct
-    // user-visible work units — top-level invocations PLUS orphan
-    // subs that look like top-levels in this window — so an
-    // aggregation containing only orphan subs reports a non-zero
-    // invocations count consistent with non-zero cost.
+    // Cost AND tokens include in-window sub-invocations (folded into
+    // the root parent's totals): a top-level dev-loop run that fans
+    // out to three Explorer subagents surfaces the full bill in
+    // totals.cost_usd, not just the parent's share. Invocations count
+    // distinct user-visible work units (top-level only); orphan subs
+    // were already filtered out above so they never reach this branch.
     if (countsAsInvocation) totals.invocations += 1;
     totals.cost_usd += num(r.cost_usd);
     totals.tokens.input += num(r.tokens?.input);

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -16,7 +16,7 @@
 // ops.config.json; the aggregator accepts them as plain options so it
 // stays pure (no config-loading inside this module).
 
-import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -85,7 +85,20 @@ export function isoWeekDesignation(monday) {
  * @param {Date} end
  */
 export function readRecordsInWindow(metricsDir, start, end) {
-  if (!existsSync(metricsDir)) return [];
+  // Single TOCTOU-safe stat. existsSync was the previous gate but it
+  // does not guarantee the path is a DIRECTORY: a metricsDir that
+  // points at a regular file (or a symlink to one, or a dead symlink)
+  // would slip past existsSync and crash readdirSync with ENOTDIR /
+  // ENOENT, taking the weekly report CLI down. statSync inside a
+  // try/catch handles every failure mode (missing, not-a-dir,
+  // permission denied) by returning the same empty-window result.
+  let st;
+  try {
+    st = statSync(metricsDir);
+  } catch {
+    return [];
+  }
+  if (!st.isDirectory()) return [];
   const startKey = ymdKey(start);
   const endKey = ymdKey(end);
   const files = readdirSync(metricsDir)

--- a/scripts/lib/metrics/aggregate.mjs
+++ b/scripts/lib/metrics/aggregate.mjs
@@ -70,6 +70,16 @@ export function isoWeekDesignation(monday) {
  * objects. Malformed lines are skipped with no throw — the recorder is
  * the contract gate; the aggregator stays resilient.
  *
+ * Schema enforcement: schemas/metrics-record.schema.json sets
+ * additionalProperties:false at every layer, but THIS function does
+ * not run ajv validation against parsed lines. That is deliberate:
+ * a bad line (extra key, fractional token, negative cost) is degraded
+ * gracefully by the downstream `intNum` / `num` clamps and the
+ * `isPlainRecord` shape check, which keeps a single corrupted line
+ * from blowing up the whole weekly rollup. Third-party consumers that
+ * want strict additionalProperties enforcement should run their own
+ * ajv pass on the raw JSONL; the schema file is the contract for them.
+ *
  * @param {string} metricsDir
  * @param {Date} start
  * @param {Date} end
@@ -176,10 +186,10 @@ export function aggregate(records, opts) {
     const acc = skillStats.get(skill) ?? newSkillAcc();
     if (countsAsInvocation) acc.invocations += 1;
     acc.cost_usd += num(r.cost_usd);
-    acc.tokens_input += num(r.tokens?.input);
-    acc.tokens_output += num(r.tokens?.output);
-    acc.tokens_cache_read += num(r.tokens?.cache_read);
-    acc.tokens_cache_write += num(r.tokens?.cache_write);
+    acc.tokens_input += intNum(r.tokens?.input);
+    acc.tokens_output += intNum(r.tokens?.output);
+    acc.tokens_cache_read += intNum(r.tokens?.cache_read);
+    acc.tokens_cache_write += intNum(r.tokens?.cache_write);
     skillStats.set(skill, acc);
 
     // Cost AND tokens include in-window sub-invocations (folded into
@@ -190,10 +200,10 @@ export function aggregate(records, opts) {
     // were already filtered out above so they never reach this branch.
     if (countsAsInvocation) totals.invocations += 1;
     totals.cost_usd += num(r.cost_usd);
-    totals.tokens.input += num(r.tokens?.input);
-    totals.tokens.output += num(r.tokens?.output);
-    totals.tokens.cache_read += num(r.tokens?.cache_read);
-    totals.tokens.cache_write += num(r.tokens?.cache_write);
+    totals.tokens.input += intNum(r.tokens?.input);
+    totals.tokens.output += intNum(r.tokens?.output);
+    totals.tokens.cache_read += intNum(r.tokens?.cache_read);
+    totals.tokens.cache_write += intNum(r.tokens?.cache_write);
   }
 
   const perSkill = [];
@@ -361,6 +371,18 @@ function num(v) {
   const n = Number(v ?? 0);
   if (!Number.isFinite(n)) return 0;
   return n < 0 ? 0 : n;
+}
+
+function intNum(v) {
+  // Token-field variant of num(): also truncates to integer. The
+  // weekly rollup schema requires every tokens.* and per_skill.*.tokens.*
+  // field to be an integer (minimum 0). buildRecord coerces token
+  // inputs through Math.trunc(), but a hand-edited JSONL line could
+  // still land a fractional value; truncating here keeps the rollup
+  // schema-valid without forcing readRecordsInWindow to reject the
+  // whole record. Cost stays float (num()) since cost_usd is allowed
+  // to carry decimal precision.
+  return Math.trunc(num(v));
 }
 
 function computeCacheHitRate(input, cacheRead) {

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -227,6 +227,39 @@ export function writeRecord(record, stateDir) {
   if (!validExits.has(record.exit)) {
     throw new Error(`metrics.writeRecord: record.exit must be one of ${[...validExits].join(", ")}; got ${JSON.stringify(record.exit)}`);
   }
+  // Optional top-level fields. orderedRecord copies model and
+  // mcp_servers_used through verbatim; the schema specifies their
+  // shapes (string for model; non-empty string array for
+  // mcp_servers_used). A caller that mutated the record after
+  // buildRecord could otherwise land schema-invalid JSONL on disk —
+  // valid JSON, but rejected by every downstream consumer that ran
+  // ajv against the schema. Validate here so the bad bytes never
+  // reach disk.
+  if (record.model !== undefined && typeof record.model !== "string") {
+    throw new Error(`metrics.writeRecord: record.model must be a string when present; got ${JSON.stringify(record.model)}`);
+  }
+  if (record.mcp_servers_used !== undefined) {
+    if (!Array.isArray(record.mcp_servers_used)) {
+      throw new Error(`metrics.writeRecord: record.mcp_servers_used must be an array of strings when present; got ${JSON.stringify(record.mcp_servers_used)}`);
+    }
+    for (const item of record.mcp_servers_used) {
+      if (typeof item !== "string" || item.length === 0) {
+        throw new Error(`metrics.writeRecord: record.mcp_servers_used items must be non-empty strings; got ${JSON.stringify(item)}`);
+      }
+    }
+  }
+  if (record.subagents !== undefined) {
+    const sa = record.subagents;
+    if (sa == null || typeof sa !== "object") {
+      throw new Error(`metrics.writeRecord: record.subagents must be an object when present; got ${JSON.stringify(sa)}`);
+    }
+    for (const k of ["count", "total_tokens"]) {
+      const v = sa[k];
+      if (typeof v !== "number" || !Number.isFinite(v) || v < 0 || !Number.isInteger(v)) {
+        throw new Error(`metrics.writeRecord: record.subagents.${k} must be a non-negative integer when present; got ${JSON.stringify(v)}`);
+      }
+    }
+  }
   const date = utcDateFromIso(record.started_at, "started_at");
   const dir = resolve(stateDir, "metrics");
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -479,11 +479,21 @@ export function utcDateFromIso(iso, fieldName = "timestamp") {
   // Both branches now go through the same Date parse + UTC extract;
   // the regex pre-filter still rejects shapes the spec disallows
   // (e.g. naive timestamps with no zone designator).
-  if (/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/.test(iso) ||
-      /^\d{4}-\d{2}-\d{2}T[\d:.]+(?:[+-]\d{2}:?\d{2})$/.test(iso)) {
+  // Tighten to the RFC3339 / `format: date-time` shape that
+  // ajv-formats validates the schema against. The schemas use
+  // `format: date-time`; without these stricter regexes a buildRecord
+  // / writeRecord caller could accept timestamps (e.g. "T10:00Z" with
+  // no seconds, or "-0500" with no colon in the offset) that pass our
+  // accept-then-Date-parse path here AND then fail the read schema
+  // on the next aggregator pass. Required shape:
+  //   YYYY-MM-DDTHH:MM:SS(.fraction)?(Z | +HH:MM | -HH:MM)
+  // — seconds always required, offset must include the colon.
+  const rfc3339Z = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+  const rfc3339Offset = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?[+-]\d{2}:\d{2}$/;
+  if (rfc3339Z.test(iso) || rfc3339Offset.test(iso)) {
     const d = new Date(iso);
     if (Number.isNaN(d.getTime())) {
-      throw new Error(`metrics: ${fieldName} unparseable as ISO 8601; got ${JSON.stringify(iso)}`);
+      throw new Error(`metrics: ${fieldName} unparseable as RFC3339 / ISO 8601 date-time; got ${JSON.stringify(iso)}`);
     }
     const yyyy = d.getUTCFullYear();
     const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
@@ -491,7 +501,7 @@ export function utcDateFromIso(iso, fieldName = "timestamp") {
     return `${yyyy}-${mm}-${dd}`;
   }
   throw new Error(
-    `metrics: ${fieldName} must be ISO 8601 with Z or +/-HH:MM offset; got ${JSON.stringify(iso)}`,
+    `metrics: ${fieldName} must be RFC3339 date-time (YYYY-MM-DDTHH:MM:SS(.fraction)? followed by Z or +/-HH:MM); got ${JSON.stringify(iso)}`,
   );
 }
 

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -98,6 +98,15 @@ export function newTraceId() {
  * @returns {object}
  */
 export function buildRecord(input) {
+  // Explicit object guard so a caller passing null / undefined / a
+  // primitive gets a stable `metrics.buildRecord:` error instead of a
+  // generic `Cannot read properties of null` TypeError thrown by the
+  // `input[k]` access in the required-field loop below.
+  if (input == null || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error(
+      `metrics.buildRecord: input must be a plain object; got ${input === null ? "null" : Array.isArray(input) ? "array" : typeof input}`,
+    );
+  }
   const required = ["skill", "started_at", "ended_at", "tokens"];
   for (const k of required) {
     if (input[k] == null) throw new Error(`metrics.buildRecord: ${k} is required`);

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -1,0 +1,223 @@
+// scripts/lib/metrics/record.mjs
+//
+// Per-skill invocation recorder. Appends ONE JSONL line per invocation
+// to .claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl, keyed by the start
+// timestamp's UTC date. Pure record-side logic; the aggregator
+// (aggregate.mjs) reads these files to produce weekly rollups.
+//
+// Record shape: schemas/metrics-record.schema.json. The recorder
+// produces records that conform to that schema; aggregate-time
+// validation is the consumer's job (record-time validation would
+// add latency to every skill invocation for marginal value).
+//
+// Cost computation: cost_usd is derived from the four token fields and
+// a model rate table. The table covers the rates documented at the
+// time of writing; callers may pass `rates` explicitly to override
+// (useful in tests and when a model's rate changes between releases).
+
+import { mkdirSync, appendFileSync, existsSync } from "node:fs";
+import { dirname, join, resolve, sep } from "node:path";
+import { randomBytes } from "node:crypto";
+
+// Per-million-token rates in USD. Source: documented Anthropic public
+// pricing at the time of authoring. Override via `opts.rates` when
+// invoking record(); aggregate-time computations also accept overrides.
+//
+// Wildcard `default` is used when the model field is absent or unknown
+// so an invocation never lands with cost=0 silently.
+export const DEFAULT_RATES = {
+  "claude-opus-4-7":      { input: 15.00, output: 75.00, cache_read: 1.50, cache_write: 18.75 },
+  "claude-sonnet-4-6":    { input:  3.00, output: 15.00, cache_read: 0.30, cache_write:  3.75 },
+  "claude-haiku-4-5":     { input:  1.00, output:  5.00, cache_read: 0.10, cache_write:  1.25 },
+  default:                { input:  3.00, output: 15.00, cache_read: 0.30, cache_write:  3.75 },
+};
+
+/**
+ * Compute the USD cost for one invocation's tokens against a rate table.
+ * Pure: same inputs always produce the same output. Rates are per
+ * million tokens; we divide once.
+ *
+ * @param {{input:number, output:number, cache_read:number, cache_write:number}} tokens
+ * @param {string} [model]
+ * @param {typeof DEFAULT_RATES} [rates]
+ * @returns {number}
+ */
+export function computeCostUsd(tokens, model, rates = DEFAULT_RATES) {
+  const rate = (model && rates[model]) || rates.default;
+  const cost =
+    (tokens.input * rate.input) +
+    (tokens.output * rate.output) +
+    (tokens.cache_read * rate.cache_read) +
+    (tokens.cache_write * rate.cache_write);
+  // Round to 6 dp to keep JSONL stable. JSON.stringify on Number is
+  // ECMAScript-spec-stable for finite values, but we round defensively
+  // so cross-process JSON diffs stay byte-identical.
+  return Number((cost / 1_000_000).toFixed(6));
+}
+
+/**
+ * Generate a stable trace id. Stays independent of process.pid so
+ * subagent invocations don't collide with parents on the same host.
+ * @returns {string}
+ */
+export function newTraceId() {
+  return `t-${randomBytes(8).toString("hex")}`;
+}
+
+/**
+ * Build a record from the supplied invocation summary. Returns the
+ * record object so callers can inspect it before writing (useful in
+ * tests). The `tokens` object MUST carry all four fields; pass 0 for
+ * any that don't apply.
+ *
+ * @param {object} input
+ * @param {string} input.skill
+ * @param {string} input.started_at  ISO 8601
+ * @param {string} input.ended_at    ISO 8601
+ * @param {{input:number, output:number, cache_read:number, cache_write:number}} input.tokens
+ * @param {string} [input.trace_id]
+ * @param {string} [input.parent_trace_id]
+ * @param {string} [input.model]
+ * @param {{count:number, total_tokens:number}} [input.subagents]
+ * @param {string[]} [input.mcp_servers_used]
+ * @param {"success"|"halt"|"fault"|"error"|"cancelled"} [input.exit]
+ * @param {typeof DEFAULT_RATES} [input.rates]
+ * @returns {object}
+ */
+export function buildRecord(input) {
+  const required = ["skill", "started_at", "ended_at", "tokens"];
+  for (const k of required) {
+    if (input[k] == null) throw new Error(`metrics.buildRecord: ${k} is required`);
+  }
+  const tokens = normaliseTokens(input.tokens);
+  const record = {
+    trace_id: input.trace_id ?? newTraceId(),
+    parent_trace_id: input.parent_trace_id ?? null,
+    skill: input.skill,
+    started_at: input.started_at,
+    ended_at: input.ended_at,
+    tokens,
+    cost_usd: computeCostUsd(tokens, input.model, input.rates),
+    exit: input.exit ?? "success",
+  };
+  if (input.model) record.model = input.model;
+  if (input.subagents) {
+    record.subagents = {
+      count: int(input.subagents.count),
+      total_tokens: int(input.subagents.total_tokens),
+    };
+  }
+  if (Array.isArray(input.mcp_servers_used) && input.mcp_servers_used.length > 0) {
+    // Dedupe + sort so JSONL diffs stay stable across record orderings.
+    record.mcp_servers_used = [...new Set(input.mcp_servers_used)].sort();
+  }
+  return record;
+}
+
+/**
+ * Write a record to the daily JSONL file. The path is computed from the
+ * record's started_at field's UTC date so the file boundary is stable
+ * regardless of the recorder's local timezone.
+ *
+ * Returns the absolute path written so callers can log it.
+ *
+ * @param {object} record  output of buildRecord()
+ * @param {string} stateDir  absolute path to .claude/state (or test scratch dir)
+ * @returns {string} the path of the JSONL file the record was appended to
+ */
+export function writeRecord(record, stateDir) {
+  if (!record || typeof record !== "object") {
+    throw new Error("metrics.writeRecord: record must be an object");
+  }
+  if (typeof stateDir !== "string" || stateDir.length === 0) {
+    throw new Error("metrics.writeRecord: stateDir must be a non-empty string");
+  }
+  // Reject path-traversal in the skill name as a defence-in-depth
+  // measure: skill is interpolated into NOTHING below, but the schema
+  // additionalProperties:false will reject malformed records on read,
+  // and we'd rather catch it on write.
+  if (typeof record.skill !== "string" || record.skill.includes("/") || record.skill.includes("..")) {
+    throw new Error(`metrics.writeRecord: invalid skill name ${JSON.stringify(record.skill)}`);
+  }
+  const date = utcDateFromIso(record.started_at);
+  const dir = resolve(stateDir, "metrics");
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const file = join(dir, `${date}.jsonl`);
+  // Append exactly one JSON line. JSON.stringify on plain objects is
+  // deterministic for primitive values (the only kind we accept), so
+  // the line bytes don't depend on key insertion order at the schema
+  // level — but to be defensively stable, render through an explicit
+  // key order.
+  const line = JSON.stringify(record) + "\n";
+  appendFileSync(file, line);
+  return file;
+}
+
+/**
+ * Convenience: build + write in one shot. Returns the record AND the
+ * file path, in case the caller wants to log the trace_id back to the
+ * skill state.
+ */
+export function record(input, stateDir) {
+  const r = buildRecord(input);
+  const path = writeRecord(r, stateDir);
+  return { record: r, path };
+}
+
+// ---------- internals ----------
+
+function normaliseTokens(t) {
+  if (!t || typeof t !== "object") {
+    throw new Error("metrics: tokens must be an object");
+  }
+  return {
+    input: int(t.input),
+    output: int(t.output),
+    cache_read: int(t.cache_read),
+    cache_write: int(t.cache_write),
+  };
+}
+
+function int(v) {
+  const n = Number(v ?? 0);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new Error(`metrics: token counts must be non-negative finite numbers; got ${v}`);
+  }
+  return Math.trunc(n);
+}
+
+/**
+ * Extract the UTC YYYY-MM-DD prefix from an ISO 8601 string. We do not
+ * use new Date() round-tripping because the input may already be the
+ * canonical "2026-04-28T..." form and we want to preserve the exact
+ * date no matter what the host's locale says.
+ *
+ * @param {string} iso
+ * @returns {string}
+ */
+export function utcDateFromIso(iso) {
+  if (typeof iso !== "string" || !/^\d{4}-\d{2}-\d{2}T/.test(iso)) {
+    throw new Error(`metrics: started_at must be ISO 8601 with date prefix; got ${JSON.stringify(iso)}`);
+  }
+  return iso.slice(0, 10);
+}
+
+// Resolve the state-metrics directory for a given project root. The
+// installer (scripts/install.mjs) is the canonical owner of the
+// `.claude/state/` path; centralising it here keeps callers consistent
+// even when ops.config eventually lets a project relocate it.
+export function metricsDirForProject(projectRoot) {
+  return resolve(projectRoot, ".claude", "state", "metrics");
+}
+
+// Build a portable POSIX-style relative path so callers logging
+// `recorded to <path>` get a consistent shape across OSes.
+export function toPosixRelative(absPath, base) {
+  const rel = absPath.startsWith(base) ? absPath.slice(base.length) : absPath;
+  return rel.split(sep).filter(Boolean).join("/");
+}
+
+// `dirname` is re-exported only because callers using `metricsDirForProject`
+// sometimes want the parent of the metrics dir. Keep this minimal so we
+// don't grow a kitchen-sink module.
+export { dirname };

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -53,7 +53,19 @@ export const DEFAULT_RATES = {
  * @returns {number}
  */
 export function computeCostUsd(tokens, model, rates = DEFAULT_RATES) {
-  const rate = (model && rates[model]) || rates.default;
+  // Resolve the rate: model-specific entry first, fall back to the
+  // table's `default`, and FINALLY fall back to DEFAULT_RATES.default
+  // when the caller passed an override map without a `default` entry.
+  // The previous code dereferenced an undefined `rate` if the override
+  // omitted both the model AND `default`, throwing a generic "Cannot
+  // read properties of undefined" instead of producing a sensible
+  // result. Falling through to DEFAULT_RATES.default keeps cost
+  // reporting non-zero in that pathological case (callers can still
+  // pass a complete override when they need exact rates).
+  const rate =
+    (model && rates && rates[model]) ||
+    (rates && rates.default) ||
+    DEFAULT_RATES.default;
   const cost =
     (tokens.input * rate.input) +
     (tokens.output * rate.output) +
@@ -162,6 +174,22 @@ export function writeRecord(record, stateDir) {
   // second line of defence; this is the first.
   if (typeof record.skill !== "string" || !/^[a-z0-9][a-z0-9_-]*$/.test(record.skill)) {
     throw new Error(`metrics.writeRecord: invalid skill name ${JSON.stringify(record.skill)} (expected /^[a-z0-9][a-z0-9_-]*$/)`);
+  }
+  // Validate the nested `tokens` shape too: all four keys must be
+  // non-negative finite numbers. Without this check, a caller that
+  // hand-built a record (skipping buildRecord) could land a JSONL
+  // line whose tokens object is missing fields or carries strings;
+  // the read schema would reject it on aggregator-side validation,
+  // but the file would already be on disk. Fail at write time so the
+  // bad record never lands.
+  if (record.tokens == null || typeof record.tokens !== "object") {
+    throw new Error("metrics.writeRecord: record.tokens must be an object with input/output/cache_read/cache_write");
+  }
+  for (const k of ["input", "output", "cache_read", "cache_write"]) {
+    const v = record.tokens[k];
+    if (typeof v !== "number" || !Number.isFinite(v) || v < 0) {
+      throw new Error(`metrics.writeRecord: record.tokens.${k} must be a non-negative finite number; got ${JSON.stringify(v)}`);
+    }
   }
   const date = utcDateFromIso(record.started_at);
   const dir = resolve(stateDir, "metrics");

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -6,9 +6,16 @@
 // (aggregate.mjs) reads these files to produce weekly rollups.
 //
 // Record shape: schemas/metrics-record.schema.json. The recorder
-// produces records that conform to that schema; aggregate-time
-// validation is the consumer's job (record-time validation would
-// add latency to every skill invocation for marginal value).
+// runs lightweight runtime validation BEFORE appending each JSONL
+// line: pattern checks on trace_id / parent_trace_id / skill,
+// shape checks on tokens / subagents / mcp_servers_used, RFC3339
+// shape on started_at / ended_at, exit-enum membership, etc. (see
+// buildRecord + writeRecord). Full ajv schema validation is NOT
+// run on every write — that would add hot-path latency for the
+// recorder. The aggregator side stays loose by design too (see
+// aggregate.mjs::readRecordsInWindow); third-party consumers
+// that want strict schema enforcement can run ajv against the
+// schema themselves.
 //
 // orderedRecord() projects every object level through an explicit
 // whitelist: the top-level keys against RECORD_KEY_ORDER, and the

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -434,8 +434,13 @@ export function record(input, stateDir) {
 // ---------- internals ----------
 
 function normaliseTokens(t) {
-  if (!t || typeof t !== "object") {
-    throw new Error("metrics: tokens must be an object");
+  // Reject arrays explicitly. `typeof [] === "object"` is true, so
+  // `tokens: []` would silently coerce all four fields to 0 via
+  // int() and produce a schema-valid record with zero token counts
+  // and zero cost. That hides caller mistakes; require a plain
+  // (non-array) object.
+  if (t == null || typeof t !== "object" || Array.isArray(t)) {
+    throw new Error("metrics: tokens must be a plain object with input/output/cache_read/cache_write");
   }
   return {
     input: int(t.input),

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -67,10 +67,19 @@ export function computeCostUsd(tokens, model, rates = DEFAULT_RATES) {
   // opus rate. The DEFAULT_RATES.default tail keeps cost non-zero
   // even when the override omits both the model AND `default`, so
   // computeCostUsd never throws on a partial map.
+  // Use Object.hasOwn at every step so model values that match
+  // inherited Object.prototype properties ("toString", "valueOf",
+  // "__proto__", "constructor", ...) never accidentally resolve to
+  // a non-rate function/value, which would coerce to NaN through
+  // the multiplications below and downstream blow up writeRecord's
+  // cost_usd validation. The own-property check ALSO defends against
+  // a malicious input pretending to set `__proto__` to spoof a
+  // pricing entry, which is cheap insurance even though the model
+  // string is normally agent-supplied.
   const rate =
-    (model && rates && rates[model]) ||
-    (model && DEFAULT_RATES[model]) ||
-    (rates && rates.default) ||
+    pickRate(rates, model) ||
+    pickRate(DEFAULT_RATES, model) ||
+    pickRate(rates, "default") ||
     DEFAULT_RATES.default;
   const cost =
     (tokens.input * rate.input) +
@@ -81,6 +90,23 @@ export function computeCostUsd(tokens, model, rates = DEFAULT_RATES) {
   // ECMAScript-spec-stable for finite values, but we round defensively
   // so cross-process JSON diffs stay byte-identical.
   return Number((cost / 1_000_000).toFixed(6));
+}
+
+function pickRate(table, key) {
+  // Own-property + shape check. Returns the rate entry only when the
+  // table has its own (non-inherited) property at `key` AND the value
+  // looks like a rate object (numeric input/output/cache_read/cache_write).
+  // Falsy return signals "not a rate" so the chain in computeCostUsd
+  // can fall through to the next step.
+  if (table == null || typeof table !== "object") return null;
+  if (typeof key !== "string" || key.length === 0) return null;
+  if (!Object.hasOwn(table, key)) return null;
+  const r = table[key];
+  if (r == null || typeof r !== "object") return null;
+  for (const f of ["input", "output", "cache_read", "cache_write"]) {
+    if (typeof r[f] !== "number" || !Number.isFinite(r[f])) return null;
+  }
+  return r;
 }
 
 /**

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -10,12 +10,15 @@
 // validation is the consumer's job (record-time validation would
 // add latency to every skill invocation for marginal value).
 //
-// Top-level keys are rendered through orderedRecord() with an
-// explicit RECORD_KEY_ORDER so two callers passing the same logical
-// record write byte-identical JSONL lines. Nested objects (`tokens`,
-// `subagents`) are constructed inside this module with deterministic
-// key insertion (see normaliseTokens / buildRecord); they are not
-// re-sorted on write because callers cannot reach in to mutate them.
+// orderedRecord() projects every object level through an explicit
+// whitelist: the top-level keys against RECORD_KEY_ORDER, and the
+// nested `tokens` / `subagents` objects against their own per-key
+// allow-lists. Two callers passing the same logical record write
+// byte-identical JSONL lines AND any unknown key the caller has
+// reached in to add (after buildRecord returned the object) is
+// dropped at write time. That keeps the schema's
+// `additionalProperties: false` guarantee load-bearing on write,
+// not just on aggregator-side validation.
 //
 // Cost computation: cost_usd is derived from the four token fields and
 // a model rate table. The table covers the rates documented at the
@@ -180,16 +183,42 @@ const RECORD_KEY_ORDER = [
   "exit",
 ];
 
+// Per-nested-object key whitelists. Both `tokens` and `subagents` set
+// `additionalProperties: false` in their schemas; mirroring those
+// allow-lists here means a caller that mutates the object returned
+// from buildRecord (e.g. to smuggle a `tokens.thinking` count) gets
+// the unknown key dropped at write time, the same way an unknown
+// top-level key gets dropped.
+const TOKENS_KEY_ORDER = ["input", "output", "cache_read", "cache_write"];
+const SUBAGENTS_KEY_ORDER = ["count", "total_tokens"];
+
 function orderedRecord(record) {
-  // Whitelist-only: drop any key the schema doesn't know about. The
-  // record schema sets `additionalProperties: false`, so a record
-  // that smuggled an extra field through writeRecord would be
-  // rejected on read. Enforcing the same contract on write keeps the
-  // privacy guarantee strict and makes the recorder's shape
+  // Whitelist-only at every layer: drop any key the schema doesn't
+  // know about. The record schema sets `additionalProperties: false`
+  // at top-level AND on the nested `tokens` and `subagents` objects;
+  // a record that smuggled an extra field through writeRecord would
+  // be rejected on read. Enforcing the same contract on write keeps
+  // the privacy guarantee strict and makes the recorder's shape
   // predictable for downstream consumers.
   const out = {};
   for (const k of RECORD_KEY_ORDER) {
-    if (k in record && record[k] !== undefined) out[k] = record[k];
+    if (!(k in record) || record[k] === undefined) continue;
+    if (k === "tokens") out[k] = projectKeys(record[k], TOKENS_KEY_ORDER);
+    else if (k === "subagents") out[k] = projectKeys(record[k], SUBAGENTS_KEY_ORDER);
+    else out[k] = record[k];
+  }
+  return out;
+}
+
+function projectKeys(obj, keys) {
+  // Pure projection: take only the keys we know, in canonical order,
+  // dropping unknown keys silently. The caller is responsible for
+  // having validated the values via buildRecord; this helper is the
+  // last-mile shape filter.
+  const out = {};
+  if (!obj || typeof obj !== "object") return out;
+  for (const k of keys) {
+    if (k in obj && obj[k] !== undefined) out[k] = obj[k];
   }
   return out;
 }

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -181,14 +181,16 @@ const RECORD_KEY_ORDER = [
 ];
 
 function orderedRecord(record) {
+  // Whitelist-only: drop any key the schema doesn't know about. The
+  // record schema sets `additionalProperties: false`, so a record
+  // that smuggled an extra field through writeRecord would be
+  // rejected on read. Enforcing the same contract on write keeps the
+  // privacy guarantee strict and makes the recorder's shape
+  // predictable for downstream consumers.
   const out = {};
   for (const k of RECORD_KEY_ORDER) {
     if (k in record && record[k] !== undefined) out[k] = record[k];
   }
-  // Defensive: any unknown key (the schema forbids it on read but the
-  // recorder is permissive on write) is appended in lex order.
-  const extras = Object.keys(record).filter((k) => !RECORD_KEY_ORDER.includes(k)).sort();
-  for (const k of extras) out[k] = record[k];
   return out;
 }
 

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -53,17 +53,23 @@ export const DEFAULT_RATES = {
  * @returns {number}
  */
 export function computeCostUsd(tokens, model, rates = DEFAULT_RATES) {
-  // Resolve the rate: model-specific entry first, fall back to the
-  // table's `default`, and FINALLY fall back to DEFAULT_RATES.default
-  // when the caller passed an override map without a `default` entry.
-  // The previous code dereferenced an undefined `rate` if the override
-  // omitted both the model AND `default`, throwing a generic "Cannot
-  // read properties of undefined" instead of producing a sensible
-  // result. Falling through to DEFAULT_RATES.default keeps cost
-  // reporting non-zero in that pathological case (callers can still
-  // pass a complete override when they need exact rates).
+  // Resolve the rate by walking a four-step fallback chain:
+  //   1. caller's override at rates[model]      (most specific)
+  //   2. DEFAULT_RATES[model]                   (known model, just not overridden)
+  //   3. caller's rates.default                 (caller's chosen default)
+  //   4. DEFAULT_RATES.default                  (last-resort sane number)
+  // The DEFAULT_RATES[model] step matters: a caller that overrides
+  // pricing for one model should NOT cause every OTHER known model to
+  // fall to the caller's default rate. Without this step, a record
+  // for claude-opus-4-7 priced through an override map that defines
+  // only "some-other-model" + "default" would silently use the
+  // (probably-wrong) default-tier price instead of the documented
+  // opus rate. The DEFAULT_RATES.default tail keeps cost non-zero
+  // even when the override omits both the model AND `default`, so
+  // computeCostUsd never throws on a partial map.
   const rate =
     (model && rates && rates[model]) ||
+    (model && DEFAULT_RATES[model]) ||
     (rates && rates.default) ||
     DEFAULT_RATES.default;
   const cost =

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -102,16 +102,21 @@ export function computeCostUsd(tokens, model, rates = DEFAULT_RATES) {
 function pickRate(table, key) {
   // Own-property + shape check. Returns the rate entry only when the
   // table has its own (non-inherited) property at `key` AND the value
-  // looks like a rate object (numeric input/output/cache_read/cache_write).
-  // Falsy return signals "not a rate" so the chain in computeCostUsd
-  // can fall through to the next step.
+  // looks like a rate object: numeric, finite, AND non-negative
+  // input/output/cache_read/cache_write fields. A negative rate
+  // would propagate through computeCostUsd as a negative cost_usd
+  // and trip writeRecord's `cost_usd >= 0` validation later; reject
+  // the entry here so the fallback chain falls through to a saner
+  // table instead of producing the bad value at all.
+  // Falsy return signals "not a rate".
   if (table == null || typeof table !== "object") return null;
   if (typeof key !== "string" || key.length === 0) return null;
   if (!Object.hasOwn(table, key)) return null;
   const r = table[key];
   if (r == null || typeof r !== "object") return null;
   for (const f of ["input", "output", "cache_read", "cache_write"]) {
-    if (typeof r[f] !== "number" || !Number.isFinite(r[f])) return null;
+    const v = r[f];
+    if (typeof v !== "number" || !Number.isFinite(v) || v < 0) return null;
   }
   return r;
 }
@@ -217,8 +222,8 @@ export function buildRecord(input) {
       throw new Error(`metrics.buildRecord: subagents.count and subagents.total_tokens are required numeric fields; got ${JSON.stringify(input.subagents)}`);
     }
     record.subagents = {
-      count: int(input.subagents.count),
-      total_tokens: int(input.subagents.total_tokens),
+      count: int(input.subagents.count, "subagents.count"),
+      total_tokens: int(input.subagents.total_tokens, "subagents.total_tokens"),
     };
   }
   if (input.mcp_servers_used != null) {
@@ -443,17 +448,21 @@ function normaliseTokens(t) {
     throw new Error("metrics: tokens must be a plain object with input/output/cache_read/cache_write");
   }
   return {
-    input: int(t.input),
-    output: int(t.output),
-    cache_read: int(t.cache_read),
-    cache_write: int(t.cache_write),
+    input: int(t.input, "tokens.input"),
+    output: int(t.output, "tokens.output"),
+    cache_read: int(t.cache_read, "tokens.cache_read"),
+    cache_write: int(t.cache_write, "tokens.cache_write"),
   };
 }
 
-function int(v) {
+function int(v, label = "value") {
+  // `label` lets callers identify the offending field in the error
+  // message. Used for both tokens.* and subagents.{count,total_tokens};
+  // the previous hard-coded "token counts" wording was misleading
+  // when subagents validation tripped here.
   const n = Number(v ?? 0);
   if (!Number.isFinite(n) || n < 0) {
-    throw new Error(`metrics: token counts must be non-negative finite numbers; got ${v}`);
+    throw new Error(`metrics: ${label} must be a non-negative finite number; got ${v}`);
   }
   return Math.trunc(n);
 }

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -67,8 +67,11 @@ export function newTraceId() {
 /**
  * Build a record from the supplied invocation summary. Returns the
  * record object so callers can inspect it before writing (useful in
- * tests). The `tokens` object MUST carry all four fields; pass 0 for
- * any that don't apply.
+ * tests). The `tokens` object SHOULD carry all four fields
+ * (input, output, cache_read, cache_write); missing fields coerce to
+ * 0, so a caller that only knows two of them still produces a valid
+ * record. Negative or non-finite values throw; the schema's "minimum:
+ * 0" constraint is the contract.
  *
  * @param {object} input
  * @param {string} input.skill
@@ -132,25 +135,54 @@ export function writeRecord(record, stateDir) {
   if (typeof stateDir !== "string" || stateDir.length === 0) {
     throw new Error("metrics.writeRecord: stateDir must be a non-empty string");
   }
-  // Reject path-traversal in the skill name as a defence-in-depth
-  // measure: skill is interpolated into NOTHING below, but the schema
-  // additionalProperties:false will reject malformed records on read,
-  // and we'd rather catch it on write.
-  if (typeof record.skill !== "string" || record.skill.includes("/") || record.skill.includes("..")) {
-    throw new Error(`metrics.writeRecord: invalid skill name ${JSON.stringify(record.skill)}`);
+  // Reject path-traversal AND any path-separator in the skill name.
+  // Use an allowlist regex (lowercase alnum + `-` + `_`) — that's a
+  // proper superset of every skill name the bundle ships and rules out
+  // both POSIX `/` and Windows `\\` separators in one check, plus `..`
+  // segments. additionalProperties:false on the read schema is the
+  // second line of defence; this is the first.
+  if (typeof record.skill !== "string" || !/^[a-z0-9][a-z0-9_-]*$/.test(record.skill)) {
+    throw new Error(`metrics.writeRecord: invalid skill name ${JSON.stringify(record.skill)} (expected /^[a-z0-9][a-z0-9_-]*$/)`);
   }
   const date = utcDateFromIso(record.started_at);
   const dir = resolve(stateDir, "metrics");
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   const file = join(dir, `${date}.jsonl`);
-  // Append exactly one JSON line. JSON.stringify on plain objects is
-  // deterministic for primitive values (the only kind we accept), so
-  // the line bytes don't depend on key insertion order at the schema
-  // level — but to be defensively stable, render through an explicit
-  // key order.
-  const line = JSON.stringify(record) + "\n";
+  // Render the record with an explicit key order so the JSONL bytes
+  // don't depend on caller mutation order. Two callers that pass the
+  // same logical record produce byte-identical lines, which keeps
+  // diffs of the JSONL stable across recorder versions.
+  const line = JSON.stringify(orderedRecord(record)) + "\n";
   appendFileSync(file, line);
   return file;
+}
+
+// Canonical key order for a record on disk. Matches the field order in
+// schemas/metrics-record.schema.json.
+const RECORD_KEY_ORDER = [
+  "trace_id",
+  "parent_trace_id",
+  "skill",
+  "started_at",
+  "ended_at",
+  "model",
+  "tokens",
+  "cost_usd",
+  "subagents",
+  "mcp_servers_used",
+  "exit",
+];
+
+function orderedRecord(record) {
+  const out = {};
+  for (const k of RECORD_KEY_ORDER) {
+    if (k in record && record[k] !== undefined) out[k] = record[k];
+  }
+  // Defensive: any unknown key (the schema forbids it on read but the
+  // recorder is permissive on write) is appended in lex order.
+  const extras = Object.keys(record).filter((k) => !RECORD_KEY_ORDER.includes(k)).sort();
+  for (const k of extras) out[k] = record[k];
+  return out;
 }
 
 /**
@@ -202,12 +234,27 @@ export function utcDateFromIso(iso) {
   return iso.slice(0, 10);
 }
 
-// Resolve the state-metrics directory for a given project root. The
+// Resolve the .claude/state directory for a given project root. The
 // installer (scripts/install.mjs) is the canonical owner of the
 // `.claude/state/` path; centralising it here keeps callers consistent
 // even when ops.config eventually lets a project relocate it.
+//
+// IMPORTANT: writeRecord() expects this exact path (the parent of the
+// metrics/ subdir) and appends `metrics/<date>.jsonl` itself. A caller
+// passing `<root>/.claude/state/metrics` would produce a nested
+// `metrics/metrics/<date>.jsonl` — the helper below returns the
+// correct value. The legacy `metricsDirForProject` alias is kept as a
+// deprecated re-export for any out-of-tree caller that already wired
+// against it; it now points at the same `.claude/state` parent so its
+// output is the right one to feed writeRecord.
+export function stateDirForProject(projectRoot) {
+  return resolve(projectRoot, ".claude", "state");
+}
+
+// @deprecated use stateDirForProject; retained as an alias so existing
+// callers pass the right path to writeRecord (which appends `metrics`).
 export function metricsDirForProject(projectRoot) {
-  return resolve(projectRoot, ".claude", "state", "metrics");
+  return stateDirForProject(projectRoot);
 }
 
 // Build a portable POSIX-style relative path so callers logging

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -26,7 +26,7 @@
 // (useful in tests and when a model's rate changes between releases).
 
 import { mkdirSync, appendFileSync, existsSync } from "node:fs";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { randomBytes } from "node:crypto";
 
 // Per-million-token rates in USD. Source: documented Anthropic public
@@ -496,16 +496,11 @@ export function metricsDirForProject(projectRoot) {
   return stateDirForProject(projectRoot);
 }
 
-// Build a portable POSIX-style relative path so callers logging
-// `recorded to <path>` get a consistent shape across OSes. Uses
-// path.relative() rather than a raw startsWith strip so unrelated
-// path prefixes (e.g. base "/a/b" vs absPath "/a/bad/file") don't
-// produce a misleading "ad/file"; relative() emits "../bad/file"
-// instead.
-export function toPosixRelative(absPath, base) {
-  const rel = relative(base, absPath);
-  return rel.split(sep).filter(Boolean).join("/");
-}
+// Removed: in-file `toPosixRelative(absPath, base)`. It duplicated
+// scripts/lib/fsx.mjs::relPosix and reversed the argument order vs
+// Node's `path.relative(from, to)`. Callers that need a portable
+// POSIX-style relative path should import `relPosix(from, to)` from
+// scripts/lib/fsx.mjs directly.
 
 // `dirname` is re-exported only because callers using `metricsDirForProject`
 // sometimes want the parent of the metrics dir. Keep this minimal so we

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -129,6 +129,19 @@ export function buildRecord(input) {
   for (const k of required) {
     if (input[k] == null) throw new Error(`metrics.buildRecord: ${k} is required`);
   }
+  // Schema-conformance invariants. buildRecord is documented as
+  // producing schema-valid records; surface invariant violations
+  // here instead of relying on writeRecord to discover them at JSONL
+  // append time. Same patterns the schema enforces.
+  if (typeof input.skill !== "string" || !/^[a-z0-9][a-z0-9_-]*$/.test(input.skill)) {
+    throw new Error(`metrics.buildRecord: skill must match /^[a-z0-9][a-z0-9_-]*$/; got ${JSON.stringify(input.skill)}`);
+  }
+  if (input.parent_trace_id != null && (typeof input.parent_trace_id !== "string" || !/^t-[0-9a-f]{16}$/.test(input.parent_trace_id))) {
+    throw new Error(`metrics.buildRecord: parent_trace_id must match /^t-[0-9a-f]{16}$/ when present; got ${JSON.stringify(input.parent_trace_id)}`);
+  }
+  if (input.trace_id != null && (typeof input.trace_id !== "string" || !/^t-[0-9a-f]{16}$/.test(input.trace_id))) {
+    throw new Error(`metrics.buildRecord: trace_id must match /^t-[0-9a-f]{16}$/ when supplied; got ${JSON.stringify(input.trace_id)}`);
+  }
   const tokens = normaliseTokens(input.tokens);
   const record = {
     trace_id: input.trace_id ?? newTraceId(),
@@ -242,10 +255,15 @@ export function writeRecord(record, stateDir) {
     if (!Array.isArray(record.mcp_servers_used)) {
       throw new Error(`metrics.writeRecord: record.mcp_servers_used must be an array of strings when present; got ${JSON.stringify(record.mcp_servers_used)}`);
     }
+    const seen = new Set();
     for (const item of record.mcp_servers_used) {
       if (typeof item !== "string" || item.length === 0) {
         throw new Error(`metrics.writeRecord: record.mcp_servers_used items must be non-empty strings; got ${JSON.stringify(item)}`);
       }
+      if (seen.has(item)) {
+        throw new Error(`metrics.writeRecord: record.mcp_servers_used must contain unique items (schema uniqueItems:true); got duplicate ${JSON.stringify(item)}`);
+      }
+      seen.add(item);
     }
   }
   if (record.subagents !== undefined) {

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -142,6 +142,22 @@ export function buildRecord(input) {
   if (input.trace_id != null && (typeof input.trace_id !== "string" || !/^t-[0-9a-f]{16}$/.test(input.trace_id))) {
     throw new Error(`metrics.buildRecord: trace_id must match /^t-[0-9a-f]{16}$/ when supplied; got ${JSON.stringify(input.trace_id)}`);
   }
+  // ISO 8601 shape for started_at + ended_at. utcDateFromIso accepts
+  // both Z-form and offset-form and rejects naive timestamps; running
+  // it once here surfaces a malformed value at buildRecord time
+  // instead of writeRecord time. The result is discarded; we just
+  // want the throw on bad input.
+  utcDateFromIso(input.started_at, "started_at");
+  utcDateFromIso(input.ended_at, "ended_at");
+  if (input.exit != null) {
+    const validExits = new Set(["success", "halt", "fault", "error", "cancelled"]);
+    if (!validExits.has(input.exit)) {
+      throw new Error(`metrics.buildRecord: exit must be one of ${[...validExits].join(", ")} when present; got ${JSON.stringify(input.exit)}`);
+    }
+  }
+  if (input.model != null && typeof input.model !== "string") {
+    throw new Error(`metrics.buildRecord: model must be a string when present; got ${JSON.stringify(input.model)}`);
+  }
   const tokens = normaliseTokens(input.tokens);
   const record = {
     trace_id: input.trace_id ?? newTraceId(),
@@ -220,8 +236,10 @@ export function writeRecord(record, stateDir) {
   if (typeof record.trace_id !== "string" || !/^t-[0-9a-f]{16}$/.test(record.trace_id)) {
     throw new Error(`metrics.writeRecord: record.trace_id must match /^t-[0-9a-f]{16}$/; got ${JSON.stringify(record.trace_id)}`);
   }
-  if (record.parent_trace_id != null && typeof record.parent_trace_id !== "string") {
-    throw new Error(`metrics.writeRecord: record.parent_trace_id must be a string or null; got ${JSON.stringify(record.parent_trace_id)}`);
+  if (record.parent_trace_id != null) {
+    if (typeof record.parent_trace_id !== "string" || !/^t-[0-9a-f]{16}$/.test(record.parent_trace_id)) {
+      throw new Error(`metrics.writeRecord: record.parent_trace_id must match /^t-[0-9a-f]{16}$/ when present; got ${JSON.stringify(record.parent_trace_id)}`);
+    }
   }
   if (typeof record.started_at !== "string") {
     throw new Error(`metrics.writeRecord: record.started_at must be an ISO 8601 string; got ${JSON.stringify(record.started_at)}`);

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -219,7 +219,7 @@ export function writeRecord(record, stateDir) {
   // utcDateFromIso below already enforces ISO 8601 shape on started_at;
   // re-run it now on ended_at so a malformed value surfaces here, not
   // on the next aggregator pass.
-  utcDateFromIso(record.ended_at);
+  utcDateFromIso(record.ended_at, "ended_at");
   if (typeof record.cost_usd !== "number" || !Number.isFinite(record.cost_usd) || record.cost_usd < 0) {
     throw new Error(`metrics.writeRecord: record.cost_usd must be a non-negative finite number; got ${JSON.stringify(record.cost_usd)}`);
   }
@@ -227,7 +227,7 @@ export function writeRecord(record, stateDir) {
   if (!validExits.has(record.exit)) {
     throw new Error(`metrics.writeRecord: record.exit must be one of ${[...validExits].join(", ")}; got ${JSON.stringify(record.exit)}`);
   }
-  const date = utcDateFromIso(record.started_at);
+  const date = utcDateFromIso(record.started_at, "started_at");
   const dir = resolve(stateDir, "metrics");
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   const file = join(dir, `${date}.jsonl`);
@@ -338,23 +338,27 @@ function int(v) {
  * @param {string} iso
  * @returns {string}
  */
-export function utcDateFromIso(iso) {
+export function utcDateFromIso(iso, fieldName = "timestamp") {
   if (typeof iso !== "string") {
-    throw new Error(`metrics: started_at must be ISO 8601; got ${JSON.stringify(iso)}`);
+    throw new Error(`metrics: ${fieldName} must be ISO 8601; got ${JSON.stringify(iso)}`);
   }
   // Two acceptable shapes:
-  //   1. Strict UTC form ending in `Z`: slice the date prefix directly.
+  //   1. Strict UTC form ending in `Z`: parse via Date to reject
+  //      impossible dates like 2026-99-99T...Z (the regex shape would
+  //      otherwise pass and produce an impossible YYYY-MM-DD prefix
+  //      that breaks window selection downstream).
   //   2. ISO with a timezone offset: convert to UTC via Date so the
   //      file-boundary date reflects the UTC calendar day, NOT the
   //      caller's local day. Without this, `2026-04-28T23:30:00-05:00`
   //      (an instant on UTC 2026-04-29) would land in the 04-28 file.
-  if (/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/.test(iso)) {
-    return iso.slice(0, 10);
-  }
-  if (/^\d{4}-\d{2}-\d{2}T[\d:.]+(?:[+-]\d{2}:?\d{2})$/.test(iso)) {
+  // Both branches now go through the same Date parse + UTC extract;
+  // the regex pre-filter still rejects shapes the spec disallows
+  // (e.g. naive timestamps with no zone designator).
+  if (/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/.test(iso) ||
+      /^\d{4}-\d{2}-\d{2}T[\d:.]+(?:[+-]\d{2}:?\d{2})$/.test(iso)) {
     const d = new Date(iso);
     if (Number.isNaN(d.getTime())) {
-      throw new Error(`metrics: started_at unparseable as ISO 8601; got ${JSON.stringify(iso)}`);
+      throw new Error(`metrics: ${fieldName} unparseable as ISO 8601; got ${JSON.stringify(iso)}`);
     }
     const yyyy = d.getUTCFullYear();
     const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
@@ -362,7 +366,7 @@ export function utcDateFromIso(iso) {
     return `${yyyy}-${mm}-${dd}`;
   }
   throw new Error(
-    `metrics: started_at must be ISO 8601 with Z or +/-HH:MM offset; got ${JSON.stringify(iso)}`,
+    `metrics: ${fieldName} must be ISO 8601 with Z or +/-HH:MM offset; got ${JSON.stringify(iso)}`,
   );
 }
 

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -10,6 +10,13 @@
 // validation is the consumer's job (record-time validation would
 // add latency to every skill invocation for marginal value).
 //
+// Top-level keys are rendered through orderedRecord() with an
+// explicit RECORD_KEY_ORDER so two callers passing the same logical
+// record write byte-identical JSONL lines. Nested objects (`tokens`,
+// `subagents`) are constructed inside this module with deterministic
+// key insertion (see normaliseTokens / buildRecord); they are not
+// re-sorted on write because callers cannot reach in to mutate them.
+//
 // Cost computation: cost_usd is derived from the four token fields and
 // a model rate table. The table covers the rates documented at the
 // time of writing; callers may pass `rates` explicitly to override

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -248,8 +248,8 @@ export function writeRecord(record, stateDir) {
   }
   for (const k of ["input", "output", "cache_read", "cache_write"]) {
     const v = record.tokens[k];
-    if (typeof v !== "number" || !Number.isFinite(v) || v < 0) {
-      throw new Error(`metrics.writeRecord: record.tokens.${k} must be a non-negative finite number; got ${JSON.stringify(v)}`);
+    if (typeof v !== "number" || !Number.isFinite(v) || v < 0 || !Number.isInteger(v)) {
+      throw new Error(`metrics.writeRecord: record.tokens.${k} must be a non-negative integer; got ${JSON.stringify(v)}`);
     }
   }
   // Validate the remaining required top-level fields. A caller that
@@ -425,13 +425,21 @@ function int(v) {
 }
 
 /**
- * Extract the UTC YYYY-MM-DD prefix from an ISO 8601 string. We do not
- * use new Date() round-tripping because the input may already be the
- * canonical "2026-04-28T..." form and we want to preserve the exact
- * date no matter what the host's locale says.
+ * Extract the UTC YYYY-MM-DD calendar day from an ISO 8601 string.
+ * Both accepted shapes (Z-form and explicit-offset form) go through
+ * `new Date(iso)` for two reasons:
+ *   1. Reject impossible dates like "2026-99-99T..." that would
+ *      otherwise pass the regex pre-filter and produce an invalid
+ *      YYYY-MM-DD prefix.
+ *   2. Normalise an offset timestamp (e.g. "2026-04-28T23:30:00-05:00",
+ *      which is UTC 2026-04-29) to the correct UTC calendar day.
+ * The Date object's UTC accessors are independent of the host's
+ * locale, so the output is stable across machines.
  *
  * @param {string} iso
- * @returns {string}
+ * @param {string} [fieldName] field label used in error messages
+ *                             (e.g. "started_at", "ended_at")
+ * @returns {string} YYYY-MM-DD
  */
 export function utcDateFromIso(iso, fieldName = "timestamp") {
   if (typeof iso !== "string") {

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -197,6 +197,36 @@ export function writeRecord(record, stateDir) {
       throw new Error(`metrics.writeRecord: record.tokens.${k} must be a non-negative finite number; got ${JSON.stringify(v)}`);
     }
   }
+  // Validate the remaining required top-level fields. A caller that
+  // bypassed buildRecord (or mutated its output) could otherwise land
+  // a JSONL line with a missing trace_id, an unparseable started_at,
+  // or a negative cost, and the read schema would only reject it
+  // later (when it is already on disk and may have skewed the rollup
+  // for one or more weeks). Fail at write time so the bad record
+  // never lands on disk.
+  if (typeof record.trace_id !== "string" || !/^t-[0-9a-f]{16}$/.test(record.trace_id)) {
+    throw new Error(`metrics.writeRecord: record.trace_id must match /^t-[0-9a-f]{16}$/; got ${JSON.stringify(record.trace_id)}`);
+  }
+  if (record.parent_trace_id != null && typeof record.parent_trace_id !== "string") {
+    throw new Error(`metrics.writeRecord: record.parent_trace_id must be a string or null; got ${JSON.stringify(record.parent_trace_id)}`);
+  }
+  if (typeof record.started_at !== "string") {
+    throw new Error(`metrics.writeRecord: record.started_at must be an ISO 8601 string; got ${JSON.stringify(record.started_at)}`);
+  }
+  if (typeof record.ended_at !== "string") {
+    throw new Error(`metrics.writeRecord: record.ended_at must be an ISO 8601 string; got ${JSON.stringify(record.ended_at)}`);
+  }
+  // utcDateFromIso below already enforces ISO 8601 shape on started_at;
+  // re-run it now on ended_at so a malformed value surfaces here, not
+  // on the next aggregator pass.
+  utcDateFromIso(record.ended_at);
+  if (typeof record.cost_usd !== "number" || !Number.isFinite(record.cost_usd) || record.cost_usd < 0) {
+    throw new Error(`metrics.writeRecord: record.cost_usd must be a non-negative finite number; got ${JSON.stringify(record.cost_usd)}`);
+  }
+  const validExits = new Set(["success", "halt", "fault", "error", "cancelled"]);
+  if (!validExits.has(record.exit)) {
+    throw new Error(`metrics.writeRecord: record.exit must be one of ${[...validExits].join(", ")}; got ${JSON.stringify(record.exit)}`);
+  }
   const date = utcDateFromIso(record.started_at);
   const dir = resolve(stateDir, "metrics");
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -196,15 +196,37 @@ export function buildRecord(input) {
     exit: input.exit ?? "success",
   };
   if (input.model) record.model = input.model;
-  if (input.subagents) {
+  if (input.subagents != null) {
+    // Strict shape check. The previous truthy guard accepted any
+    // non-falsy value (including `true`, `42`, `"yes"`) and silently
+    // coerced count / total_tokens through int(), which masks real
+    // caller mistakes. buildRecord is documented as producing
+    // schema-conformant records, so reject anything that is not a
+    // plain object with the two required numeric fields.
+    if (typeof input.subagents !== "object" || Array.isArray(input.subagents)) {
+      throw new Error(`metrics.buildRecord: subagents must be an object with {count, total_tokens} when present; got ${JSON.stringify(input.subagents)}`);
+    }
+    if (typeof input.subagents.count !== "number" || typeof input.subagents.total_tokens !== "number") {
+      throw new Error(`metrics.buildRecord: subagents.count and subagents.total_tokens are required numeric fields; got ${JSON.stringify(input.subagents)}`);
+    }
     record.subagents = {
       count: int(input.subagents.count),
       total_tokens: int(input.subagents.total_tokens),
     };
   }
-  if (Array.isArray(input.mcp_servers_used) && input.mcp_servers_used.length > 0) {
-    // Dedupe + sort so JSONL diffs stay stable across record orderings.
-    record.mcp_servers_used = [...new Set(input.mcp_servers_used)].sort();
+  if (input.mcp_servers_used != null) {
+    if (!Array.isArray(input.mcp_servers_used)) {
+      throw new Error(`metrics.buildRecord: mcp_servers_used must be an array of non-empty strings when present; got ${JSON.stringify(input.mcp_servers_used)}`);
+    }
+    for (const item of input.mcp_servers_used) {
+      if (typeof item !== "string" || item.length === 0) {
+        throw new Error(`metrics.buildRecord: mcp_servers_used items must be non-empty strings; got ${JSON.stringify(item)}`);
+      }
+    }
+    if (input.mcp_servers_used.length > 0) {
+      // Dedupe + sort so JSONL diffs stay stable across record orderings.
+      record.mcp_servers_used = [...new Set(input.mcp_servers_used)].sort();
+    }
   }
   return record;
 }

--- a/scripts/lib/metrics/record.mjs
+++ b/scripts/lib/metrics/record.mjs
@@ -23,7 +23,7 @@
 // (useful in tests and when a model's rate changes between releases).
 
 import { mkdirSync, appendFileSync, existsSync } from "node:fs";
-import { dirname, join, resolve, sep } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { randomBytes } from "node:crypto";
 
 // Per-million-token rates in USD. Source: documented Anthropic public
@@ -235,10 +235,31 @@ function int(v) {
  * @returns {string}
  */
 export function utcDateFromIso(iso) {
-  if (typeof iso !== "string" || !/^\d{4}-\d{2}-\d{2}T/.test(iso)) {
-    throw new Error(`metrics: started_at must be ISO 8601 with date prefix; got ${JSON.stringify(iso)}`);
+  if (typeof iso !== "string") {
+    throw new Error(`metrics: started_at must be ISO 8601; got ${JSON.stringify(iso)}`);
   }
-  return iso.slice(0, 10);
+  // Two acceptable shapes:
+  //   1. Strict UTC form ending in `Z`: slice the date prefix directly.
+  //   2. ISO with a timezone offset: convert to UTC via Date so the
+  //      file-boundary date reflects the UTC calendar day, NOT the
+  //      caller's local day. Without this, `2026-04-28T23:30:00-05:00`
+  //      (an instant on UTC 2026-04-29) would land in the 04-28 file.
+  if (/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/.test(iso)) {
+    return iso.slice(0, 10);
+  }
+  if (/^\d{4}-\d{2}-\d{2}T[\d:.]+(?:[+-]\d{2}:?\d{2})$/.test(iso)) {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) {
+      throw new Error(`metrics: started_at unparseable as ISO 8601; got ${JSON.stringify(iso)}`);
+    }
+    const yyyy = d.getUTCFullYear();
+    const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+    const dd = String(d.getUTCDate()).padStart(2, "0");
+    return `${yyyy}-${mm}-${dd}`;
+  }
+  throw new Error(
+    `metrics: started_at must be ISO 8601 with Z or +/-HH:MM offset; got ${JSON.stringify(iso)}`,
+  );
 }
 
 // Resolve the .claude/state directory for a given project root. The
@@ -265,9 +286,13 @@ export function metricsDirForProject(projectRoot) {
 }
 
 // Build a portable POSIX-style relative path so callers logging
-// `recorded to <path>` get a consistent shape across OSes.
+// `recorded to <path>` get a consistent shape across OSes. Uses
+// path.relative() rather than a raw startsWith strip so unrelated
+// path prefixes (e.g. base "/a/b" vs absPath "/a/bad/file") don't
+// produce a misleading "ad/file"; relative() emits "../bad/file"
+// instead.
 export function toPosixRelative(absPath, base) {
-  const rel = absPath.startsWith(base) ? absPath.slice(base.length) : absPath;
+  const rel = relative(base, absPath);
   return rel.split(sep).filter(Boolean).join("/");
 }
 

--- a/scripts/report_metrics.mjs
+++ b/scripts/report_metrics.mjs
@@ -17,9 +17,10 @@
 // The JSON rollup is the durable artefact (other tools consume it); the
 // markdown is the human-readable view.
 
-import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdirSync, readFileSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { parseArgv } from "./lib/argv.mjs";
+import { atomicWriteText } from "./lib/fsx.mjs";
 import {
   isoWeekWindow,
   readRecordsInWindow,
@@ -27,7 +28,7 @@ import {
   renderMarkdown,
 } from "./lib/metrics/aggregate.mjs";
 
-function main() {
+async function main() {
   const { flags } = parseArgv(process.argv.slice(2), {
     booleans: new Set(["weekly", "help"]),
   });
@@ -79,8 +80,11 @@ function main() {
   if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
   const jsonPath = join(outDir, `${window.isoWeek}.json`);
   const mdPath = join(outDir, `${window.isoWeek}.md`);
-  writeFileSync(jsonPath, JSON.stringify(rollup, null, 2) + "\n");
-  writeFileSync(mdPath, md);
+  // Atomic writes (write-to-temp + rename) so a SIGINT mid-run never
+  // leaves a partial JSON or markdown behind. Matches the convention
+  // in scripts/install.mjs and the rest of the writer surface.
+  await atomicWriteText(jsonPath, JSON.stringify(rollup, null, 2) + "\n");
+  await atomicWriteText(mdPath, md);
 
   process.stdout.write(md);
   process.stdout.write(`\n(rollup written to ${jsonPath})\n`);
@@ -97,9 +101,12 @@ function printHelp() {
 
 function mondayFromIsoWeek(isoWeek) {
   // Accept "YYYY-Www" and return the Monday of that ISO week as a Date.
-  const m = /^(\d{4})-W(\d{2})$/.exec(isoWeek);
+  // Accept YYYY-Www with the week digits constrained to 01..53. Reject
+  // W00 and W54..W99 fast — those are impossible ISO weeks. Matches the
+  // pattern in schemas/metrics-weekly.schema.json.
+  const m = /^(\d{4})-W(0[1-9]|[1-4][0-9]|5[0-3])$/.exec(isoWeek);
   if (!m) {
-    process.stderr.write(`error: --week must be YYYY-Www (got ${JSON.stringify(isoWeek)})\n`);
+    process.stderr.write(`error: --week must be YYYY-Www with week 01..53 (got ${JSON.stringify(isoWeek)})\n`);
     process.exit(2);
   }
   const year = Number(m[1]);
@@ -131,4 +138,7 @@ function loadPreviousAvgCost(path) {
   }
 }
 
-main();
+main().catch((err) => {
+  process.stderr.write(`error: ${err?.stack ?? err?.message ?? String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/report_metrics.mjs
+++ b/scripts/report_metrics.mjs
@@ -19,8 +19,10 @@
 
 import { mkdirSync, readFileSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { parseArgv } from "./lib/argv.mjs";
 import { atomicWriteText } from "./lib/fsx.mjs";
+import { preflight } from "./preflight.mjs";
 import {
   isoWeekWindow,
   readRecordsInWindow,
@@ -45,9 +47,16 @@ async function main() {
   const metricsDir = flags["metrics-dir"]
     ? resolve(cwd, String(flags["metrics-dir"]))
     : resolve(cwd, ".claude", "state", "metrics");
+  // Default out-dir is intentionally OUTSIDE <paths.wiki>: the wiki
+  // tree is governed by skill-llm-wiki and demands a nested-scalable
+  // layout (rules/llm-wiki.md). Weekly rollups are flat per-week
+  // artefacts that don't fit that layout. Land them under
+  // .development/local/ (gitignored by the installer) instead, so
+  // a project can choose to commit a curated subset by hand if they
+  // want it in the wiki — the script never writes there directly.
   const outDir = flags["out-dir"]
     ? resolve(cwd, String(flags["out-dir"]))
-    : resolve(cwd, ".development", "shared", "reports", "metrics");
+    : resolve(cwd, ".development", "local", "metrics");
 
   const referenceDate = flags.week
     ? mondayFromIsoWeek(String(flags.week))
@@ -138,7 +147,14 @@ function loadPreviousAvgCost(path) {
   }
 }
 
-main().catch((err) => {
-  process.stderr.write(`error: ${err?.stack ?? err?.message ?? String(err)}\n`);
-  process.exit(1);
-});
+// Direct-run guard with the shared `?? ""` form so module imports don't
+// trigger the CLI side-effect. preflight() runs first to surface a
+// friendly error on too-old Node, matching every other bundle CLI.
+const isDirectRun = import.meta.url === pathToFileURL(process.argv[1] ?? "").href;
+if (isDirectRun) {
+  await preflight();
+  await main().catch((err) => {
+    process.stderr.write(`error: ${err?.stack ?? err?.message ?? String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/report_metrics.mjs
+++ b/scripts/report_metrics.mjs
@@ -47,16 +47,21 @@ async function main() {
   const metricsDir = flags["metrics-dir"]
     ? resolve(cwd, String(flags["metrics-dir"]))
     : resolve(cwd, ".claude", "state", "metrics");
-  // Default out-dir is intentionally OUTSIDE <paths.wiki>: the wiki
-  // tree is governed by skill-llm-wiki and demands a nested-scalable
-  // layout (rules/llm-wiki.md). Weekly rollups are flat per-week
-  // artefacts that don't fit that layout. Land them under
-  // .development/local/ (gitignored by the installer) instead, so
-  // a project can choose to commit a curated subset by hand if they
-  // want it in the wiki — the script never writes there directly.
+  // Default out-dir lives under .claude/state/, which is OUTSIDE the
+  // wiki-governed .development/** tree entirely (the wiki roots
+  // include .development/local/ and .development/shared/, both of
+  // which require the skill-llm-wiki nested-scalable layout per
+  // rules/llm-wiki.md). Weekly rollups are flat per-week artefacts
+  // that do not fit that layout, so writing them anywhere under
+  // .development/** would either bypass wiki invariants or trip
+  // them. .claude/state/ is the staging area for derivative state
+  // (the daily JSONL records already live alongside, in
+  // .claude/state/metrics/). A project that wants to publish a
+  // curated rollup to the team wiki can copy it from here and run
+  // it through the wiki skill manually.
   const outDir = flags["out-dir"]
     ? resolve(cwd, String(flags["out-dir"]))
-    : resolve(cwd, ".development", "local", "metrics");
+    : resolve(cwd, ".claude", "state", "metrics-weekly");
 
   const referenceDate = flags.week
     ? mondayFromIsoWeek(String(flags.week))

--- a/scripts/report_metrics.mjs
+++ b/scripts/report_metrics.mjs
@@ -96,11 +96,15 @@ async function main() {
   if (flags["token-ceiling"] != null) {
     const raw = flags["token-ceiling"];
     const n = Number(raw);
-    if (!Number.isFinite(n) || n < 0) {
-      process.stderr.write(`error: --token-ceiling must be a non-negative number; got ${JSON.stringify(raw)}\n`);
+    // --token-ceiling is documented as an INTEGER count; silently
+    // truncating a fractional input (e.g. 5000.9 -> 5000) hides typos
+    // and makes the effective threshold non-obvious in the rendered
+    // report. Reject explicitly so the user fixes the command line.
+    if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) {
+      process.stderr.write(`error: --token-ceiling must be a non-negative integer; got ${JSON.stringify(raw)}\n`);
       process.exit(2);
     }
-    thresholds.per_skill_token_ceiling = Math.trunc(n);
+    thresholds.per_skill_token_ceiling = n;
   }
 
   const rollup = aggregate(records, {

--- a/scripts/report_metrics.mjs
+++ b/scripts/report_metrics.mjs
@@ -17,7 +17,7 @@
 // The JSON rollup is the durable artefact (other tools consume it); the
 // markdown is the human-readable view.
 
-import { mkdirSync, readFileSync, existsSync } from "node:fs";
+import { mkdirSync, readFileSync, existsSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgv, boolFlag } from "./lib/argv.mjs";
@@ -133,7 +133,31 @@ async function main() {
   });
   const md = renderMarkdown(rollup);
 
-  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+  // Out-dir guard: if the path exists but is not a directory (e.g.
+  // user pointed `--out-dir` at a file), surface a friendly error
+  // and exit 2 instead of letting atomicWriteText surface an opaque
+  // EISDIR/EACCES at write time. Same shape as the metrics-dir
+  // guard in aggregate.mjs::readRecordsInWindow.
+  if (existsSync(outDir)) {
+    let outStat;
+    try {
+      outStat = statSync(outDir);
+    } catch (err) {
+      process.stderr.write(`error: --out-dir ${JSON.stringify(outDir)} stat failed: ${err?.message ?? String(err)}\n`);
+      process.exit(2);
+    }
+    if (!outStat.isDirectory()) {
+      process.stderr.write(`error: --out-dir ${JSON.stringify(outDir)} exists but is not a directory\n`);
+      process.exit(2);
+    }
+  } else {
+    try {
+      mkdirSync(outDir, { recursive: true });
+    } catch (err) {
+      process.stderr.write(`error: --out-dir ${JSON.stringify(outDir)} could not be created: ${err?.message ?? String(err)}\n`);
+      process.exit(2);
+    }
+  }
   const jsonPath = join(outDir, `${window.isoWeek}.json`);
   const mdPath = join(outDir, `${window.isoWeek}.md`);
   // Atomic writes (write-to-temp + rename) so a SIGINT mid-run never

--- a/scripts/report_metrics.mjs
+++ b/scripts/report_metrics.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// scripts/report_metrics.mjs
+//
+// CLI entry: render a weekly metrics rollup from the daily JSONL files
+// in .claude/state/metrics/. Usage:
+//
+//   node scripts/report_metrics.mjs --weekly [--week YYYY-Www] [--metrics-dir <dir>]
+//                                   [--out-dir <dir>] [--cache-min <0..1>]
+//                                   [--token-ceiling <int>] [--prev-week-json <path>]
+//
+// Without --week the current week (UTC) is used. Without --metrics-dir
+// the script defaults to <cwd>/.claude/state/metrics. Output:
+//   1. JSON rollup written to <out-dir>/<isoWeek>.json
+//   2. Markdown report written to <out-dir>/<isoWeek>.md
+//   3. The markdown report is also echoed to stdout
+//
+// The JSON rollup is the durable artefact (other tools consume it); the
+// markdown is the human-readable view.
+
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseArgv } from "./lib/argv.mjs";
+import {
+  isoWeekWindow,
+  readRecordsInWindow,
+  aggregate,
+  renderMarkdown,
+} from "./lib/metrics/aggregate.mjs";
+
+function main() {
+  const { flags } = parseArgv(process.argv.slice(2), {
+    booleans: new Set(["weekly", "help"]),
+  });
+  if (flags.help) {
+    printHelp();
+    return;
+  }
+  if (!flags.weekly) {
+    process.stderr.write("error: pass --weekly (other rollups not yet implemented)\n");
+    process.exit(2);
+  }
+
+  const cwd = process.cwd();
+  const metricsDir = flags["metrics-dir"]
+    ? resolve(cwd, String(flags["metrics-dir"]))
+    : resolve(cwd, ".claude", "state", "metrics");
+  const outDir = flags["out-dir"]
+    ? resolve(cwd, String(flags["out-dir"]))
+    : resolve(cwd, ".development", "shared", "reports", "metrics");
+
+  const referenceDate = flags.week
+    ? mondayFromIsoWeek(String(flags.week))
+    : new Date();
+  const window = isoWeekWindow(referenceDate);
+  const records = readRecordsInWindow(metricsDir, window.start, window.end);
+
+  const previousAvgCostBySkill = flags["prev-week-json"]
+    ? loadPreviousAvgCost(String(flags["prev-week-json"]))
+    : new Map();
+
+  const thresholds = {};
+  if (flags["cache-min"] != null) {
+    const n = Number(flags["cache-min"]);
+    if (Number.isFinite(n) && n >= 0 && n <= 1) thresholds.cache_hit_rate_min = n;
+  }
+  if (flags["token-ceiling"] != null) {
+    const n = Number(flags["token-ceiling"]);
+    if (Number.isFinite(n) && n >= 0) thresholds.per_skill_token_ceiling = Math.trunc(n);
+  }
+
+  const rollup = aggregate(records, {
+    isoWeek: window.isoWeek,
+    window,
+    thresholds,
+    previousAvgCostBySkill,
+  });
+  const md = renderMarkdown(rollup);
+
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+  const jsonPath = join(outDir, `${window.isoWeek}.json`);
+  const mdPath = join(outDir, `${window.isoWeek}.md`);
+  writeFileSync(jsonPath, JSON.stringify(rollup, null, 2) + "\n");
+  writeFileSync(mdPath, md);
+
+  process.stdout.write(md);
+  process.stdout.write(`\n(rollup written to ${jsonPath})\n`);
+}
+
+function printHelp() {
+  process.stdout.write(
+    "Usage: node scripts/report_metrics.mjs --weekly [--week YYYY-Www]\n" +
+      "                                       [--metrics-dir <dir>] [--out-dir <dir>]\n" +
+      "                                       [--cache-min <0..1>] [--token-ceiling <int>]\n" +
+      "                                       [--prev-week-json <path>]\n",
+  );
+}
+
+function mondayFromIsoWeek(isoWeek) {
+  // Accept "YYYY-Www" and return the Monday of that ISO week as a Date.
+  const m = /^(\d{4})-W(\d{2})$/.exec(isoWeek);
+  if (!m) {
+    process.stderr.write(`error: --week must be YYYY-Www (got ${JSON.stringify(isoWeek)})\n`);
+    process.exit(2);
+  }
+  const year = Number(m[1]);
+  const week = Number(m[2]);
+  // ISO 8601: week 1 is the week containing Jan 4. Monday of week 1 is
+  // Jan 4 minus its weekday-1 days. Then add (week-1) * 7 days.
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Dow = jan4.getUTCDay() || 7;
+  const week1Monday = new Date(jan4.getTime() - (jan4Dow - 1) * 86400000);
+  return new Date(week1Monday.getTime() + (week - 1) * 7 * 86400000);
+}
+
+function loadPreviousAvgCost(path) {
+  // Load a previous-week rollup JSON and return a Map<skill, avg_cost>.
+  // Used to compute delta_vs_prev. Missing or malformed input ->
+  // empty Map (no deltas), never throws.
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    if (!parsed || !Array.isArray(parsed.per_skill)) return new Map();
+    const out = new Map();
+    for (const row of parsed.per_skill) {
+      if (typeof row?.skill === "string" && typeof row?.avg_cost === "number") {
+        out.set(row.skill, row.avg_cost);
+      }
+    }
+    return out;
+  } catch {
+    return new Map();
+  }
+}
+
+main();

--- a/scripts/report_metrics.mjs
+++ b/scripts/report_metrics.mjs
@@ -154,7 +154,22 @@ function mondayFromIsoWeek(isoWeek) {
   const jan4 = new Date(Date.UTC(year, 0, 4));
   const jan4Dow = jan4.getUTCDay() || 7;
   const week1Monday = new Date(jan4.getTime() - (jan4Dow - 1) * 86400000);
-  return new Date(week1Monday.getTime() + (week - 1) * 7 * 86400000);
+  const monday = new Date(week1Monday.getTime() + (week - 1) * 7 * 86400000);
+  // Round-trip validation: ISO week 53 only exists for "long" years
+  // (where Jan 1 is a Thursday, or a leap year where Jan 1 is a
+  // Wednesday). For a year without a W53, computing
+  // monday-of-W53 above silently rolls into the next ISO year's W01,
+  // and a later report would target the wrong window without warning.
+  // Re-derive the ISO week designation from the computed Monday and
+  // bail if it differs from the user-supplied input.
+  const roundTrip = isoWeekWindow(monday).isoWeek;
+  if (roundTrip !== isoWeek) {
+    process.stderr.write(
+      `error: --week ${JSON.stringify(isoWeek)} is not a valid ISO 8601 week (re-derived as ${JSON.stringify(roundTrip)}; W53 does not exist for every ISO year)\n`,
+    );
+    process.exit(2);
+  }
+  return monday;
 }
 
 function loadPreviousAvgCost(path) {

--- a/scripts/report_metrics.mjs
+++ b/scripts/report_metrics.mjs
@@ -77,14 +77,30 @@ async function main() {
     ? loadPreviousAvgCost(String(flags["prev-week-json"]))
     : new Map();
 
+  // Threshold flags. Fail-fast on invalid values rather than silently
+  // dropping the threshold: a typo like `--cache-min=7` or
+  // `--token-ceiling=-1` previously meant the report ran without that
+  // threshold applied, which is surprising in ops usage where the user
+  // expects red flags AND would not notice the omission until they
+  // skim the rendered markdown.
   const thresholds = {};
   if (flags["cache-min"] != null) {
-    const n = Number(flags["cache-min"]);
-    if (Number.isFinite(n) && n >= 0 && n <= 1) thresholds.cache_hit_rate_min = n;
+    const raw = flags["cache-min"];
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < 0 || n > 1) {
+      process.stderr.write(`error: --cache-min must be a number in [0, 1]; got ${JSON.stringify(raw)}\n`);
+      process.exit(2);
+    }
+    thresholds.cache_hit_rate_min = n;
   }
   if (flags["token-ceiling"] != null) {
-    const n = Number(flags["token-ceiling"]);
-    if (Number.isFinite(n) && n >= 0) thresholds.per_skill_token_ceiling = Math.trunc(n);
+    const raw = flags["token-ceiling"];
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < 0) {
+      process.stderr.write(`error: --token-ceiling must be a non-negative number; got ${JSON.stringify(raw)}\n`);
+      process.exit(2);
+    }
+    thresholds.per_skill_token_ceiling = Math.trunc(n);
   }
 
   const rollup = aggregate(records, {

--- a/scripts/report_metrics.mjs
+++ b/scripts/report_metrics.mjs
@@ -20,7 +20,7 @@
 import { mkdirSync, readFileSync, existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { parseArgv } from "./lib/argv.mjs";
+import { parseArgv, boolFlag } from "./lib/argv.mjs";
 import { atomicWriteText } from "./lib/fsx.mjs";
 import { preflight } from "./preflight.mjs";
 import {
@@ -34,11 +34,15 @@ async function main() {
   const { flags } = parseArgv(process.argv.slice(2), {
     booleans: new Set(["weekly", "help"]),
   });
-  if (flags.help) {
+  // Resolve --help / --weekly through boolFlag so a `--help=false` or
+  // `--weekly=false` (parseArgv's eq branch yields the string "false",
+  // which is truthy) is interpreted as an explicit "no" rather than
+  // an enabled flag.
+  if (boolFlag(flags, "help")) {
     printHelp();
     return;
   }
-  if (!flags.weekly) {
+  if (!boolFlag(flags, "weekly")) {
     process.stderr.write("error: pass --weekly (other rollups not yet implemented)\n");
     process.exit(2);
   }

--- a/scripts/report_metrics.mjs
+++ b/scripts/report_metrics.mjs
@@ -47,6 +47,24 @@ async function main() {
     process.exit(2);
   }
 
+  // Reject bare flags (`--metrics-dir` without a value) explicitly.
+  // parseArgv yields boolean `true` for a bare flag; without this
+  // guard the value would be coerced (`String(true)` -> "true",
+  // `Number(true)` -> 1) and silently produce surprising behaviour
+  // (--metrics-dir=true reading a directory called "true";
+  // --token-ceiling silently setting the threshold to 1; etc.).
+  // Apply the guard to every string-valued AND number-valued flag.
+  for (const f of ["metrics-dir", "out-dir", "prev-week-json", "week", "cache-min", "token-ceiling"]) {
+    if (f in flags && typeof flags[f] !== "string") {
+      process.stderr.write(`error: --${f} requires a value (got bare flag)\n`);
+      process.exit(2);
+    }
+    if (typeof flags[f] === "string" && flags[f].length === 0) {
+      process.stderr.write(`error: --${f} value must be non-empty\n`);
+      process.exit(2);
+    }
+  }
+
   const cwd = process.cwd();
   const metricsDir = flags["metrics-dir"]
     ? resolve(cwd, String(flags["metrics-dir"]))

--- a/tests/metrics/aggregate.test.mjs
+++ b/tests/metrics/aggregate.test.mjs
@@ -20,7 +20,9 @@ function tmp() {
 }
 
 test("isoWeekWindow: Monday-anchored, half-open interval", () => {
-  // 2026-04-28 is a Tuesday; week 17 starts Mon 2026-04-27.
+  // 2026-04-28 is a Tuesday in ISO week 18 (Monday: 2026-04-27).
+  // ISO 8601 numbering: Jan 4 lives in W01 by definition; counting
+  // Mondays forward, 2026-04-27 starts W18.
   const w = isoWeekWindow(new Date("2026-04-28T10:00:00Z"));
   assert.equal(w.start.toISOString(), "2026-04-27T00:00:00.000Z");
   assert.equal(w.end.toISOString(), "2026-05-04T00:00:00.000Z");

--- a/tests/metrics/aggregate.test.mjs
+++ b/tests/metrics/aggregate.test.mjs
@@ -1,0 +1,241 @@
+// Tests for scripts/lib/metrics/aggregate.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  isoWeekWindow,
+  isoWeekDesignation,
+  readRecordsInWindow,
+  aggregate,
+  renderMarkdown,
+} from "../../scripts/lib/metrics/aggregate.mjs";
+import { buildRecord, writeRecord } from "../../scripts/lib/metrics/record.mjs";
+
+function tmp() {
+  return mkdtempSync(join(tmpdir(), "metrics-aggregate-"));
+}
+
+test("isoWeekWindow: Monday-anchored, half-open interval", () => {
+  // 2026-04-28 is a Tuesday; week 17 starts Mon 2026-04-27.
+  const w = isoWeekWindow(new Date("2026-04-28T10:00:00Z"));
+  assert.equal(w.start.toISOString(), "2026-04-27T00:00:00.000Z");
+  assert.equal(w.end.toISOString(), "2026-05-04T00:00:00.000Z");
+  assert.equal(w.isoWeek, "2026-W18");
+});
+
+test("isoWeekDesignation: ISO 8601 year + week pair", () => {
+  // 2024 has 52 ISO weeks; 2025-01-01 is a Wednesday so it falls in 2025-W01.
+  // Use Mondays.
+  assert.equal(isoWeekDesignation(new Date(Date.UTC(2025, 0, 6))), "2025-W02"); // 6 Jan = Mon of W02
+  assert.equal(isoWeekDesignation(new Date(Date.UTC(2024, 11, 30))), "2025-W01"); // ISO year flips
+});
+
+test("readRecordsInWindow: only files inside [start, end) are read", () => {
+  const dir = tmp();
+  try {
+    const m = join(dir, "metrics");
+    mkdirSync(m, { recursive: true });
+    writeFileSync(join(m, "2026-04-26.jsonl"), JSON.stringify({ skill: "x", tokens: {} }) + "\n"); // before window
+    writeFileSync(join(m, "2026-04-27.jsonl"), JSON.stringify({ skill: "in", tokens: {} }) + "\n"); // start of window
+    writeFileSync(join(m, "2026-05-03.jsonl"), JSON.stringify({ skill: "in", tokens: {} }) + "\n"); // last day in
+    writeFileSync(join(m, "2026-05-04.jsonl"), JSON.stringify({ skill: "out", tokens: {} }) + "\n"); // exclusive upper
+    const w = isoWeekWindow(new Date("2026-04-28T10:00:00Z"));
+    const records = readRecordsInWindow(m, w.start, w.end);
+    assert.equal(records.length, 2);
+    assert.deepEqual(records.map((r) => r.skill), ["in", "in"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readRecordsInWindow: malformed lines are skipped, valid lines are kept", () => {
+  const dir = tmp();
+  try {
+    const m = join(dir, "metrics");
+    mkdirSync(m, { recursive: true });
+    writeFileSync(
+      join(m, "2026-04-27.jsonl"),
+      [
+        JSON.stringify({ skill: "ok", tokens: { input: 1, output: 0, cache_read: 0, cache_write: 0 } }),
+        "{ broken json",
+        JSON.stringify({ skill: "also-ok", tokens: { input: 2, output: 0, cache_read: 0, cache_write: 0 } }),
+        "",
+      ].join("\n"),
+    );
+    const w = isoWeekWindow(new Date("2026-04-28T10:00:00Z"));
+    const records = readRecordsInWindow(m, w.start, w.end);
+    assert.equal(records.length, 2);
+    assert.deepEqual(records.map((r) => r.skill).sort(), ["also-ok", "ok"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("aggregate: per-skill totals + cache_hit_rate from real records", () => {
+  const dir = tmp();
+  try {
+    const r1 = buildRecord({
+      skill: "dev-loop",
+      started_at: "2026-04-27T10:00:00Z",
+      ended_at: "2026-04-27T10:01:00Z",
+      tokens: { input: 1000, output: 500, cache_read: 4000, cache_write: 200 },
+      model: "claude-opus-4-7",
+    });
+    const r2 = buildRecord({
+      skill: "dev-loop",
+      started_at: "2026-04-28T10:00:00Z",
+      ended_at: "2026-04-28T10:00:30Z",
+      tokens: { input: 500, output: 300, cache_read: 1500, cache_write: 100 },
+      model: "claude-opus-4-7",
+    });
+    const r3 = buildRecord({
+      skill: "pr-iteration",
+      started_at: "2026-04-28T11:00:00Z",
+      ended_at: "2026-04-28T11:00:05Z",
+      tokens: { input: 200, output: 100, cache_read: 800, cache_write: 0 },
+      model: "claude-haiku-4-5",
+    });
+    writeRecord(r1, dir);
+    writeRecord(r2, dir);
+    writeRecord(r3, dir);
+    const w = isoWeekWindow(new Date("2026-04-28T10:00:00Z"));
+    const records = readRecordsInWindow(join(dir, "metrics"), w.start, w.end);
+    const out = aggregate(records, { isoWeek: w.isoWeek });
+    assert.equal(out.iso_week, "2026-W18");
+    // Totals: 3 invocations, sum cost from per-record cost.
+    assert.equal(out.totals.invocations, 3);
+    // Per-skill rows lex-sorted: dev-loop then pr-iteration.
+    assert.equal(out.per_skill.length, 2);
+    assert.equal(out.per_skill[0].skill, "dev-loop");
+    assert.equal(out.per_skill[0].invocations, 2);
+    assert.equal(out.per_skill[1].skill, "pr-iteration");
+    assert.equal(out.per_skill[1].invocations, 1);
+    // dev-loop total cache_read = 4000 + 1500; total input = 1500;
+    // hit rate = 5500 / (1500 + 5500) = 0.7857...
+    assert.ok(out.per_skill[0].cache_hit_rate > 0.78 && out.per_skill[0].cache_hit_rate < 0.80);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("aggregate: sub-invocations fold into parent skill, never appear as their own row", () => {
+  const dir = tmp();
+  try {
+    const parent = buildRecord({
+      skill: "dev-loop",
+      started_at: "2026-04-28T10:00:00Z",
+      ended_at: "2026-04-28T10:00:30Z",
+      tokens: { input: 1000, output: 500, cache_read: 0, cache_write: 0 },
+    });
+    const sub = buildRecord({
+      skill: "explorer",
+      started_at: "2026-04-28T10:00:10Z",
+      ended_at: "2026-04-28T10:00:25Z",
+      tokens: { input: 500, output: 200, cache_read: 0, cache_write: 0 },
+      parent_trace_id: parent.trace_id,
+    });
+    writeRecord(parent, dir);
+    writeRecord(sub, dir);
+    const w = isoWeekWindow(new Date("2026-04-28T10:00:00Z"));
+    const records = readRecordsInWindow(join(dir, "metrics"), w.start, w.end);
+    const out = aggregate(records, { isoWeek: w.isoWeek });
+    // Only one skill row: "dev-loop". "explorer" must NOT appear.
+    assert.deepEqual(out.per_skill.map((r) => r.skill), ["dev-loop"]);
+    // Invocations counts top-level only.
+    assert.equal(out.per_skill[0].invocations, 1);
+    // But token totals include the sub-invocation's tokens.
+    assert.equal(out.totals.tokens.input, 1500);
+    assert.equal(out.totals.tokens.output, 700);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("aggregate: thresholds drive red flags, sorted by skill then kind", () => {
+  // Synthetic records where dev-loop has a low cache hit and a big avg.
+  const records = [
+    {
+      trace_id: "t1", skill: "dev-loop", parent_trace_id: null,
+      started_at: "2026-04-28T10:00:00Z", ended_at: "2026-04-28T10:00:30Z",
+      tokens: { input: 10000, output: 0, cache_read: 0, cache_write: 0 },
+      cost_usd: 0.15, exit: "success",
+    },
+    {
+      trace_id: "t2", skill: "pr-iteration", parent_trace_id: null,
+      started_at: "2026-04-28T11:00:00Z", ended_at: "2026-04-28T11:00:05Z",
+      tokens: { input: 100, output: 0, cache_read: 1000, cache_write: 0 },
+      cost_usd: 0.001, exit: "success",
+    },
+  ];
+  const out = aggregate(records, {
+    isoWeek: "2026-W18",
+    thresholds: { cache_hit_rate_min: 0.7, per_skill_token_ceiling: 5000 },
+  });
+  // dev-loop fires both flags; pr-iteration fires neither.
+  assert.equal(out.red_flags.length, 2);
+  assert.deepEqual(out.red_flags.map((f) => f.skill), ["dev-loop", "dev-loop"]);
+  // Within the same skill, sorted by kind name lex.
+  assert.deepEqual(out.red_flags.map((f) => f.kind), ["avg_tokens_above_ceiling", "cache_hit_rate_below_min"]);
+});
+
+test("aggregate: delta_vs_prev null for new skills, fractional for known ones", () => {
+  const records = [
+    {
+      trace_id: "t1", skill: "dev-loop", parent_trace_id: null,
+      started_at: "2026-04-28T10:00:00Z", ended_at: "2026-04-28T10:00:30Z",
+      tokens: { input: 100, output: 0, cache_read: 0, cache_write: 0 },
+      cost_usd: 0.10, exit: "success",
+    },
+    {
+      trace_id: "t2", skill: "incident-intake", parent_trace_id: null,
+      started_at: "2026-04-28T11:00:00Z", ended_at: "2026-04-28T11:00:05Z",
+      tokens: { input: 100, output: 0, cache_read: 0, cache_write: 0 },
+      cost_usd: 0.05, exit: "success",
+    },
+  ];
+  const previousAvgCostBySkill = new Map([["dev-loop", 0.13]]);
+  const out = aggregate(records, { isoWeek: "2026-W18", previousAvgCostBySkill });
+  const dev = out.per_skill.find((r) => r.skill === "dev-loop");
+  const intake = out.per_skill.find((r) => r.skill === "incident-intake");
+  // (0.10 - 0.13) / 0.13 ~= -0.2308
+  assert.ok(Math.abs(dev.delta_vs_prev - (-0.2308)) < 0.001);
+  assert.equal(intake.delta_vs_prev, null);
+});
+
+test("aggregate: deterministic JSON output (re-runs are byte-identical)", () => {
+  const records = [
+    {
+      trace_id: "t1", skill: "dev-loop", parent_trace_id: null,
+      started_at: "2026-04-28T10:00:00Z", ended_at: "2026-04-28T10:00:30Z",
+      tokens: { input: 1000, output: 500, cache_read: 4000, cache_write: 200 },
+      cost_usd: 0.15, exit: "success",
+    },
+  ];
+  const a = JSON.stringify(aggregate(records, { isoWeek: "2026-W18" }));
+  const b = JSON.stringify(aggregate(records, { isoWeek: "2026-W18" }));
+  assert.equal(a, b);
+});
+
+test("renderMarkdown: contains header + per-skill table + red-flags section", () => {
+  const records = [
+    {
+      trace_id: "t1", skill: "dev-loop", parent_trace_id: null,
+      started_at: "2026-04-28T10:00:00Z", ended_at: "2026-04-28T10:00:30Z",
+      tokens: { input: 10000, output: 0, cache_read: 0, cache_write: 0 },
+      cost_usd: 0.15, exit: "success",
+    },
+  ];
+  const out = aggregate(records, {
+    isoWeek: "2026-W18",
+    thresholds: { cache_hit_rate_min: 0.7 },
+  });
+  const md = renderMarkdown(out);
+  assert.match(md, /^# Week 2026-W18\n/);
+  assert.match(md, /Total cost: \$0\.15 across 1 skill invocations/);
+  assert.match(md, /\| skill \| invocations \|/);
+  assert.match(md, /Red flags:/);
+});

--- a/tests/metrics/aggregate.test.mjs
+++ b/tests/metrics/aggregate.test.mjs
@@ -157,6 +157,30 @@ test("aggregate: sub-invocations fold into parent skill, never appear as their o
   }
 });
 
+test("aggregate: orphan sub-invocations are dropped, never appear as a phantom row", () => {
+  // A sub-invocation whose parent record is NOT present in this batch
+  // (because the parent ran in a different ISO week or was filtered
+  // out) is "orphaned". The contract: orphans are dropped from the
+  // rollup entirely, never surfaced as their own per_skill row. This
+  // keeps invocation counts stable at week boundaries — a sub run on
+  // Sunday whose parent ran on Monday must not flip between "folded"
+  // and "phantom" depending on the aggregation window.
+  const records = [
+    {
+      trace_id: "child-1", skill: "explorer", parent_trace_id: "parent-not-here",
+      started_at: "2026-04-28T10:00:00Z", ended_at: "2026-04-28T10:00:30Z",
+      tokens: { input: 999, output: 999, cache_read: 0, cache_write: 0 },
+      cost_usd: 0.50, exit: "success",
+    },
+  ];
+  const w = isoWeekWindow(new Date("2026-04-28T10:00:00Z"));
+  const out = aggregate(records, { isoWeek: w.isoWeek });
+  assert.equal(out.per_skill.length, 0, "orphan sub must not surface as a row");
+  assert.equal(out.totals.invocations, 0, "orphan sub must not count as an invocation");
+  assert.equal(out.totals.cost_usd, 0, "orphan sub cost is dropped");
+  assert.equal(out.totals.tokens.input, 0, "orphan sub tokens are dropped");
+});
+
 test("aggregate: thresholds drive red flags, sorted by skill then kind", () => {
   // Synthetic records where dev-loop has a low cache hit and a big avg.
   const records = [

--- a/tests/metrics/record.test.mjs
+++ b/tests/metrics/record.test.mjs
@@ -141,14 +141,35 @@ test("writeRecord: rejects records whose tokens shape is malformed", () => {
   }
 });
 
-test("computeCostUsd: rates override missing the `default` entry falls back to DEFAULT_RATES.default", () => {
-  // A caller passing a partial override map without a `default` entry
-  // (and an unknown model) previously threw "Cannot read properties of
-  // undefined". Now the code falls through to DEFAULT_RATES.default so
-  // cost reporting stays non-zero.
+test("computeCostUsd: known-model fallback uses DEFAULT_RATES[model] before caller's default", () => {
+  // A caller's partial override map MUST NOT downgrade pricing for a
+  // KNOWN model that simply isn't in the override. The fallback chain:
+  // (1) rates[model] (2) DEFAULT_RATES[model] (3) rates.default
+  // (4) DEFAULT_RATES.default. Step 2 catches this case: the override
+  // applies where the caller asked, but every other DOCUMENTED model
+  // continues to price through DEFAULT_RATES.
+  const tokens = { input: 1_000_000, output: 0, cache_read: 0, cache_write: 0 };
+  const partial = {
+    "some-other-model": { input: 999, output: 999, cache_read: 999, cache_write: 999 },
+    default: { input: 999, output: 999, cache_read: 999, cache_write: 999 },
+  };
+  const cost = computeCostUsd(tokens, "claude-opus-4-7", partial);
+  assert.equal(
+    cost,
+    DEFAULT_RATES["claude-opus-4-7"].input,
+    "known model price must come from DEFAULT_RATES, not the caller's default",
+  );
+});
+
+test("computeCostUsd: truly-unknown model with empty override falls back to DEFAULT_RATES.default", () => {
+  // Last-resort tail of the fallback chain. A caller passing a partial
+  // override map with NEITHER the model NOR a `default` entry, AND a
+  // model name that is unknown to DEFAULT_RATES, lands on
+  // DEFAULT_RATES.default. The previous code threw "Cannot read
+  // properties of undefined" on this path.
   const tokens = { input: 1_000_000, output: 0, cache_read: 0, cache_write: 0 };
   const partial = { "some-other-model": { input: 1, output: 1, cache_read: 1, cache_write: 1 } };
-  const cost = computeCostUsd(tokens, "claude-opus-4-7", partial);
+  const cost = computeCostUsd(tokens, "totally-unknown-model", partial);
   assert.equal(cost, DEFAULT_RATES.default.input);
 });
 

--- a/tests/metrics/record.test.mjs
+++ b/tests/metrics/record.test.mjs
@@ -105,8 +105,12 @@ test("buildRecord: produces a schema-conformant object with all required fields"
 });
 
 test("buildRecord: sub-invocation carries parent_trace_id", () => {
-  const r = buildRecord({ ...validInput(), parent_trace_id: "t-parent-123" });
-  assert.equal(r.parent_trace_id, "t-parent-123");
+  // Use a real trace-id-shaped value (matches schema pattern
+  // ^t-[0-9a-f]{16}$) so the test does not encode an invalid shape
+  // that buildRecord's pattern check would reject.
+  const parentTraceId = newTraceId();
+  const r = buildRecord({ ...validInput(), parent_trace_id: parentTraceId });
+  assert.equal(r.parent_trace_id, parentTraceId);
 });
 
 test("buildRecord: mcp_servers_used is deduped + sorted", () => {

--- a/tests/metrics/record.test.mjs
+++ b/tests/metrics/record.test.mjs
@@ -106,6 +106,37 @@ test("buildRecord: rejects negative or non-finite token counts", () => {
   assert.throws(() => buildRecord({ ...validInput(), tokens: { input: NaN, output: 0, cache_read: 0, cache_write: 0 } }));
 });
 
+test("writeRecord: nested whitelist drops unknown keys mutated onto tokens / subagents", () => {
+  // The schema sets additionalProperties: false at top level AND on the
+  // nested `tokens` and `subagents` objects. orderedRecord() now mirrors
+  // that contract on write: a caller that mutates the buildRecord
+  // output to add a non-schema field at any layer gets the unknown
+  // field dropped at JSONL serialisation time, the same way an unknown
+  // top-level key is dropped. Without nested projection the schema
+  // guarantee would only hold on read, after a downstream tool tripped
+  // over the smuggled field.
+  const dir = tmp();
+  try {
+    const r = buildRecord({
+      ...validInput(),
+      subagents: { count: 1, total_tokens: 100 },
+    });
+    // Mutate after buildRecord to mimic a sloppy caller that reaches
+    // into the returned object.
+    r.tokens.thinking = 9999;
+    r.subagents.parent_id = "t-leak";
+    r.unexpected_top = "leak";
+    const file = writeRecord(r, dir);
+    const body = readFileSync(file, "utf8");
+    const parsed = JSON.parse(body.split("\n")[0]);
+    assert.deepEqual(Object.keys(parsed.tokens), ["input", "output", "cache_read", "cache_write"]);
+    assert.deepEqual(Object.keys(parsed.subagents), ["count", "total_tokens"]);
+    assert.equal(parsed.unexpected_top, undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("writeRecord: appends one JSONL line per invocation, file keyed by UTC date", () => {
   const dir = tmp();
   try {

--- a/tests/metrics/record.test.mjs
+++ b/tests/metrics/record.test.mjs
@@ -119,6 +119,39 @@ test("buildRecord: rejects negative or non-finite token counts", () => {
   assert.throws(() => buildRecord({ ...validInput(), tokens: { input: NaN, output: 0, cache_read: 0, cache_write: 0 } }));
 });
 
+test("writeRecord: rejects records whose tokens shape is malformed", () => {
+  // Defends against hand-built records that skip buildRecord and would
+  // otherwise land malformed JSONL on disk. additionalProperties:false
+  // on the read schema would reject these on the next aggregator run,
+  // but the bad bytes are already on disk by then; fail at write time.
+  const dir = tmp();
+  try {
+    const r = buildRecord(validInput());
+    // Missing token field
+    const missing = { ...r, tokens: { input: 0, output: 0, cache_read: 0 } };
+    assert.throws(() => writeRecord(missing, dir), /tokens\.cache_write/);
+    // Wrong type
+    const wrongType = { ...r, tokens: { input: "10", output: 0, cache_read: 0, cache_write: 0 } };
+    assert.throws(() => writeRecord(wrongType, dir), /tokens\.input/);
+    // Missing tokens object entirely
+    const noTokens = { ...r, tokens: undefined };
+    assert.throws(() => writeRecord(noTokens, dir), /tokens must be an object/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("computeCostUsd: rates override missing the `default` entry falls back to DEFAULT_RATES.default", () => {
+  // A caller passing a partial override map without a `default` entry
+  // (and an unknown model) previously threw "Cannot read properties of
+  // undefined". Now the code falls through to DEFAULT_RATES.default so
+  // cost reporting stays non-zero.
+  const tokens = { input: 1_000_000, output: 0, cache_read: 0, cache_write: 0 };
+  const partial = { "some-other-model": { input: 1, output: 1, cache_read: 1, cache_write: 1 } };
+  const cost = computeCostUsd(tokens, "claude-opus-4-7", partial);
+  assert.equal(cost, DEFAULT_RATES.default.input);
+});
+
 test("writeRecord: nested whitelist drops unknown keys mutated onto tokens / subagents", () => {
   // The schema sets additionalProperties: false at top level AND on the
   // nested `tokens` and `subagents` objects. orderedRecord() now mirrors

--- a/tests/metrics/record.test.mjs
+++ b/tests/metrics/record.test.mjs
@@ -68,6 +68,19 @@ test("utcDateFromIso: returns the YYYY-MM-DD prefix", () => {
   assert.throws(() => utcDateFromIso(null));
 });
 
+test("buildRecord: rejects non-object inputs with a stable error", () => {
+  // Without the explicit object guard at the top of buildRecord, these
+  // inputs threw a generic `Cannot read properties of null/undefined`
+  // TypeError from the input[k] access in the required-field loop. The
+  // guard surfaces a stable `metrics.buildRecord:` message instead so
+  // callers (and human ops) get one diagnostic shape they can match on.
+  assert.throws(() => buildRecord(null), /metrics\.buildRecord: input must be a plain object/);
+  assert.throws(() => buildRecord(undefined), /metrics\.buildRecord: input must be a plain object/);
+  assert.throws(() => buildRecord(42), /metrics\.buildRecord: input must be a plain object/);
+  assert.throws(() => buildRecord("string"), /metrics\.buildRecord: input must be a plain object/);
+  assert.throws(() => buildRecord([]), /metrics\.buildRecord: input must be a plain object/);
+});
+
 test("buildRecord: required fields enforced", () => {
   assert.throws(() => buildRecord({}), /skill is required/);
   assert.throws(

--- a/tests/metrics/record.test.mjs
+++ b/tests/metrics/record.test.mjs
@@ -111,7 +111,9 @@ test("writeRecord: appends one JSONL line per invocation, file keyed by UTC date
   try {
     const r = buildRecord(validInput());
     const file = writeRecord(r, dir);
-    assert.ok(file.endsWith("metrics/2026-04-28.jsonl"), `unexpected path: ${file}`);
+    // Use join() for the suffix so the assertion is portable across
+    // POSIX (`/`) and Windows (`\`) path separators.
+    assert.ok(file.endsWith(join("metrics", "2026-04-28.jsonl")), `unexpected path: ${file}`);
     const body = readFileSync(file, "utf8");
     // Single line + trailing newline.
     assert.equal(body.split("\n").length, 2);

--- a/tests/metrics/record.test.mjs
+++ b/tests/metrics/record.test.mjs
@@ -1,0 +1,178 @@
+// Tests for scripts/lib/metrics/record.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  buildRecord,
+  computeCostUsd,
+  newTraceId,
+  utcDateFromIso,
+  writeRecord,
+  record,
+  DEFAULT_RATES,
+} from "../../scripts/lib/metrics/record.mjs";
+
+function tmp() {
+  return mkdtempSync(join(tmpdir(), "metrics-record-"));
+}
+
+const validInput = () => ({
+  skill: "dev-loop",
+  started_at: "2026-04-28T10:00:00.000Z",
+  ended_at: "2026-04-28T10:01:00.000Z",
+  tokens: { input: 1000, output: 500, cache_read: 4000, cache_write: 200 },
+  model: "claude-opus-4-7",
+});
+
+test("computeCostUsd: applies per-million-token rates and rounds to 6 dp", () => {
+  const cost = computeCostUsd(
+    { input: 1_000_000, output: 0, cache_read: 0, cache_write: 0 },
+    "claude-opus-4-7",
+  );
+  assert.equal(cost, DEFAULT_RATES["claude-opus-4-7"].input);
+});
+
+test("computeCostUsd: unknown model falls back to default rates (no silent zero)", () => {
+  const cost = computeCostUsd(
+    { input: 1_000_000, output: 0, cache_read: 0, cache_write: 0 },
+    "claude-future-99",
+  );
+  assert.equal(cost, DEFAULT_RATES.default.input);
+});
+
+test("computeCostUsd: rates override is honoured", () => {
+  const cost = computeCostUsd(
+    { input: 1_000_000, output: 0, cache_read: 0, cache_write: 0 },
+    "x",
+    { x: { input: 2.5, output: 0, cache_read: 0, cache_write: 0 }, default: { input: 0, output: 0, cache_read: 0, cache_write: 0 } },
+  );
+  assert.equal(cost, 2.5);
+});
+
+test("newTraceId: returns a t- prefixed hex id, unique per call", () => {
+  const a = newTraceId();
+  const b = newTraceId();
+  assert.match(a, /^t-[0-9a-f]{16}$/);
+  assert.match(b, /^t-[0-9a-f]{16}$/);
+  assert.notEqual(a, b);
+});
+
+test("utcDateFromIso: returns the YYYY-MM-DD prefix", () => {
+  assert.equal(utcDateFromIso("2026-04-28T23:59:59.000Z"), "2026-04-28");
+  assert.equal(utcDateFromIso("2026-12-31T00:00:00.000Z"), "2026-12-31");
+  assert.throws(() => utcDateFromIso("not-iso"));
+  assert.throws(() => utcDateFromIso(null));
+});
+
+test("buildRecord: required fields enforced", () => {
+  assert.throws(() => buildRecord({}), /skill is required/);
+  assert.throws(
+    () => buildRecord({ skill: "x", started_at: "2026-04-28T00:00:00Z" }),
+    /ended_at is required/,
+  );
+  assert.throws(
+    () => buildRecord({ ...validInput(), tokens: undefined }),
+    /tokens is required/,
+  );
+});
+
+test("buildRecord: produces a schema-conformant object with all required fields", () => {
+  const r = buildRecord(validInput());
+  assert.ok(typeof r.trace_id === "string");
+  assert.equal(r.parent_trace_id, null);
+  assert.equal(r.skill, "dev-loop");
+  assert.equal(r.exit, "success");
+  assert.deepEqual(r.tokens, { input: 1000, output: 500, cache_read: 4000, cache_write: 200 });
+  assert.equal(r.model, "claude-opus-4-7");
+  assert.ok(typeof r.cost_usd === "number" && r.cost_usd > 0);
+});
+
+test("buildRecord: sub-invocation carries parent_trace_id", () => {
+  const r = buildRecord({ ...validInput(), parent_trace_id: "t-parent-123" });
+  assert.equal(r.parent_trace_id, "t-parent-123");
+});
+
+test("buildRecord: mcp_servers_used is deduped + sorted", () => {
+  const r = buildRecord({ ...validInput(), mcp_servers_used: ["sqlite", "git", "git", "filesystem"] });
+  assert.deepEqual(r.mcp_servers_used, ["filesystem", "git", "sqlite"]);
+});
+
+test("buildRecord: rejects negative or non-finite token counts", () => {
+  assert.throws(() => buildRecord({ ...validInput(), tokens: { input: -1, output: 0, cache_read: 0, cache_write: 0 } }));
+  assert.throws(() => buildRecord({ ...validInput(), tokens: { input: NaN, output: 0, cache_read: 0, cache_write: 0 } }));
+});
+
+test("writeRecord: appends one JSONL line per invocation, file keyed by UTC date", () => {
+  const dir = tmp();
+  try {
+    const r = buildRecord(validInput());
+    const file = writeRecord(r, dir);
+    assert.ok(file.endsWith("metrics/2026-04-28.jsonl"), `unexpected path: ${file}`);
+    const body = readFileSync(file, "utf8");
+    // Single line + trailing newline.
+    assert.equal(body.split("\n").length, 2);
+    assert.equal(body.split("\n")[1], "");
+    const parsed = JSON.parse(body.split("\n")[0]);
+    assert.equal(parsed.skill, "dev-loop");
+    assert.equal(parsed.cost_usd, r.cost_usd);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeRecord: appends multiple invocations in order to the same daily file", () => {
+  const dir = tmp();
+  try {
+    const r1 = buildRecord(validInput());
+    const r2 = buildRecord({ ...validInput(), skill: "pr-iteration" });
+    writeRecord(r1, dir);
+    writeRecord(r2, dir);
+    const file = readdirSync(join(dir, "metrics"))[0];
+    const lines = readFileSync(join(dir, "metrics", file), "utf8").trim().split("\n");
+    assert.equal(lines.length, 2);
+    assert.equal(JSON.parse(lines[0]).skill, "dev-loop");
+    assert.equal(JSON.parse(lines[1]).skill, "pr-iteration");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeRecord: rejects path-traversal in skill name", () => {
+  const dir = tmp();
+  try {
+    const r = buildRecord(validInput());
+    r.skill = "../etc/passwd";
+    assert.throws(() => writeRecord(r, dir), /invalid skill name/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeRecord: invocations on different dates land in different files", () => {
+  const dir = tmp();
+  try {
+    const r1 = buildRecord({ ...validInput(), started_at: "2026-04-28T23:59:59.000Z", ended_at: "2026-04-28T23:59:59.500Z" });
+    const r2 = buildRecord({ ...validInput(), started_at: "2026-04-29T00:00:00.000Z", ended_at: "2026-04-29T00:00:01.000Z" });
+    writeRecord(r1, dir);
+    writeRecord(r2, dir);
+    const files = readdirSync(join(dir, "metrics")).sort();
+    assert.deepEqual(files, ["2026-04-28.jsonl", "2026-04-29.jsonl"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("record: convenience build+write returns both the record and the path", () => {
+  const dir = tmp();
+  try {
+    const result = record(validInput(), dir);
+    assert.ok(result.path.endsWith("2026-04-28.jsonl"));
+    assert.equal(result.record.skill, "dev-loop");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/metrics/report_metrics.cli.test.mjs
+++ b/tests/metrics/report_metrics.cli.test.mjs
@@ -1,0 +1,102 @@
+// Tests for scripts/report_metrics.mjs CLI argument handling.
+// Exercises the bare-flag rejection, --week round-trip validation,
+// invalid threshold guards, and the happy-path stdout shape.
+// Heavy e2e coverage stays in tests/metrics/aggregate.test.mjs; this
+// file is the thin entrypoint guard.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = resolve(fileURLToPath(import.meta.url), "..");
+const REPORT_CLI = resolve(__dirname, "..", "..", "scripts", "report_metrics.mjs");
+
+function tmp() {
+  return mkdtempSync(join(tmpdir(), "report-metrics-cli-"));
+}
+
+function runCli(args, cwd) {
+  return spawnSync(process.execPath, [REPORT_CLI, ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+test("report_metrics CLI: --help prints usage and exits 0", () => {
+  const r = runCli(["--help"], tmp());
+  assert.equal(r.status, 0);
+  // The actual usage banner is `Usage: node scripts/report_metrics.mjs ...`.
+  // Match case-insensitively and against the script filename.
+  assert.match(r.stdout, /usage:.*report_metrics\.mjs/i);
+});
+
+test("report_metrics CLI: refuses without --weekly", () => {
+  const r = runCli([], tmp());
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /pass --weekly/);
+});
+
+test("report_metrics CLI: rejects bare --metrics-dir / --out-dir / --prev-week-json / --week / --cache-min / --token-ceiling", () => {
+  for (const flag of ["--metrics-dir", "--out-dir", "--prev-week-json", "--week", "--cache-min", "--token-ceiling"]) {
+    const r = runCli(["--weekly", flag], tmp());
+    assert.equal(r.status, 2, `bare ${flag} should exit 2; stdout=${r.stdout} stderr=${r.stderr}`);
+    assert.match(r.stderr, new RegExp(`requires a value`));
+  }
+});
+
+test("report_metrics CLI: rejects empty --metrics-dir / --out-dir / --week", () => {
+  // parseArgv accepts `--flag=` as the empty string; the CLI guards
+  // every string-valued flag against zero-length values too.
+  for (const flag of ["--metrics-dir=", "--out-dir=", "--week="]) {
+    const r = runCli(["--weekly", flag], tmp());
+    // parseArgv throws on empty value with `=`; either way we want non-zero exit.
+    assert.notEqual(r.status, 0, `${flag} should not succeed`);
+  }
+});
+
+test("report_metrics CLI: --token-ceiling rejects non-integer", () => {
+  const r = runCli(["--weekly", "--token-ceiling=5000.9"], tmp());
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /must be a non-negative integer/);
+});
+
+test("report_metrics CLI: --cache-min rejects out-of-range value", () => {
+  const r = runCli(["--weekly", "--cache-min=7"], tmp());
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /must be a number in \[0, 1\]/);
+});
+
+test("report_metrics CLI: --week with impossible W53 round-trip-rejects", () => {
+  // 2025 is a 52-week ISO year; W53 does not exist. mondayFromIsoWeek
+  // round-trips through isoWeekWindow and rejects.
+  const r = runCli(["--weekly", "--week=2025-W53"], tmp());
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /not a valid ISO 8601 week/);
+});
+
+test("report_metrics CLI: happy path runs against an empty metrics dir and writes empty rollup", () => {
+  const dir = tmp();
+  try {
+    // Pre-create the metrics dir so readRecordsInWindow's TOCTOU
+    // guard returns an empty record list (instead of skipping
+    // entirely when the dir doesn't exist).
+    mkdirSync(join(dir, ".claude", "state", "metrics"), { recursive: true });
+    const r = runCli(["--weekly"], dir);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    // Stdout should contain the rendered markdown header.
+    // Rendered header is `# Week <YYYY-Www>`.
+    assert.match(r.stdout, /^# Week \d{4}-W\d{2}/m);
+    // JSON + markdown should land in the default out-dir.
+    const outDir = join(dir, ".claude", "state", "metrics-weekly");
+    const files = readFileSync; // referenced to keep import alive across linter passes
+    assert.ok(files);
+    // We cannot enumerate without readdir here, but the success exit
+    // code + the markdown stdout proves the write succeeded.
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/metrics/report_metrics.cli.test.mjs
+++ b/tests/metrics/report_metrics.cli.test.mjs
@@ -6,7 +6,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, readdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -87,15 +87,27 @@ test("report_metrics CLI: happy path runs against an empty metrics dir and write
     mkdirSync(join(dir, ".claude", "state", "metrics"), { recursive: true });
     const r = runCli(["--weekly"], dir);
     assert.equal(r.status, 0, `stderr: ${r.stderr}`);
-    // Stdout should contain the rendered markdown header.
     // Rendered header is `# Week <YYYY-Www>`.
     assert.match(r.stdout, /^# Week \d{4}-W\d{2}/m);
-    // JSON + markdown should land in the default out-dir.
+    // The CLI defaults the out-dir to .claude/state/metrics-weekly
+    // and writes <isoWeek>.json + .md atomically. Pick the iso week
+    // out of the rendered header so the assertion is independent of
+    // the wall-clock at test time.
+    const isoWeekMatch = /^# Week (\d{4}-W\d{2})/m.exec(r.stdout);
+    assert.ok(isoWeekMatch, `expected an iso-week heading in stdout, got: ${r.stdout}`);
+    const isoWeek = isoWeekMatch[1];
     const outDir = join(dir, ".claude", "state", "metrics-weekly");
-    const files = readFileSync; // referenced to keep import alive across linter passes
-    assert.ok(files);
-    // We cannot enumerate without readdir here, but the success exit
-    // code + the markdown stdout proves the write succeeded.
+    assert.ok(existsSync(outDir), `out-dir should exist after run: ${outDir}`);
+    const entries = readdirSync(outDir).sort();
+    assert.deepEqual(entries, [`${isoWeek}.json`, `${isoWeek}.md`]);
+    // JSON parses + matches the iso week the markdown reported.
+    const json = JSON.parse(readFileSync(join(outDir, `${isoWeek}.json`), "utf8"));
+    assert.equal(json.iso_week, isoWeek);
+    assert.equal(json.totals.invocations, 0);
+    // Markdown round-trips byte-for-byte against the rendered stdout
+    // (modulo the trailing "rollup written to" pointer line).
+    const md = readFileSync(join(outDir, `${isoWeek}.md`), "utf8");
+    assert.match(md, new RegExp(`^# Week ${isoWeek}`, "m"));
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/metrics/report_metrics.cli.test.mjs
+++ b/tests/metrics/report_metrics.cli.test.mjs
@@ -6,7 +6,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, readdirSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, readdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";


### PR DESCRIPTION
## Summary

- scripts/lib/metrics/record.mjs: build + append one JSONL line per skill invocation to \`.claude/state/metrics/<yyyy>-<mm>-<dd>.jsonl\`. Cost computed from per-model rate table with a four-step fallback chain (rates[model] -> DEFAULT_RATES[model] -> rates.default -> DEFAULT_RATES.default); unknown models never silently zero. \`writeRecord\` validates the full record shape (trace_id pattern, ISO 8601 timestamps, non-negative integer tokens / subagents, exit enum, model + mcp_servers_used types) BEFORE the bytes hit disk; nested \`tokens\` / \`subagents\` whitelists drop unknown keys at JSONL serialisation time, so the schema's \`additionalProperties: false\` is enforced on write. The aggregator does NOT re-validate on read by design (see below).
- scripts/lib/metrics/aggregate.mjs: daily -> ISO-week rollup. Sub-invocations whose parent record is in-window fold into the parent's per_skill row; orphan subs are dropped from the rollup; corrupted chains (missing/malformed root) are dropped too. Token fields are truncated to integers via \`intNum\` so a corrupted line cannot land a fractional value in the schema-required-integer rollup. Thresholds drive red flags; output is byte-stable across re-runs. \`readRecordsInWindow\` is intentionally loose (no ajv validation): a single bad JSONL line should NOT crash the weekly report — it is degraded via clamps and the \`isPlainRecord\` shape check, and TOCTOU windows around the directory + each file are wrapped in try/catch so the rollup stays resilient on filesystem hiccups.
- scripts/report_metrics.mjs: \`node scripts/report_metrics.mjs --weekly\` writes JSON + markdown to \`.claude/state/metrics-weekly/<yyyy>-Www.{json,md}\` and echoes the markdown. Output lives under \`.claude/state/\`, NOT \`.development/**\`, since the latter is wiki-governed (rules/llm-wiki.md) and requires a nested-scalable layout that flat per-week leaves do not fit. \`--cache-min\` and \`--token-ceiling\` reject invalid values explicitly (\`--token-ceiling\` requires an integer).
- schemas/metrics-{record,weekly}.schema.json: contracts. \`additionalProperties: false\` at every layer; pattern constraints on trace_id / parent_trace_id / skill match the writer's runtime checks; no PII.
- schemas/ops.config.schema.json: \`observability.{metrics_enabled, weekly_report, alert_thresholds.{cache_hit_rate_min, per_skill_token_ceiling}}\`. \`metrics_enabled\` is reserved for the per-skill dispatch wiring follow-up.
- scripts/install.mjs: gitignore \`.claude/state/metrics/\` and \`.claude/state/metrics-weekly/\` on install (unconditional, NOT gated by \`gitignore_dev_working_dir\`).
- tests/metrics/: 30+ cases covering record/aggregate/cost/threshold/orphan-drop/depth-cap/path-traversal paths, plus malformed-input rejection at every write surface.

### Status: library-only in this PR

The recorder / aggregator / weekly-report CLI all ship here, but the per-skill dispatch sites that would call \`record()\` on every invocation are NOT yet wired up — the bundle has no centralised dispatch layer today. The \`observability.metrics_enabled\` config field is reserved for that follow-up; until it lands, no JSONL records are produced automatically. The helpers can be invoked manually or through tests, and the CLI runs against any pre-existing JSONL the user (or a future version) deposits under \`.claude/state/metrics/\`.

Closes #32.

## Test plan

- [x] \`npm run validate\` (PASS)
- [x] \`npm run lint\` (0 errors)
- [x] \`npm test\` (920 / 920)
- [ ] Copilot code-review per \`rules/pr-iteration.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)